### PR TITLE
Fixes #2847

### DIFF
--- a/src/PKSim.Core/Commands/SetExpressionProfileUnitCommand.cs
+++ b/src/PKSim.Core/Commands/SetExpressionProfileUnitCommand.cs
@@ -1,0 +1,36 @@
+﻿using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
+using PKSim.Assets;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+
+namespace PKSim.Core.Commands;
+
+public class SetExpressionProfileUnitCommand: SetParameterUnitCommand
+{
+   private readonly bool _updateSimulationSubjects;
+
+   public SetExpressionProfileUnitCommand(IParameter parameter, Unit newDisplayUnit, bool updateSimulationSubjects = true) : base(parameter, newDisplayUnit)
+   {
+      _updateSimulationSubjects = updateSimulationSubjects;
+      ObjectType = PKSimConstants.ObjectTypes.Molecule;
+   }
+
+   protected override void UpdateDependenciesOnParameter(IParameter parameter, IExecutionContext context)
+   {
+      base.UpdateDependenciesOnParameter(parameter, context);
+      if (!_updateSimulationSubjects)
+         return;
+
+      var expressionProfile = context.BuildingBlockContaining(parameter) as ExpressionProfile;
+      if (expressionProfile == null) return;
+      var updateTask = context.Resolve<IExpressionProfileUpdater>();
+      updateTask.SynchronizeAllSimulationSubjectsWithExpressionProfile(expressionProfile);
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+   {
+      return new SetExpressionProfileUnitCommand(_parameter, _oldDisplayUnit, _updateSimulationSubjects).AsInverseFor(this);
+   }
+}

--- a/src/PKSim.Core/Commands/SetExpressionProfileValueCommand.cs
+++ b/src/PKSim.Core/Commands/SetExpressionProfileValueCommand.cs
@@ -38,7 +38,7 @@ namespace PKSim.Core.Commands
 
       protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
       {
-         return new SetExpressionProfileValueCommand(_parameter, _oldValue).AsInverseFor(this);
+         return new SetExpressionProfileValueCommand(_parameter, _oldValue, _updateSimulationSubjects).AsInverseFor(this);
       }
    }
 }

--- a/src/PKSim.Core/Commands/SetParameterUnitCommand.cs
+++ b/src/PKSim.Core/Commands/SetParameterUnitCommand.cs
@@ -21,7 +21,7 @@ namespace PKSim.Core.Commands
       {
          _oldDisplayUnit = _parameter.DisplayUnit;
          _oldDisplayUnitName = _oldDisplayUnit.Name;
-         double oldDisplayValue = _parameter.Dimension.BaseUnitValueToUnitValue(_oldDisplayUnit, _parameter.Value);
+         var oldDisplayValue = _parameter.Dimension.BaseUnitValueToUnitValue(_oldDisplayUnit, _parameter.Value);
          _valueToSet = _parameter.Dimension.UnitValueToBaseUnitValue(_newDisplayUnit, oldDisplayValue);
 
          base.PerformExecuteWith(context);

--- a/src/PKSim.Core/Services/ParameterTask.cs
+++ b/src/PKSim.Core/Services/ParameterTask.cs
@@ -358,10 +358,22 @@ namespace PKSim.Core.Services
 
       public ICommand SetParameterUnit(IParameter parameter, Unit displayUnit)
       {
+         if (parameter.IsExpressionProfile())
+            return setExpressionProfileUnitCommand(parameter, displayUnit, shouldUpdateDefaultStateAndValueOriginForDefaultParameter: true);
+
          if (parameter.IsStructural())
             return SetParameterUnitAsStructuralChange(parameter, displayUnit);
 
          return executeAndUpdatedDefaultStateAndValue(new SetParameterUnitCommand(parameter, displayUnit), parameter);
+      }
+
+      private IOSPSuiteCommand setExpressionProfileUnitCommand(IParameter parameter, Unit displayUnit, bool shouldUpdateDefaultStateAndValueOriginForDefaultParameter)
+      {
+         return executeAndUpdatedDefaultStateAndValue(
+            new SetExpressionProfileUnitCommand(parameter, displayUnit),
+            parameter,
+            shouldChangeVersion: true,
+            shouldUpdateDefaultStateAndValueOriginForDefaultParameter);
       }
 
       public ICommand SetParameterUnitAsStructuralChange(IParameter parameter, Unit displayUnit)

--- a/tests/PKSim.Tests/Core/ParameterTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterTaskSpecs.cs
@@ -368,6 +368,45 @@ namespace PKSim.Core
       }
    }
 
+   public class When_setting_the_unit_of_an_expression_parameter : concern_for_ParameterTask
+   {
+      private ICommand _result;
+      private Unit _unitToSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameter.Name = Constants.Parameters.REL_EXP;
+         _parameter.Value = 10;                                 //in L
+         _parameter.DisplayUnit = _volumeDimension.DefaultUnit; //L
+         _unitToSet = _volumeDimension.Unit("mL");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.SetParameterUnit(_parameter, _unitToSet);
+      }
+
+      [Observation]
+      public void the_unit_of_the_parameter_should_have_been_set_to_the_given_unit()
+      {
+         _parameter.DisplayUnit.ShouldBeEqualTo(_unitToSet);
+      }
+
+      [Observation]
+      public void the_value_of_parameter_should_have_been_set_updated()
+      {
+         _parameter.Value.ShouldBeEqualTo(0.01);
+      }
+
+      [Observation]
+      public void should_return_the_underlying_command_used_to_set_the_parameter_value()
+      {
+         _result.ShouldBeAnInstanceOf<SetExpressionProfileUnitCommand>();
+      }
+   }
+
+
    public class When_setting_the_unit_of_a_parameter_requiring_a_structural_change_command : concern_for_ParameterTask
    {
       private ICommand _result;


### PR DESCRIPTION
Fixes #2847

# Description

When display unit was changed, the synchronized method was not called. This is now the case

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):