### PR TITLE
Fixes #3071 Hexadecimal value 0x1F, is an invalid character

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.65" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -59,8 +59,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -55,9 +55,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.65" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/ObserverLoader.cs
+++ b/src/PKSim.Core/Services/ObserverLoader.cs
@@ -78,7 +78,7 @@ namespace PKSim.Core.Services
          int version;
          using (var serializationContext = SerializationTransaction.Create(_container, _dimensionFactory, _objectBaseFactory, new WithIdRepository(), _cloneManagerForModel))
          {
-            var element = XElement.Load(pkmlFileFullPath);
+            var element = XElementSerializer.PermissiveLoad(pkmlFileFullPath);
             version = element.GetPKMLVersion();
             var elementName = element.Name.LocalName;
             convertXml(element, version);

--- a/src/PKSim.Infrastructure/ORM/Repositories/DimensionRepository.cs
+++ b/src/PKSim.Infrastructure/ORM/Repositories/DimensionRepository.cs
@@ -133,7 +133,7 @@ namespace PKSim.Infrastructure.ORM.Repositories
       private void loadDimensionsFromFile()
       {
          var serializer = _unitSystemXmlSerializerRepository.SerializerFor(_dimensionFactory);
-         var xel = XElement.Load(_pkSimConfiguration.DimensionFilePath);
+         var xel = XElementSerializer.PermissiveLoad(_pkSimConfiguration.DimensionFilePath);
          serializer.Deserialize(_dimensionFactory, xel, SerializationTransaction.Create(_container));
       }
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.65" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/Services/ImportObservedDataTask.cs
+++ b/src/PKSim.Infrastructure/Services/ImportObservedDataTask.cs
@@ -80,7 +80,7 @@ namespace PKSim.Infrastructure.Services
 
             if (fileName.IsNullOrEmpty()) return null;
 
-            var xel = XElement.Load(fileName); // We have to correctly handle the case of cancellation
+            var xel = XElementSerializer.PermissiveLoad(fileName); // We have to correctly handle the case of cancellation
             return serializer.Deserialize<ImporterConfiguration>(xel, serializationContext);
          }
       }

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/Presenters/ProteinExpression/ProteinExpressionsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/ProteinExpression/ProteinExpressionsPresenter.cs
@@ -16,6 +16,8 @@ using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Core.Serialization;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ProteinExpression
 {
@@ -229,7 +231,7 @@ namespace PKSim.Presentation.Presenters.ProteinExpression
 
          if (isOldQuery)
          {
-            setQueryConfiguation(_querySettings.QueryConfiguration);
+            setQueryConfiguration(_querySettings.QueryConfiguration);
             _view.ActivateControl(ExpressionItems.ExpressionData);
             _view.SetControlEnabled(ExpressionItems.Transfer, true);
             SetWizardButtonEnabled(ExpressionItems.ExpressionData);
@@ -395,9 +397,9 @@ namespace PKSim.Presentation.Presenters.ProteinExpression
          return element.ToString(SaveOptions.DisableFormatting);
       }
 
-      private void setQueryConfiguation(string xml)
+      private void setQueryConfiguration(string xml)
       {
-         var rootElement = XElement.Load(new StringReader(xml));
+         var rootElement = XElementSerializer.PermissiveLoad(new MemoryStream(Encoding.Default.GetBytes(xml)));
 
          var expressionDataSetElement = rootElement.Element(CoreConstants.Serialization.ExpressionDataSet);
          if (expressionDataSetElement == null)

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -41,9 +41,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.65" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -55,14 +55,14 @@
   <ItemGroup>
      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -71,14 +71,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.x64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.R" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.R" Version="12.1.65" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.x64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -24,11 +24,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+		<PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+		<PackageReference Include="OSPSuite.Core" Version="12.1.65" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" />
-		<PackageReference Include="OSPSuite.UI" Version="12.1.59" />
+		<PackageReference Include="OSPSuite.UI" Version="12.1.65" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
Fixes #3071

# Description
Using a more permissive xml serialization

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):