### PR TITLE
Fixes #3114 Fix permissions in build-nightly.yml

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -6,9 +6,6 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
-permissions:
-  actions: write
-
 env:
   MAJOR: 12
   MINOR: 1
@@ -120,6 +117,8 @@ jobs:
     needs: get-latest-commit-timespan
     if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN >= 86400
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cancel workflow run
         run: |


### PR DESCRIPTION
Fixes #3114 _Fix permissions in build-nightly.yml_

# Description
It seems that the `actions: write` permission defined on the workflow level removes the required (default) permission `packages: read`
Because it is required only by the `cleanup-job:` - it was moved to the job level.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [X] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):