### PR TITLE
Fixes #2518 11.1 Cannot show PK-Analysis in a population simulations …

### DIFF
--- a/src/PKSim.Core/Services/PKAnalysesTask.cs
+++ b/src/PKSim.Core/Services/PKAnalysesTask.cs
@@ -880,11 +880,8 @@ namespace PKSim.Core.Services
          var matrix = new FloatMatrix();
          var names = new List<string>();
 
-         pkParametersList.Each(pkParameter =>
+         pkParametersList.Where(canBeUsedToCalculatePK).Each(pkParameter =>
          {
-            if (!pkParameter.ValuesAsArray.All(x => x.IsValid())) 
-               return;
-
             matrix.AddValuesAndSort(pkParameter.ValuesAsArray);
             names.Add(pkParameter.Name);
          });
@@ -903,6 +900,11 @@ namespace PKSim.Core.Services
             });
          });
          return results;
+      }
+
+      private static bool canBeUsedToCalculatePK(QuantityPKParameter pkParameter)
+      {
+         return pkParameter.ValuesAsArray.Any(x => x.IsValid());
       }
 
       private string correctNameFromMetric(string originalText, bool multipleValues, bool isLowerValue, string captionPrefix)

--- a/src/PKSim.Core/Services/PKAnalysesTask.cs
+++ b/src/PKSim.Core/Services/PKAnalysesTask.cs
@@ -878,8 +878,18 @@ namespace PKSim.Core.Services
       {
          var pkParametersList = pkParameters.ToList();
          var matrix = new FloatMatrix();
-         var names = pkParametersList.Select(x => x.Name).Distinct().ToList();
-         pkParametersList.Each(pkParameter => matrix.AddValuesAndSort(pkParameter.ValuesAsArray));
+         var names = new List<string>();
+
+         pkParametersList.Each(pkParameter =>
+         {
+            if (!pkParameter.ValuesAsArray.All(x => x.IsValid())) 
+               return;
+
+            matrix.AddValuesAndSort(pkParameter.ValuesAsArray);
+            names.Add(pkParameter.Name);
+         });
+
+         var distinctNames = names.Distinct().ToList();
 
          var results = new List<PopulationPKAnalysis>();
          selectedStatistics.Each(statisticalAnalysis =>
@@ -888,7 +898,7 @@ namespace PKSim.Core.Services
             aggregated.Each((agg, index) =>
             {
                var name = correctNameFromMetric(_representationInfoRepository.DisplayNameFor(statisticalAnalysis), aggregated.Count > 1, index == 0, captionPrefix);
-               var pkAnalysis = buildPopulationPKAnalysis(buildCurveData(pkParametersList[index], name), agg, names, simulation);
+               var pkAnalysis = buildPopulationPKAnalysis(buildCurveData(pkParametersList[index], name), agg, distinctNames, simulation);
                results.Add(pkAnalysis);
             });
          });

--- a/src/PKSim.Core/Services/PKAnalysesTask.cs
+++ b/src/PKSim.Core/Services/PKAnalysesTask.cs
@@ -904,7 +904,7 @@ namespace PKSim.Core.Services
 
       private static bool canBeUsedToCalculatePK(QuantityPKParameter pkParameter)
       {
-         return pkParameter.ValuesAsArray.Any(x => x.IsValid());
+         return pkParameter.ValuesAsArray.All(x => x.IsValid());
       }
 
       private string correctNameFromMetric(string originalText, bool multipleValues, bool isLowerValue, string captionPrefix)


### PR DESCRIPTION
New display with blanks
![image](https://user-images.githubusercontent.com/261477/214107452-0e019f56-340f-43a2-8a8c-14b2f6dbb3b0.png)

Previously everything that could not be calculated showed NaN
![image](https://user-images.githubusercontent.com/261477/214107529-804e7b08-01bb-4323-a7bc-c1419cf32bfc.png)

If the PK Parameter cannot be calculated for any compound, then it's not in the grid at all.

What's your preference here?
