### PR TITLE
Fixes #3037

### DIFF
--- a/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
@@ -78,10 +78,9 @@ namespace PKSim.Core.Mappers
                return false;
 
             //Ontogeny factor are exported also in the expression profile
-            if(parameter.IsExpressionOrOntogenyFactor())
-               return false; 
-
-
+            if (parameter.IsExpressionOrOntogenyFactor())
+               return false;
+            
             return !_sameFormulaOrValueForAllSpeciesRepository.IsSameFormulaOrValue(parameter);
          }
 

--- a/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
@@ -77,6 +77,11 @@ namespace PKSim.Core.Mappers
             if (parameter.GroupName == RELATIVE_EXPRESSION)
                return false;
 
+            //Ontogeny factor are exported also in the expression profile
+            if(parameter.IsExpressionOrOntogenyFactor())
+               return false; 
+
+
             return !_sameFormulaOrValueForAllSpeciesRepository.IsSameFormulaOrValue(parameter);
          }
 

--- a/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
@@ -17,7 +17,6 @@ namespace PKSim.IntegrationTests
       protected Individual _individual;
       protected IndividualBuildingBlock _individualBuildingBlock;
 
-
       public override void GlobalContext()
       {
          base.GlobalContext();
@@ -25,17 +24,14 @@ namespace PKSim.IntegrationTests
          _individual = DomainFactoryForSpecs.CreateStandardIndividual(population: CoreConstants.Population.ICRP);
       }
 
-
       protected override void Because()
       {
          _individualBuildingBlock = sut.MapFrom(_individual);
       }
-
    }
 
    public class When_mapping_building_block_from_individual : concern_for_IndividualToIndividualBuildingBlockMapper
    {
-    
       [Observation]
       public void the_properties_of_the_building_block_should_match()
       {
@@ -84,6 +80,5 @@ namespace PKSim.IntegrationTests
          var allOntogenyFactors = _individualBuildingBlock.Where(x => x.Name.IsOneOf(AllPlasmaProteinOntogenyFactors.ToArray()));
          allOntogenyFactors.Count().ShouldBeEqualTo(2);
       }
-
    }
 }

--- a/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
@@ -1,17 +1,22 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System.Linq;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Extensions;
 using PKSim.Core;
 using PKSim.Core.Mappers;
 using PKSim.Core.Model;
 using PKSim.Infrastructure;
+using static PKSim.Core.CoreConstants.Parameters;
 
 namespace PKSim.IntegrationTests
 {
    public abstract class concern_for_IndividualToIndividualBuildingBlockMapper : ContextForIntegration<IIndividualToIndividualBuildingBlockMapper>
    {
       protected Individual _individual;
+      protected IndividualBuildingBlock _individualBuildingBlock;
+
 
       public override void GlobalContext()
       {
@@ -19,21 +24,22 @@ namespace PKSim.IntegrationTests
          //specify a population here as we need a human specific formula
          _individual = DomainFactoryForSpecs.CreateStandardIndividual(population: CoreConstants.Population.ICRP);
       }
+
+
+      protected override void Because()
+      {
+         _individualBuildingBlock = sut.MapFrom(_individual);
+      }
+
    }
 
    public class When_mapping_building_block_from_individual : concern_for_IndividualToIndividualBuildingBlockMapper
    {
-      private IndividualBuildingBlock _buildingBlock;
-
-      protected override void Because()
-      {
-         _buildingBlock = sut.MapFrom(_individual);
-      }
-
+    
       [Observation]
       public void the_properties_of_the_building_block_should_match()
       {
-         var allDataItems = _buildingBlock.OriginData.All;
+         var allDataItems = _individualBuildingBlock.OriginData.All;
          allDataItems.ExistsByName("Species").ShouldBeTrue();
          allDataItems.ExistsByName("Population").ShouldBeTrue();
          allDataItems.ExistsByName("Gender").ShouldBeTrue();
@@ -50,9 +56,34 @@ namespace PKSim.IntegrationTests
       public void should_have_replaced_the_ROOT_key_element_path_in_all_formula()
       {
          //this formula is defined as it is human specific
-         var formula = _buildingBlock.FormulaCache.FindByName("PARAM_eGFR");
+         var formula = _individualBuildingBlock.FormulaCache.FindByName("PARAM_eGFR");
          formula.ObjectPaths.Count.ShouldBeEqualTo(2);
          formula.ObjectPaths[0][0].ShouldBeEqualTo(Constants.ORGANISM);
       }
+   }
+
+   public class When_mapping_an_individual_with_expression_to_individual : concern_for_IndividualToIndividualBuildingBlockMapper
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+
+         DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(_individual, "CYP");
+      }
+
+      [Observation]
+      public void should_not_export_the_molecule_specific_ontogeny_factors()
+      {
+         var allOntogenyFactors = _individualBuildingBlock.Where(x => x.Name.IsOneOf(OntogenyFactors.ToArray()));
+         allOntogenyFactors.Count().ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_have_exported_the_plasma_protein_molecules()
+      {
+         var allOntogenyFactors = _individualBuildingBlock.Where(x => x.Name.IsOneOf(AllPlasmaProteinOntogenyFactors.ToArray()));
+         allOntogenyFactors.Count().ShouldBeEqualTo(2);
+      }
+
    }
 }


### PR DESCRIPTION
Fixes #3037

# Description

We filter the parameters that are exported via expression profile. For some reasons, they are not in the Expression Profile group. Probably historically like this

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):