### PR TITLE
Fixes #85 - Cannot import observed data

### DIFF
--- a/appveyor-coverage.yml
+++ b/appveyor-coverage.yml
@@ -42,6 +42,7 @@ before_build:
   - nuget sources add -name simmodel -source https://ci.appveyor.com/nuget/ospsuite-simmodel
   - nuget sources add -name cvodes -source https://ci.appveyor.com/nuget/ospsuite-simmodel-solver-cvodes-282
   - nuget sources add -name core -source https://ci.appveyor.com/nuget/ospsuite-core
+  - nuget sources add -name smartxls -source https://ci.appveyor.com/nuget/ospsuite-smartxls
   - nuget restore
 
 build:

--- a/appveyor-nightly.yml
+++ b/appveyor-nightly.yml
@@ -37,6 +37,7 @@ before_build:
   - nuget sources add -name simmodel -source https://ci.appveyor.com/nuget/ospsuite-simmodel
   - nuget sources add -name cvodes -source https://ci.appveyor.com/nuget/ospsuite-simmodel-solver-cvodes-282
   - nuget sources add -name core -source https://ci.appveyor.com/nuget/ospsuite-core
+  - nuget sources add -name smartxls -source https://ci.appveyor.com/nuget/ospsuite-smartxls
   - nuget restore
   - rake "update_go_license[ApplicationStartup.cs, %GO_DIAGRAM_KEY%]"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ before_build:
   - nuget sources add -name simmodel -source https://ci.appveyor.com/nuget/ospsuite-simmodel
   - nuget sources add -name cvodes -source https://ci.appveyor.com/nuget/ospsuite-simmodel-solver-cvodes-282
   - nuget sources add -name core -source https://ci.appveyor.com/nuget/ospsuite-core
+  - nuget sources add -name smartxls -source https://ci.appveyor.com/nuget/ospsuite-smartxls
   - nuget restore
 
 build:

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -67,8 +67,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility">

--- a/src/PKSim.Assets/packages.config
+++ b/src/PKSim.Assets/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
 </packages>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -194,12 +194,12 @@
       <HintPath>..\..\packages\Northwoods.GoWin.5.2.0\lib\net45\Northwoods.Go.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.DataBinding">
@@ -211,8 +211,8 @@
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -225,16 +225,16 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\OSPSuite.TeXReporting.2.0.0.1\lib\net45\OSPSuite.TeXReporting.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.UI, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.59\lib\net452\OSPSuite.UI.dll</HintPath>
+    <Reference Include="OSPSuite.UI, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.60\lib\net452\OSPSuite.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim.BatchTool/app.config
+++ b/src/PKSim.BatchTool/app.config
@@ -83,7 +83,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SX" publicKeyToken="882b9c044052e7f6" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.1" newVersion="2.6.3.1" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.2.9" newVersion="2.6.2.9" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/PKSim.BatchTool/packages.config
+++ b/src/PKSim.BatchTool/packages.config
@@ -4,20 +4,20 @@
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Northwoods.GoWin" version="5.2.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DataBinding" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DataBinding.DevExpress" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DevExpress" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModelSolver_CVODES282" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.UI" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.UI" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -78,12 +78,12 @@
       <HintPath>..\..\packages\csmpfit.1.1.0\lib\net20\MPFitLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser">

--- a/src/PKSim.Core/packages.config
+++ b/src/PKSim.Core/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="csmpfit" version="1.1.0" targetFramework="net452" />
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -119,23 +119,23 @@
       <HintPath>..\..\packages\NHibernate.4.1.1.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.59\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
+    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.60\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -150,8 +150,8 @@
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim.Infrastructure/packages.config
+++ b/src/PKSim.Infrastructure/packages.config
@@ -11,15 +11,15 @@
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Infrastructure" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Infrastructure" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />

