### PR TITLE
Fixes #685 CLI simulations: if the same names are used, only the last…

### DIFF
--- a/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
@@ -64,9 +64,9 @@ namespace PKSim.CLI.Core.Services
          if (!inputDirectory.Exists)
             throw new OSPSuiteException($"Input folder '{inputFolder}' does not exist");
 
-         var allSimulationFiles = inputDirectory.GetFiles(Constants.Filter.JSON_FILTER);
-         if (allSimulationFiles.Length == 0)
-            throw new OSPSuiteException($"No simulation json file found in '{inputFolder}'");
+         var allSnapshsotFiles = inputDirectory.GetFiles(Constants.Filter.JSON_FILTER);
+         if (allSnapshsotFiles.Length == 0)
+            throw new OSPSuiteException($"No snapshot file found in '{inputFolder}'");
 
          var outputDirectory = new DirectoryInfo(outputFolder);
          if (!outputDirectory.Exists)
@@ -83,11 +83,11 @@ namespace PKSim.CLI.Core.Services
          });
 
          var begin = DateTime.UtcNow;
-         _logger.AddInfo($"Found {allSimulationFiles.Length} files in '{inputFolder}'");
+         _logger.AddInfo($"Found {allSnapshsotFiles.Length} files in '{inputFolder}'");
 
-         foreach (var simulationFile in allSimulationFiles)
+         foreach (var snapshotFile in allSnapshsotFiles)
          {
-            await exportSimulationsFromProject(simulationFile, outputFolder, exportMode)
+            await runAndExportSimulationsInSnapshotFile(snapshotFile, outputFolder, exportMode)
                .ConfigureAwait(false);
          }
 
@@ -129,7 +129,7 @@ namespace PKSim.CLI.Core.Services
          dataTable.ExportToCSV(fileName);
       }
 
-      private async Task exportSimulationsFromProject(FileInfo projectFile, string outputFolder, SimulationExportMode simulationExportMode)
+      private async Task runAndExportSimulationsInSnapshotFile(FileInfo projectFile, string outputFolder, SimulationExportMode simulationExportMode)
       {
          _logger.AddInfo($"Starting batch simulation export for file '{projectFile}'");
          try
@@ -143,7 +143,7 @@ namespace PKSim.CLI.Core.Services
             {
                _logger.AddDebug($"Starting batch simulation export for simulation '{simulation.Name}'");
 
-               await _simulationExporter.RunAndExport(simulation, outputFolder, _simulationRunOptions, simulationExportMode);
+               await _simulationExporter.RunAndExport(simulation, outputFolder, _simulationRunOptions, simulationExportMode, FileHelper.FileNameFromFileFullPath(projectFile.FullName));
                _allSimulationNames.Add(simulation.Name);
             }
          }

--- a/src/PKSim.CLI.Core/Services/SimulationExporter.cs
+++ b/src/PKSim.CLI.Core/Services/SimulationExporter.cs
@@ -25,9 +25,9 @@ namespace PKSim.CLI.Core.Services
 
    public interface ISimulationExporter
    {
-      Task RunAndExport(Simulation simulation, string outputFolder, SimulationRunOptions simulationRunOptions, SimulationExportMode simulationExportMode);
+      Task RunAndExport(Simulation simulation, string outputFolder, SimulationRunOptions simulationRunOptions, SimulationExportMode simulationExportMode, string projectName=null);
 
-      Task Export(Simulation simulation, string outputFolder, SimulationExportMode simulationExportMode);
+      Task Export(Simulation simulation, string outputFolder, SimulationExportMode simulationExportMode, string projectName = null);
    }
 
    public class SimulationExporter : ISimulationExporter
@@ -59,97 +59,101 @@ namespace PKSim.CLI.Core.Services
          _moBiExportTask = moBiExportTask;
       }
 
-      public async Task RunAndExport(Simulation simulation, string outputFolder, SimulationRunOptions simulationRunOptions, SimulationExportMode simulationExportMode)
+      public async Task RunAndExport(Simulation simulation, string outputFolder, SimulationRunOptions simulationRunOptions, SimulationExportMode simulationExportMode, string projectName = null)
       {
          _logger.AddDebug($"Running simulation '{simulation.Name}'");
          await _simulationRunner.RunSimulation(simulation, simulationRunOptions);
 
-         await Export(simulation, outputFolder, simulationExportMode);
+         await Export(simulation, outputFolder, simulationExportMode, projectName);
       }
 
