### PR TITLE
Fixes #3019 PKSim.CLI.exe and PKSim.BatchTool.exe missing in the port…

### DIFF
--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -87,6 +87,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\PKSim.BatchTool\PKSim.BatchTool.csproj" />
+    <ProjectReference Include="..\PKSim.CLI\PKSim.CLI.csproj" />
     <ProjectReference Include="..\PKSim.UI.Starter\PKSim.UI.Starter.csproj" />
     <ProjectReference Include="..\PKSim.UI\PKSim.UI.csproj" />
   </ItemGroup>


### PR DESCRIPTION
I rebuilt and saw that the exe's were missing from my debug folder.

Added the references and rebuilt and they are in the debug folder now. I guess the portable zips the output folder so this should do it.