--- a/src/PKSim.Matlab/PKSim.Matlab.csproj
+++ b/src/PKSim.Matlab/PKSim.Matlab.csproj
@@ -84,20 +84,20 @@
       <HintPath>..\..\packages\csmpfit.1.1.0\lib\net20\MPFitLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser, Version=0.0.0.0, Culture=neutral, processorArchitecture=x86">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
@@ -115,8 +115,8 @@
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim.Matlab/app.config
+++ b/src/PKSim.Matlab/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SX" publicKeyToken="882b9c044052e7f6" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.1" newVersion="2.6.3.1" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.2.9" newVersion="2.6.2.9" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/PKSim.Matlab/packages.config
+++ b/src/PKSim.Matlab/packages.config
@@ -4,14 +4,14 @@
   <package id="Castle.Windsor" version="3.4.0" targetFramework="net452" />
   <package id="csmpfit" version="1.1.0" targetFramework="net452" />
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
 </packages>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -84,19 +84,19 @@
       <HintPath>..\..\packages\csmpfit.1.1.0\lib\net20\MPFitLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -112,8 +112,8 @@
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim.Presentation/packages.config
+++ b/src/PKSim.Presentation/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="csmpfit" version="1.1.0" targetFramework="net452" />
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
 </packages>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -205,12 +205,12 @@
       <HintPath>..\..\packages\Northwoods.GoWin.5.2.0\lib\net45\Northwoods.Go.Xml.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.DataBinding">
@@ -222,8 +222,8 @@
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -235,16 +235,16 @@
     <Reference Include="OSPSuite.TeXReporting">
       <HintPath>..\..\packages\OSPSuite.TeXReporting.2.0.0.1\lib\net45\OSPSuite.TeXReporting.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.UI, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.59\lib\net452\OSPSuite.UI.dll</HintPath>
+    <Reference Include="OSPSuite.UI, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.UI.7.1.0.60\lib\net452\OSPSuite.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim.UI/app.config
+++ b/src/PKSim.UI/app.config
@@ -72,7 +72,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SX" publicKeyToken="882b9c044052e7f6" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.2.8" newVersion="2.6.2.8" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.3.1" newVersion="2.6.3.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />

--- a/src/PKSim.UI/packages.config
+++ b/src/PKSim.UI/packages.config
@@ -3,19 +3,19 @@
   <package id="csmpfit" version="1.1.0" targetFramework="net452" />
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
   <package id="Northwoods.GoWin" version="5.2.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DataBinding" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DataBinding.DevExpress" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DevExpress" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.UI" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.UI" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -76,19 +76,19 @@
       <HintPath>..\..\packages\csmpfit.1.1.0\lib\net20\MPFitLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.SimModel">
@@ -97,8 +97,8 @@
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/PKSim/packages.config
+++ b/src/PKSim/packages.config
@@ -2,14 +2,14 @@
 <packages>
   <package id="csmpfit" version="1.1.0" targetFramework="net452" />
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
 </packages>

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -155,26 +155,26 @@
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.BDDHelper">
       <HintPath>..\..\packages\OSPSuite.BDDHelper.2.0.0.1\lib\net45\OSPSuite.BDDHelper.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.59\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
+    <Reference Include="OSPSuite.Infrastructure, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Infrastructure.7.1.0.60\lib\net452\OSPSuite.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -189,8 +189,8 @@
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/PKSim.Tests/packages.config
+++ b/tests/PKSim.Tests/packages.config
@@ -13,17 +13,17 @@
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
   <package id="OpenCover" version="4.6.519" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.BDDHelper" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Infrastructure" version="7.1.0.59" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Infrastructure" version="7.1.0.60" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModelSolver_CVODES282" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -172,15 +172,15 @@
       <HintPath>..\..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OSPSuite.Assets, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\OSPSuite.Assets.7.1.0.59\lib\net452\OSPSuite.Assets.dll</HintPath>