-      public Task Export(Simulation simulation, string outputFolder, SimulationExportMode simulationExportMode)
+      public Task Export(Simulation simulation, string outputFolder, SimulationExportMode simulationExportMode, string projectName = null)
       {
          var tasks = new List<Task>();
          var individualSimulation = simulation as IndividualSimulation;
          var populationSimulation = simulation as PopulationSimulation;
 
          if (simulationExportMode.HasFlag(SimulationExportMode.Csv) && individualSimulation != null)
-            tasks.Add(exporIndividualSimulationToCsvAsync(individualSimulation, outputFolder));
+            tasks.Add(exporIndividualSimulationToCsvAsync(individualSimulation, outputFolder, projectName));
 
          if (simulationExportMode.HasFlag(SimulationExportMode.Csv) && populationSimulation != null)
-            tasks.Add(exportPopulationSimulationToCsvAsync(populationSimulation, outputFolder));
+            tasks.Add(exportPopulationSimulationToCsvAsync(populationSimulation, outputFolder, projectName));
 
          if (simulationExportMode.HasFlag(SimulationExportMode.Json) && individualSimulation != null)
-            tasks.Add(exportResultsToJsonAsync(individualSimulation, outputFolder));
+            tasks.Add(exportResultsToJsonAsync(individualSimulation, outputFolder, projectName));
 
          if (simulationExportMode.HasFlag(SimulationExportMode.Xml))
-            tasks.Add(exportSimModelXmlAsync(simulation, outputFolder));
+            tasks.Add(exportSimModelXmlAsync(simulation, outputFolder, projectName));
 
          if (simulationExportMode.HasFlag(SimulationExportMode.Pkml))
-            tasks.Add(exportSimulationPkmlAsync(simulation, outputFolder));
+            tasks.Add(exportSimulationPkmlAsync(simulation, outputFolder, projectName));
 
          return Task.WhenAll(tasks);
       }
 
-      private async Task exportSimulationPkmlAsync(Simulation simulation, string outputFolder)
+      private async Task exportSimulationPkmlAsync(Simulation simulation, string outputFolder, string projectName)
       {
-         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.PKML_EXTENSION);
+         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.PKML_EXTENSION, projectName);
          await _moBiExportTask.SaveSimulationToFileAsync(simulation, fileName);
          _logger.AddDebug($"Exporting simulation pkml to '{fileName}'");
       }
 
-      private async Task exportSimModelXmlAsync(Simulation simulation, string outputFolder)
+      private async Task exportSimModelXmlAsync(Simulation simulation, string outputFolder, string projectName)
       {
-         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.XML_EXTENSION);
+         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.XML_EXTENSION, projectName);
          await _simulationExportTask.ExportSimulationToSimModelXmlAsync(simulation, fileName);
          _logger.AddDebug($"Exporting simulation SimModel xml to '{fileName}'");
       }
 
-      private async Task exportResultsToJsonAsync(IndividualSimulation simulation, string outputFolder)
+      private async Task exportResultsToJsonAsync(IndividualSimulation simulation, string outputFolder, string projectName)
       {
-         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.JSON_EXTENSION);
+         var fileName = pathUnder(outputFolder, simulation.Name, Constants.Filter.JSON_EXTENSION, projectName);
          await _simulationResultsExporter.ExportToJsonAsync(simulation, simulation.DataRepository, fileName);
          _logger.AddDebug($"Exporting simulation results to '{fileName}'");
       }
 
-      private async Task exporIndividualSimulationToCsvAsync(IndividualSimulation simulation, string outputFolder)
+      private async Task exporIndividualSimulationToCsvAsync(IndividualSimulation simulation, string outputFolder, string projectName)
       {
-         await exportSimulationResultsToCsv(simulation, outputFolder);
-         exportParameters(outputFolder, simulation);
+         await exportSimulationResultsToCsv(simulation, outputFolder, projectName);
+         exportParameters(outputFolder, simulation, projectName);
       }
 
-      private async Task exportPopulationSimulationToCsvAsync(PopulationSimulation populationSimulation, string outputFolder)
+      private async Task exportPopulationSimulationToCsvAsync(PopulationSimulation populationSimulation, string outputFolder, string projectName)
       {
          var populationFile = CoreConstants.DefaultPopulationExportNameFor(populationSimulation.Name);
-         var populationFileFullPath = csvPathUnder(outputFolder, populationFile);
+         var populationFileFullPath = csvPathUnder(outputFolder, populationFile, projectName);
          _populationExportTask.ExportToCSV(populationSimulation, populationFileFullPath);
 
-         await exportSimulationResultsToCsv(populationSimulation, outputFolder);
+         await exportSimulationResultsToCsv(populationSimulation, outputFolder, projectName);
 
          var populationPKAnalysesFile = CoreConstants.DefaultPKAnalysesExportNameFor(populationSimulation.Name);
-         var populationPKAnalysesFullPath = csvPathUnder(outputFolder, populationPKAnalysesFile);
+         var populationPKAnalysesFullPath = csvPathUnder(outputFolder, populationPKAnalysesFile, projectName);
          await _simulationExportTask.ExportPKAnalysesToCSVAsync(populationSimulation, populationPKAnalysesFullPath);
       }
 
