### PR TITLE
Fixes #2988 Error configuring Simulation when removing concentration

### DIFF
--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.SimModel.Services;
+using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
 
 namespace PKSim.Core.Services
@@ -58,6 +61,8 @@ namespace PKSim.Core.Services
                return;
 
             simulation.OutputSelections.UpdatePropertiesFrom(outputSelections, _cloner);
+            mappingsNotSelected(simulation).Each(simulation.OutputMappings.Remove);
+            
             _executionContext.PublishEvent(new SimulationOutputSelectionsChangedEvent(simulation));
          }
 
@@ -65,6 +70,12 @@ namespace PKSim.Core.Services
 
          addAnalysableToSimulationIfRequired(simulation);
       }
+
+      private static IReadOnlyList<OutputMapping> mappingsNotSelected(Simulation simulation) => 
+         simulation.OutputMappings.Where(outputMapping => !outputMappingIsSelected(simulation, outputMapping)).ToList();
+
+      private static bool outputMappingIsSelected(Simulation simulation, OutputMapping outputMapping) => 
+         simulation.OutputSelections.AllOutputs.Any(quantitySelection => Equals(quantitySelection.Path, outputMapping.OutputPath));
 
       private bool outputSelectionRequired(Simulation simulation, bool selectOutput)
       {

--- a/src/PKSim.Presentation/UICommands/RunSimulationCommand.cs
+++ b/src/PKSim.Presentation/UICommands/RunSimulationCommand.cs
@@ -25,7 +25,7 @@ namespace PKSim.Presentation.UICommands
 
    public class RunSimulationWithSettingsCommand : RunSimulationCommand
    {
-      public RunSimulationWithSettingsCommand(IInteractiveSimulationRunner simulationRunner, IActiveSubjectRetriever activeSubjectRetriever) : base(simulationRunner, activeSubjectRetriever, true)
+      public RunSimulationWithSettingsCommand(IInteractiveSimulationRunner simulationRunner, IActiveSubjectRetriever activeSubjectRetriever) : base(simulationRunner, activeSubjectRetriever, selectOutput:true)
       {
       }
    }

--- a/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
@@ -27,10 +27,41 @@ namespace PKSim.Core
          _cloner = A.Fake<ICloner>();
          _simulationSettingsRetriever = A.Fake<ISimulationSettingsRetriever>();
          _simulationRunner = A.Fake<ISimulationRunner>();
-         _lazyLoadTask= A.Fake<ILazyLoadTask>();
+         _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _executionContext = A.Fake<IExecutionContext>();
          sut = new InteractiveSimulationRunner(_simulationSettingsRetriever, _simulationRunner, _cloner, _simulationAnalysisCreator, _lazyLoadTask, _executionContext);
          return _completed;
+      }
+   }
+
+   public class When_an_output_with_mapping_is_removed_from_simulation_run : concern_for_InteractiveSimulationRunner
+   {
+      private IndividualSimulation _simulation;
+      private QuantitySelection _quantitySelection;
+      private OutputSelections _modifiedOutputSelections;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _simulation = A.Fake<IndividualSimulation>();
+         _simulation.OutputSelections = new OutputSelections();
+         _quantitySelection = new QuantitySelection("output|selection");
+         _simulation.OutputSelections.AddOutput(_quantitySelection);
+         _modifiedOutputSelections = new OutputSelections();
+         _simulation.OutputMappings.Add(new OutputMapping { OutputSelection = new SimulationQuantitySelection(_simulation, _quantitySelection) });
+
+         A.CallTo(() => _simulationSettingsRetriever.SettingsFor(_simulation)).Returns(_modifiedOutputSelections);
+      }
+
+      protected override Task Because()
+      {
+         return sut.RunSimulation(_simulation, true);
+      }
+
+      [Observation]
+      public void the_runner_should_remove_the_mapping_from_the_simulation()
+      {
+         _simulation.OutputMappings.ShouldBeEmpty();
       }
    }
 
@@ -79,7 +110,8 @@ namespace PKSim.Core
 
       protected override Task Because()
       {
-         return sut.RunSimulation(_simulation, false); ;
+         return sut.RunSimulation(_simulation, false);
+         ;
       }
 
       [Observation]
@@ -97,14 +129,14 @@ namespace PKSim.Core
       {
          await base.Context();
          _simulation = A.Fake<IndividualSimulation>();
-         A.CallTo(() => _simulation.Analyses).Returns(new List<ISimulationAnalysis> {A.Fake<ISimulationAnalysis>()});
+         A.CallTo(() => _simulation.Analyses).Returns(new List<ISimulationAnalysis> { A.Fake<ISimulationAnalysis>() });
          A.CallTo(() => _simulation.HasResults).Returns(true);
          await sut.RunSimulation(_simulation, false);
       }
 
       protected override Task Because()
       {
-         return sut.RunSimulation(_simulation, false); 
+         return sut.RunSimulation(_simulation, false);
       }
 
       [Observation]
@@ -172,7 +204,7 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_not_update_the_population_settings_in_the_popoulation()
+      public void should_not_update_the_population_settings_in_the_population()
       {
          _populationSimulation.OutputSelections.ShouldNotBeNull();
       }


### PR DESCRIPTION
Fixes #2988

# Description
When an output is removed from a simulation run, the mappings also have to be removed.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):