+    <Reference Include="OSPSuite.Assets, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\..\packages\OSPSuite.Assets.7.1.0.60\lib\net452\OSPSuite.Assets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.BDDHelper">
       <HintPath>..\..\..\packages\OSPSuite.BDDHelper.2.0.0.1\lib\net45\OSPSuite.BDDHelper.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Core, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\OSPSuite.Core.7.1.0.59\lib\net452\OSPSuite.Core.dll</HintPath>
+    <Reference Include="OSPSuite.Core, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\..\packages\OSPSuite.Core.7.1.0.60\lib\net452\OSPSuite.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.DataBinding">
@@ -192,8 +192,8 @@
     <Reference Include="OSPSuite.FuncParser">
       <HintPath>..\..\..\packages\OSPSuite.FuncParser.2.0.0.1\lib\net45\OSPSuite.FuncParser.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.Presentation, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\OSPSuite.Presentation.7.1.0.59\lib\net452\OSPSuite.Presentation.dll</HintPath>
+    <Reference Include="OSPSuite.Presentation, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\..\packages\OSPSuite.Presentation.7.1.0.60\lib\net452\OSPSuite.Presentation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Serializer">
@@ -205,16 +205,16 @@
     <Reference Include="OSPSuite.TeXReporting">
       <HintPath>..\..\..\packages\OSPSuite.TeXReporting.2.0.0.1\lib\net45\OSPSuite.TeXReporting.dll</HintPath>
     </Reference>
-    <Reference Include="OSPSuite.UI, Version=7.1.0.59, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\..\..\packages\OSPSuite.UI.7.1.0.59\lib\net452\OSPSuite.UI.dll</HintPath>
+    <Reference Include="OSPSuite.UI, Version=7.1.0.60, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\..\packages\OSPSuite.UI.7.1.0.60\lib\net452\OSPSuite.UI.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OSPSuite.Utility">
       <HintPath>..\..\..\packages\OSPSuite.Utility.2.0.0.1\lib\net45\OSPSuite.Utility.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
-    <Reference Include="SX, Version=2.6.3.1, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\OSPSuite.SmartXLS.2.6.2.9\lib\net45\SX.dll</HintPath>
+    <Reference Include="SX, Version=2.6.2.9, Culture=neutral, PublicKeyToken=882b9c044052e7f6, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\OSPSuite.SmartXLS.2.6.2.90\lib\net45\SX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests/app.config
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests/app.config
@@ -80,7 +80,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SX" publicKeyToken="882b9c044052e7f6" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.1" newVersion="2.6.3.1" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.2.9" newVersion="2.6.2.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests/packages.config
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests/packages.config
@@ -5,20 +5,20 @@
   <package id="MathNet.Numerics" version="3.17.0" targetFramework="net452" />
   <package id="Northwoods.GoWin" version="5.2.0" targetFramework="net452" />
   <package id="NUnit" version="3.5.0" targetFramework="net452" />
-  <package id="OSPSuite.Assets" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Assets" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.BDDHelper" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Core" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Core" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.DataBinding" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DataBinding.DevExpress" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.DevExpress" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.DevExpress.Presentation" version="16.2.4" targetFramework="net452" />
   <package id="OSPSuite.FuncParser" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.Presentation" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.Presentation" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Serializer" version="2.0.0.1" targetFramework="net452" />
   <package id="OSPSuite.SimModel" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.SmartXLS" version="2.6.2.9" targetFramework="net452" />
+  <package id="OSPSuite.SmartXLS" version="2.6.2.90" targetFramework="net452" />
   <package id="OSPSuite.TeXReporting" version="2.0.0.1" targetFramework="net452" />
-  <package id="OSPSuite.UI" version="7.1.0.59" targetFramework="net452" />
+  <package id="OSPSuite.UI" version="7.1.0.60" targetFramework="net452" />
   <package id="OSPSuite.Utility" version="2.0.0.1" targetFramework="net452" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />


### PR DESCRIPTION
Updated OSPSuite.Core and OSPSUite.SmartXLS to use the release version in all cases.