### PR TITLE
Fixes #2934 Error when loading compound in Visual Studio (Debug)

### DIFF
--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -16,6 +16,7 @@
     <NoWarn>1591, 3246</NoWarn>
     <ApplicationIcon>PKSim.ico</ApplicationIcon>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fixes #2934

This seems to be a common problem when an assembly targets System.ComponentModel.Annoatations from NetStandard 2 and then you have a .NET Framework app that targets both this assembly and System.ComponentModel.Annotations. The apparent fix is to forward all the bindings.

Luckily, there's a single property of the .net Framework project that will handle it.