### PR TITLE
Fixes #3117 Serialization should ignore unknown elements

### DIFF
--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UsedBuildingBlockXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UsedBuildingBlockXmlSerializer.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Xml.Linq;
 using PKSim.Core.Model;
 using OSPSuite.Core.Serialization.Xml;
+using OSPSuite.Serializer;
 
 namespace PKSim.Infrastructure.Serialization.Xml.Serializers
 {
@@ -34,7 +35,7 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          var serializer = SerializerRepository.SerializerFor(buildingBlockNode);
 
          if (serializer == null)
-            return;
+            throw new SerializerNotFoundException(buildingBlockNode.Name.LocalName);
 
          usedBuildingBlock.BuildingBlock = serializer.Deserialize<IPKSimBuildingBlock>(buildingBlockNode, context);
       }

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UsedBuildingBlockXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UsedBuildingBlockXmlSerializer.cs
@@ -33,6 +33,9 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          var buildingBlockNode = usedBuildingBlockNode.Elements().First();
          var serializer = SerializerRepository.SerializerFor(buildingBlockNode);
 
+         if (serializer == null)
+            return;
+
          usedBuildingBlock.BuildingBlock = serializer.Deserialize<IPKSimBuildingBlock>(buildingBlockNode, context);
       }
    }

--- a/src/PKSim.Infrastructure/Serialization/Xml/XmlReader.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/XmlReader.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Xml.Linq;
-using OSPSuite.Serializer;
+using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Serializer.Xml;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
-using OSPSuite.Core.Serialization.Xml;
 
 namespace PKSim.Infrastructure.Serialization.Xml
 {
@@ -24,7 +23,7 @@ namespace PKSim.Infrastructure.Serialization.Xml
 
       public T ReadFrom(XElement element, SerializationContext serializationContext)
       {
-         var itemSerializer = resolveSerializer(typeof (T), element);
+         var itemSerializer = resolveSerializer(typeof(T), element);
          _serializerRepository.DeserializeFormulaCache(element, serializationContext, itemSerializer.ObjectType);
          return itemSerializer.Deserialize<T>(element, serializationContext);
       }
@@ -39,15 +38,10 @@ namespace PKSim.Infrastructure.Serialization.Xml
 
       private IXmlSerializer<SerializationContext> resolveSerializer(Type typeOfObject, XElement element)
       {
-         try
-         {
-            return _serializerRepository.SerializerFor(element);
-         }
+         var serializer = _serializerRepository.SerializerFor(element);
+
          //this can happen if the given type was not registered explicitly in the serializer.
-         catch (SerializerNotFoundException)
-         {
-            return _serializerRepository.SerializerFor(typeOfObject);
-         }
+         return serializer ?? _serializerRepository.SerializerFor(typeOfObject);
       }
    }
 }

--- a/tests/PKSim.Tests/Infrastructure/XmlReaderSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/XmlReaderSpecs.cs
@@ -48,7 +48,7 @@ namespace PKSim.Infrastructure
          //serializers only defined for type but not for element
          A.CallTo(() => _serializerRepository.SerializerFor(typeof(IEntity))).Returns(_entitySerializer);
 
-         A.CallTo(() => _serializerRepository.SerializerFor(_element)).Throws(new SerializerNotFoundException("toto"));
+         A.CallTo(() => _serializerRepository.SerializerFor(_element)).Returns(null);
       }
 
       protected override void Because()

--- a/tests/PKSim.Tests/IntegrationTests/SimulationXmlSerializerSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationXmlSerializerSpecs.cs
@@ -1,10 +1,9 @@
 ﻿using System.Linq;
+using NUnit.Framework;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
-using NUnit.Framework;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
-using OSPSuite.Core.Domain.ParameterIdentifications;
 using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Infrastructure;
@@ -62,13 +61,11 @@ namespace PKSim.IntegrationTests
          _deserializedSimulation.Settings.ShouldNotBeNull();
       }
 
-
       [Observation]
       public void should_have_deserialized_the_solver_settings()
       {
          _deserializedSimulation.Solver.ShouldNotBeNull();
       }
-
 
       [Observation]
       public void should_have_deserialized_the_output_selection()
@@ -88,7 +85,7 @@ namespace PKSim.IntegrationTests
          foreach (var compound in _deserializedSimulation.Compounds)
          {
             var cp = _deserializedSimulation.CompoundPropertiesFor(compound);
-            Assert.AreSame(cp.Compound,compound);
+            Assert.AreSame(cp.Compound, compound);
          }
       }
 


### PR DESCRIPTION
Fixes #3117

# Description
This is a follow up to changes made in OSPSuite.Serializer to allow unknown XML nodes to not crash the deserialization

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):