### PR TITLE
Fixes #2946

### DIFF
--- a/src/PKSim.Infrastructure/ProjectConverter/ConverterConstants.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/ConverterConstants.cs
@@ -74,6 +74,7 @@ namespace PKSim.Infrastructure.ProjectConverter
          public static readonly string DynamicSumFormulas = "DynamicSumFormulas";
          public static readonly string BMI = "BMI";
          public static readonly string Individual_AgeDependent = "Individual_AgeDependent";
+         public static readonly string Individual_HeightDependent = "Individual_HeightDependent";
       }
 
       public static class Category

--- a/src/PKSim.Infrastructure/ProjectConverter/v12/Converter11To12.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v12/Converter11To12.cs
@@ -73,7 +73,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v12
          foreach (var calculationMethodElement in all.Elements().ToList())
          {
             var name = calculationMethodElement.GetAttribute("name");
-            //BMI Calculation method was split into TWO calculation method. So we need to rename one and ADD A new one
+            //BMI Calculation method was split into TWO calculation methods. So we need to rename one and ADD A new one
             if (string.Equals(name, ConverterConstants.CalculationMethod.BMI))
             {
                calculationMethodElement.SetAttributeValue("name", ConverterConstants.CalculationMethod.Individual_HeightDependent);

--- a/src/PKSim.Infrastructure/ProjectConverter/v12/Converter11To12.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v12/Converter11To12.cs
@@ -19,7 +19,6 @@ namespace PKSim.Infrastructure.ProjectConverter.v12
       private readonly IDefaultIndividualRetriever _defaultIndividualRetriever;
       private readonly ICloner _cloner;
       private bool _converted;
-      private const string _buildMode = "mode";
       public bool IsSatisfiedBy(int version) => version == ProjectVersions.V11;
 
       public Converter11To12(IDefaultIndividualRetriever defaultIndividualRetriever, ICloner cloner)
@@ -48,19 +47,19 @@ namespace PKSim.Infrastructure.ProjectConverter.v12
             convertCalculationMethods(calculationMethodCacheElement);
          }
 
-         element.DescendantsAndSelf().Where(x => x.GetAttribute(_buildMode) != null).Each(convertBuildMode);
+         element.DescendantsAndSelf().Where(x => x.GetAttribute("mode") != null).Each(convertBuildMode);
 
          return (ProjectVersions.V12, _converted);
       }
 
       private void convertBuildMode(XElement parameterNode)
       {
-         var buildMode = parameterNode.GetAttribute(_buildMode);
+         var buildMode = parameterNode.GetAttribute("mode");
          
          if (!string.Equals(buildMode, "Property"))
             return;
 
-         parameterNode.SetAttributeValue(_buildMode, "Global");
+         parameterNode.SetAttributeValue("mode", "Global");
          _converted = true;
       }
 
@@ -70,12 +69,17 @@ namespace PKSim.Infrastructure.ProjectConverter.v12
          if (all == null)
             return;
 
-         foreach (var calculationMethodElement in all.Elements())
+         //TO list because we are going to modify the list while we iterate
+         foreach (var calculationMethodElement in all.Elements().ToList())
          {
             var name = calculationMethodElement.GetAttribute("name");
+            //BMI Calculation method was split into TWO calculation method. So we need to rename one and ADD A new one
             if (string.Equals(name, ConverterConstants.CalculationMethod.BMI))
             {
-               calculationMethodElement.SetAttributeValue("name", ConverterConstants.CalculationMethod.Individual_AgeDependent);
+               calculationMethodElement.SetAttributeValue("name", ConverterConstants.CalculationMethod.Individual_HeightDependent);
+               var newElement = new XElement(calculationMethodElement.Name);
+               newElement.SetAttributeValue("name", ConverterConstants.CalculationMethod.Individual_AgeDependent);
+               all.Add(newElement);
                _converted = true;
             }
          }

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -13,24 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="ProjectConverter\v6_1\**" />
-    <Compile Remove="ProjectConverter\v6_2\**" />
-    <Compile Remove="ProjectConverter\v6_3\**" />
-    <Compile Remove="ProjectConverter\v6_4\**" />
-    <Compile Remove="ProjectConverter\v7_1\**" />
-    <EmbeddedResource Remove="ProjectConverter\v6_1\**" />
-    <EmbeddedResource Remove="ProjectConverter\v6_2\**" />
-    <EmbeddedResource Remove="ProjectConverter\v6_3\**" />
-    <EmbeddedResource Remove="ProjectConverter\v6_4\**" />
-    <EmbeddedResource Remove="ProjectConverter\v7_1\**" />
-    <None Remove="ProjectConverter\v6_1\**" />
-    <None Remove="ProjectConverter\v6_2\**" />
-    <None Remove="ProjectConverter\v6_3\**" />
-    <None Remove="ProjectConverter\v6_4\**" />
-    <None Remove="ProjectConverter\v7_1\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -13,6 +13,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="ProjectConverter\v6_1\**" />
+    <Compile Remove="ProjectConverter\v6_2\**" />
+    <Compile Remove="ProjectConverter\v6_3\**" />
+    <Compile Remove="ProjectConverter\v6_4\**" />
+    <Compile Remove="ProjectConverter\v7_1\**" />
+    <EmbeddedResource Remove="ProjectConverter\v6_1\**" />
+    <EmbeddedResource Remove="ProjectConverter\v6_2\**" />
+    <EmbeddedResource Remove="ProjectConverter\v6_3\**" />
+    <EmbeddedResource Remove="ProjectConverter\v6_4\**" />
+    <EmbeddedResource Remove="ProjectConverter\v7_1\**" />
+    <None Remove="ProjectConverter\v6_1\**" />
+    <None Remove="ProjectConverter\v6_2\**" />
+    <None Remove="ProjectConverter\v6_3\**" />
+    <None Remove="ProjectConverter\v6_4\**" />
+    <None Remove="ProjectConverter\v7_1\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
@@ -59,11 +77,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="ProjectConverter\v6_1\" />
-    <Folder Include="ProjectConverter\v6_2\" />
-    <Folder Include="ProjectConverter\v6_3\" />
-    <Folder Include="ProjectConverter\v6_4\" />
-    <Folder Include="ProjectConverter\v7_1\" />
     <Folder Include="Properties\" />
     <Folder Include="Reporting\" />
   </ItemGroup>

--- a/tests/PKSim.Tests/ProjectConverter/v12/Converter11To12Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v12/Converter11To12Specs.cs
@@ -8,6 +8,7 @@ using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Infrastructure.ProjectConverter.v12;
 using PKSim.IntegrationTests;
+using static PKSim.Infrastructure.ProjectConverter.ConverterConstants.CalculationMethod;
 
 namespace PKSim.ProjectConverter.v12
 {
@@ -47,6 +48,8 @@ namespace PKSim.ProjectConverter.v12
       private void validateIndividual(Individual individual)
       {
          individual.Organism.Parameter(CoreConstants.Parameters.PMA).ShouldNotBeNull();
+         individual.OriginData.CalculationMethodCache.Contains(Individual_HeightDependent).ShouldBeTrue();
+         individual.OriginData.CalculationMethodCache.Contains(Individual_AgeDependent).ShouldBeTrue();
       }
    }
 }


### PR DESCRIPTION
Fixes #2946

# Description

BMI calculation methods was split into two but only one CM was added during conversion

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):