### PR TITLE
Fixes #3098 Refactor GHA to run a separate job on merge to develop

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -1,7 +1,7 @@
-name: Build and Test
+name: Build PR
 
 on:
-  push:
+  pull_request:
     branches:
     - develop
 
@@ -35,21 +35,8 @@ jobs:
       - name: Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"
 
-      - name: Create R dependency artifact
-        run: |
-          pushd .
-          cd src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}
-          7z.exe a pk-sim-r-dependencies.zip -x@"excludedFiles.txt" * -xr!runtimes
-          popd
-
       - name: Push test log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: testLog_Windows
           path: ./testLog*.html
-
-      - name: Push R dependencies as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: PKSim R Dependencies
-          path: src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}\pk-sim-r-dependencies.zip

--- a/PKSim.sln
+++ b/PKSim.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.github\workflows\build-and-test-pr.yml = .github\workflows\build-and-test-pr.yml
 		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		.github\workflows\build-nightly.yml = .github\workflows\build-nightly.yml
 		.github\workflows\coverage.yml = .github\workflows\coverage.yml


### PR DESCRIPTION
Fixes #3098 

# Description
The assemblies required for OSPSuite-R are downloaded as an artifact from the Action. The problem with the old way of conditionally publishing the artifact if the action runs on the develop branch is that for the given action, the latest successful run may not have produced this artifact.

This PR makes it so that if the Action runs successfully, the artifact will be there, and also, we still don't publish the artifact on a PR for no reason.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [x] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):