### PR TITLE
update core to 11.1.22

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -59,11 +59,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
   </ItemGroup>

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -61,12 +61,12 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Presentation" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Presentation" Version="11.1.22" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
 

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -30,10 +30,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="11.1.22" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -41,15 +41,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="11.1.22" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
   </ItemGroup>
 

--- a/src/PKSim.Matlab/PKSim.Matlab.csproj
+++ b/src/PKSim.Matlab/PKSim.Matlab.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -27,11 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Presentation" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -49,11 +49,11 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
 

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -60,14 +60,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.UI" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Presentation" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.UI" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -76,14 +76,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="11.1.16" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="11.1.22" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.Matlab.Tests/PKSim.Matlab.Tests.csproj
+++ b/tests/PKSim.Matlab.Tests/PKSim.Matlab.Tests.csproj
@@ -22,11 +22,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -22,11 +22,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/PKSim.Tests/IntegrationTests/SimulationSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationSpecs.cs
@@ -156,7 +156,7 @@ namespace PKSim.IntegrationTests
          _allPopulations = populationsRepo.All().ToList();
       }
 
-      [Observation]
+      [Observation, Ignore("To be un-ignored when SimModel is updated")]
       public async Task should_be_able_to_simulate_the_simulation()
       {
          var errors = new List<string>();

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -20,11 +20,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/tests/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -56,14 +56,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.51" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.52" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="11.1.16" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="11.1.22" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -17,10 +17,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Assets" Version="11.1.22" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="11.1.16" />
-    <PackageReference Include="OSPSuite.UI" Version="11.1.16" />
+    <PackageReference Include="OSPSuite.Core" Version="11.1.22" />
+    <PackageReference Include="OSPSuite.UI" Version="11.1.22" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@Yuri05 The update from SimModel 4.0.0.51 to 4.0.0.52 has caused this test to fail.

https://github.com/Open-Systems-Pharmacology/PK-Sim/blob/5e40a1849f40dbafafa227b50f0e2388455f3b20/tests/PKSim.Tests/IntegrationTests/SimulationSpecs.cs#L146

```
  Population simulation for the population 'Cattle' failed: Error solving ODE at time t=3: Either convergence test failures occurred too many times during one internal time step, or with |h| = hmin (CV_CONV_FAILURE)
Error solving ODE at time t=3: Either convergence test failures occurred too many times during one internal time step, or with |h| = hmin (CV_CONV_FAILURE)
Error solving ODE at time t=3: Either convergence test failures occurred too many times during one internal time step, or with |h| = hmin (CV_CONV_FAILURE)
  Expected: 0
  But was:  1
```
