### PR TITLE
Fixes #2940 Nightly crashes on PK-Sim start

### DIFF
--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -107,4 +107,11 @@
     <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
     <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
   </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <ItemGroup>
+	    <WindowsFiles Include="$(TargetDir)x64/SQLite.Interop.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WindowsFiles);" DestinationFolder="$(TargetFolder)" DestinationFiles="@(WindowsFiles->Replace('x64/SQLite.Interop.dll', 'SQLite.Interop.dll'))" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes #2940

The nightly did not work because the `SQLite.Interop.dll` is not copied to the zip directory when the nightly is built. This makes sure the file is copied on build