### PR TITLE
Fixes #3059 Error opening a simulation after loading a snapshot

### DIFF
--- a/src/PKSim.Presentation/Presenters/Charts/SimulationTimeProfileChartPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Charts/SimulationTimeProfileChartPresenter.cs
@@ -14,7 +14,6 @@ using PKSim.Core.Chart;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.Presenters.Simulations;
-using PKSim.Presentation.Services;
 using PKSim.Presentation.Views.Charts;
 using IChartTemplatingTask = PKSim.Presentation.Services.IChartTemplatingTask;
 
@@ -65,7 +64,8 @@ namespace PKSim.Presentation.Presenters.Charts
       protected override void NotifyProjectChanged()
       {
          base.NotifyProjectChanged();
-         Simulation.HasChanged = true;
+         if (Simulation != null)
+            Simulation.HasChanged = true;
       }
 
       public void UpdateAnalysisBasedOn(IndividualSimulation individualSimulation)
@@ -89,7 +89,7 @@ namespace PKSim.Presentation.Presenters.Charts
          InitializeFromTemplateIfRequired();
       }
 
-      protected Simulation Simulation => _repositoryCache.First();
+      protected Simulation Simulation => _repositoryCache.FirstOrDefault();
 
       protected DataRepository DataRepository => DataRepositoryFor(Simulation);
 
@@ -118,7 +118,7 @@ namespace PKSim.Presentation.Presenters.Charts
          if (!canHandle(eventToHandle)) return;
          _chartTask.SetOriginTextFor(Simulation.Name, Chart);
       }
-      
+
       private void groupByCategoryColumn()
       {
          var categoryColumnSettings = Column(BrowserColumns.Category);
@@ -126,13 +126,13 @@ namespace PKSim.Presentation.Presenters.Charts
          categoryColumnSettings.GroupIndex = 1;
          ChartEditorPresenter.ApplyColumnSettings(categoryColumnSettings);
       }
-      
+
       private void configureEditor()
       {
          ChartEditorPresenter.SetGroupRowFormat(GridGroupRowFormats.HideColumnName);
          groupByCategoryColumn();
       }
-      
+
       protected override void ConfigureColumns()
       {
          base.ConfigureColumns();

--- a/tests/PKSim.Tests/Presentation/SimulationTimeProfileChartPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationTimeProfileChartPresenterSpecs.cs
@@ -45,7 +45,6 @@ namespace PKSim.Presentation
       protected IObservedDataTask _observedDataTask;
       protected IChartEditorAndDisplayPresenter _chartEditorAndDisplayPresenter;
       protected IList<ChartEditorLayoutTemplate> _allTemplates;
-      protected IStartOptions _runOptions;
       protected IChartEditorLayoutTask _chartLayoutTask;
       protected IChartTemplatingTask _chartTemplatingTask;
       private IProjectRetriever _projectRetriever;
@@ -459,6 +458,34 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_notified_that_the_time_profile_chart_was_renamed_but_simulation_results_were_not_added : concern_for_SimulationTimeProfileChartPresenter
+   {
+      private SimulationTimeProfileChart _chart;
+      private DataRepository _observedData;
+      private readonly string _newName = "NEW NAME";
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedData = A.Fake<DataRepository>();
+         _chart = new SimulationTimeProfileChart();
+         _chart.AddObservedData(_observedData);
+         sut.InitializeAnalysis(_chart);
+         _chart.Name = _newName;
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new RenamedEvent(_chart));
+      }
+
+      [Observation]
+      public void should_update_the_view_caption()
+      {
+         _view.Caption.ShouldBeEqualTo(_newName);
+      }
+   }
+
    public class When_notified_that_the_time_profile_chart_was_renamed : concern_for_SimulationTimeProfileChartPresenter
    {
       private SimulationTimeProfileChart _chart;
@@ -487,6 +514,12 @@ namespace PKSim.Presentation
       public void should_update_the_view_caption()
       {
          _view.Caption.ShouldBeEqualTo(_newName);
+      }
+
+      [Observation]
+      public void the_simulation_should_be_marked_as_changed()
+      {
+         _simulation.HasChanged.ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
Fixes #3059 

# Description
When you load a snapshot and a simulation does not have any results (uncheck 'Run Simulations') then the chart does not have a reference yet to a simulation.

So, in this PR, I added an explicit check to the chart to make sure that a simulation has been associated before trying to mark the simulation as changed.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):