-      private async Task exportSimulationResultsToCsv(Simulation simulation, string outputFolder)
+      private async Task exportSimulationResultsToCsv(Simulation simulation, string outputFolder, string projectName)
       {
-         var simulationResultFileFullPath = csvPathUnder(outputFolder, simulation.Name);
+         var simulationResultFileFullPath = csvPathUnder(outputFolder, simulation.Name, projectName);
          await _simulationExportTask.ExportResultsToCSVAsync(simulation, simulationResultFileFullPath);
          _logger.AddDebug($"Exporting simulation results to '{simulationResultFileFullPath}'");
       }
 
-      private void exportParameters(string outputFolder, IndividualSimulation individualSimulation)
+      private void exportParameters(string outputFolder, IndividualSimulation individualSimulation, string projectName)
       {
-         var parameterReportFileName = csvPathUnder(outputFolder, $"{individualSimulation.Name}_parameters");
+         var parameterReportFileName = csvPathUnder(outputFolder, $"{individualSimulation.Name}_parameters", projectName);
          _parametersReportCreator.ExportParametersTo(individualSimulation.Model, parameterReportFileName);
          _logger.AddDebug($"Exporting simulation parameters to '{parameterReportFileName}'");
       }
 
-      private string csvPathUnder(string outputFolder, string fileNameWithoutExtension) => pathUnder(outputFolder, fileNameWithoutExtension, Constants.Filter.CSV_EXTENSION);
+      private string csvPathUnder(string outputFolder, string fileNameWithoutExtension, string projectName) => pathUnder(outputFolder, fileNameWithoutExtension, Constants.Filter.CSV_EXTENSION, projectName);
 
-      private string pathUnder(string outputFolder, string fileName, string extension)
+      private string pathUnder(string outputFolder, string fileName, string extension, string projectName)
       {
-         return Path.Combine(outputFolder, $"{FileHelper.RemoveIllegalCharactersFrom(fileName)}{extension}");
+         var fileNameWithPrefix = fileName;
+         if (!string.IsNullOrEmpty(projectName))
+            fileNameWithPrefix = $"{projectName}-{fileName}";
+
+         return Path.Combine(outputFolder, $"{FileHelper.RemoveIllegalCharactersFrom(fileNameWithPrefix)}{extension}");
       }
    }
 }

--- a/tests/PKSim.Tests/CLI/ExportSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/CLI/ExportSimulationRunnerSpecs.cs
@@ -129,8 +129,8 @@ namespace PKSim.CLI
       [Observation]
       public void should_run_the_export_for_all_simulations_defined_in_the_project()
       {
-         A.CallTo(() => _simulationExporter.Export(_simulation1, _s1OutputFolder, _exportRunOptions.ExportMode)).MustHaveHappened();
-         A.CallTo(() => _simulationExporter.Export(_simulation2, _s2OutputFolder, _exportRunOptions.ExportMode)).MustHaveHappened();
+         A.CallTo(() => _simulationExporter.Export(_simulation1, _s1OutputFolder, _exportRunOptions.ExportMode, A<string>._)).MustHaveHappened();
+         A.CallTo(() => _simulationExporter.Export(_simulation2, _s2OutputFolder, _exportRunOptions.ExportMode, A<string>._)).MustHaveHappened();
       }
 
       [Observation]
@@ -182,13 +182,13 @@ namespace PKSim.CLI
       [Observation]
       public void should_run_the_export_for_the_selected_simulations_defined_in_the_project()
       {
-         A.CallTo(() => _simulationExporter.Export(_simulation1, _s1OutputFolder,  _exportRunOptions.ExportMode)).MustHaveHappened();
+         A.CallTo(() => _simulationExporter.Export(_simulation1, _s1OutputFolder,  _exportRunOptions.ExportMode, null)).MustHaveHappened();
       }
 
       [Observation]
       public void should_not_run_the_export_for_the_simulation_excluded_from_the_run()
       {
-         A.CallTo(() => _simulationExporter.Export(_simulation2, _s2OutputFolder,  _exportRunOptions.ExportMode)).MustNotHaveHappened();
+         A.CallTo(() => _simulationExporter.Export(_simulation2, _s2OutputFolder,  _exportRunOptions.ExportMode, null)).MustNotHaveHappened();
       }
 
       [Observation]
@@ -236,7 +236,7 @@ namespace PKSim.CLI
       [Observation]
       public void should_run_the_export_for_the_simulations_defined_in_the_project()
       {
-         A.CallTo(() => _simulationExporter.RunAndExport(_simulation1, _s1OutputFolder,  A<SimulationRunOptions>._, _exportRunOptions.ExportMode)).MustHaveHappened();
+         A.CallTo(() => _simulationExporter.RunAndExport(_simulation1, _s1OutputFolder,  A<SimulationRunOptions>._, _exportRunOptions.ExportMode, null)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
… one survives without warning


This is the only way moving forward as the problem is much more likely to happen when creating snapshot from project. 
Now exported file have the format "<project_file_name>_<sim_name>"