### PR TITLE
#3028 exception when comparing

### DIFF
--- a/src/PKSim.Core/Mappers/PKSimPathToPathElementsMapper.cs
+++ b/src/PKSim.Core/Mappers/PKSimPathToPathElementsMapper.cs
@@ -61,13 +61,16 @@ namespace PKSim.Core.Mappers
 
       protected override PathElements CreatePathElementsFrom(IReadOnlyList<IContainer> containers, string name)
       {
+         IQuantity quantity = null;
          var pathElements = base.CreatePathElementsFrom(containers, name);
          var lastContainer = containers.LastOrDefault();
 
          if (lastContainer == null)
             return pathElements;
 
-         var quantity = lastContainer.EntityAt<IQuantity>(name);
+         if (!string.IsNullOrEmpty(name))
+            quantity = lastContainer.EntityAt<IQuantity>(name);
+
          if (quantity == null)
             return pathElements;
 

--- a/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
@@ -111,9 +111,8 @@ namespace PKSim.Core
    }
 
    
-   public class When_creating_the_path_elements_for_an_empty_name :concern_for_PKSimPathToPathElementsMapper
+   public class When_creating_the_path_elements_for_an_empty_name : concern_for_PKSimPathToPathElementsMapper
    {
-
       [Observation]
       public void should_not_throw_exception_on_empty_entity_path()
       {

--- a/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System.Collections.Generic;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
@@ -106,6 +107,17 @@ namespace PKSim.Core
          _pathElements[PathElementId.BottomCompartment].DisplayName.ShouldBeEqualTo(compartment);
          _pathElements[PathElementId.Molecule].DisplayName.ShouldBeEqualTo(molecule);
          _pathElements[PathElementId.Name].DisplayName.ShouldBeEqualTo(name);
+      }
+   }
+
+   
+   public class When_creating_the_path_elements_for_an_empty_name :concern_for_PKSimPathToPathElementsMapper
+   {
+
+      [Observation]
+      public void should_not_throw_exception_on_empty_entity_path()
+      {
+         sut.MapFrom(new Container(), new List<string>())
       }
    }
 

--- a/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/PKSimPathToPathElementsMapperSpecs.cs
@@ -117,7 +117,7 @@ namespace PKSim.Core
       [Observation]
       public void should_not_throw_exception_on_empty_entity_path()
       {
-         sut.MapFrom(new Container(), new List<string>())
+         sut.MapFrom(new Container(), new List<string>());
       }
    }
 


### PR DESCRIPTION
Fixes #3028 

# Description

Comparison of two expression profiles was throwing an error

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):