### PR TITLE
Fixes #3069 Parameters under Applications are not found when importing from snapshot created with ≤ V11 (Simulations and PIs)

### DIFF
--- a/src/PKSim.Core/Snapshots/Mappers/IdentificationParameterMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/IdentificationParameterMapper.cs
@@ -6,7 +6,9 @@ using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
 using PKSim.Assets;
-using PKSim.Core.Model;
+using PKSim.Core.Extensions;
+using static OSPSuite.Core.Domain.Constants;
+using static PKSim.Core.CoreConstants.ContainerName;
 using ModelIdentificationParameter = OSPSuite.Core.Domain.ParameterIdentifications.IdentificationParameter;
 using SnapshotIdentificationParameter = PKSim.Core.Snapshots.IdentificationParameter;
 
@@ -51,7 +53,7 @@ namespace PKSim.Core.Snapshots.Mappers
          if (snapshot.LinkedParameters == null || !snapshot.LinkedParameters.Any())
             return null;
 
-         var parameterSelections = snapshot.LinkedParameters.Select(x => parameterSelectionFrom(x, snapshotContext.Project));
+         var parameterSelections = snapshot.LinkedParameters.Select(x => parameterSelectionFrom(x, snapshotContext));
 
          var identificationParameter = _identificationParameterFactory.CreateFor(parameterSelections, snapshotContext.ParameterIdentification);
          if (identificationParameter == null)
@@ -73,14 +75,14 @@ namespace PKSim.Core.Snapshots.Mappers
          return identificationParameter;
       }
 
-      private ParameterSelection parameterSelectionFrom(string parameterFullPath, PKSimProject project)
+      private ParameterSelection parameterSelectionFrom(string parameterFullPath, ParameterIdentificationContext snapshotContext)
       {
          var parameterPath = new ObjectPath(parameterFullPath.ToPathArray());
          if (parameterPath.Count == 0)
             return null;
 
          var simulationName = parameterPath[0];
-         var simulation = project.All<Model.Simulation>().FindByName(simulationName);
+         var simulation = snapshotContext.Project.All<Model.Simulation>().FindByName(simulationName);
          if (simulation == null)
          {
             _logger.AddWarning(PKSimConstants.Error.CouldNotFindSimulation(simulationName));
@@ -88,7 +90,30 @@ namespace PKSim.Core.Snapshots.Mappers
          }
 
          parameterPath.RemoveAt(0);
+
+         if (snapshotContext.IsV11FormatOrEarlier)
+            updatePathsForV12(parameterPath);
+
          return new ParameterSelection(simulation, parameterPath);
+      }
+
+      private static void updatePathsForV12(ObjectPath parameterPath)
+      {
+         parameterPath.Replace(Applications, EVENTS);
+
+         replaceRenalClearanceName(parameterPath, PKSimConstants.UI.GlomerularFiltration);
+         replaceRenalClearanceName(parameterPath, PKSimConstants.UI.RenalClearance);
+      }
+
+      // renal clearances container names have been modified to append the name of the compound
+      private static void replaceRenalClearanceName(ObjectPath parameterPath, string processName)
+      {
+         var processContainerName = parameterPath.FirstOrDefault(x => x.StartsWith(processName));
+         if (string.IsNullOrEmpty(processContainerName)) 
+            return;
+
+         var compoundName = parameterPath.ElementAt(parameterPath.IndexOf(processContainerName) - 1);
+         parameterPath.Replace(processContainerName, CompositeNameFor(processContainerName, compoundName));
       }
    }
 }

--- a/src/PKSim.Core/Snapshots/Mappers/IdentificationParameterMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/IdentificationParameterMapper.cs
@@ -75,14 +75,14 @@ namespace PKSim.Core.Snapshots.Mappers
          return identificationParameter;
       }
 
-      private ParameterSelection parameterSelectionFrom(string parameterFullPath, ParameterIdentificationContext snapshotContext)
+      private ParameterSelection parameterSelectionFrom(string parameterFullPath, ParameterIdentificationContext parameterIdentificationContext)
       {
          var parameterPath = new ObjectPath(parameterFullPath.ToPathArray());
          if (parameterPath.Count == 0)
             return null;
 
          var simulationName = parameterPath[0];
-         var simulation = snapshotContext.Project.All<Model.Simulation>().FindByName(simulationName);
+         var simulation = parameterIdentificationContext.Project.All<Model.Simulation>().FindByName(simulationName);
          if (simulation == null)
          {
             _logger.AddWarning(PKSimConstants.Error.CouldNotFindSimulation(simulationName));
@@ -91,7 +91,7 @@ namespace PKSim.Core.Snapshots.Mappers
 
          parameterPath.RemoveAt(0);
 
-         if (snapshotContext.IsV11FormatOrEarlier)
+         if (parameterIdentificationContext.IsV11FormatOrEarlier)
             updatePathsForV12(parameterPath);
 
          return new ParameterSelection(simulation, parameterPath);

--- a/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
@@ -4,10 +4,13 @@ using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.ParameterIdentifications;
 using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Services;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Snapshots.Mappers;
 using Parameter = PKSim.Core.Snapshots.Parameter;
@@ -19,13 +22,16 @@ namespace PKSim.Core
       protected ParameterMapper _parameterMapper;
       protected IdentificationParameter _identificationParameter;
       protected Snapshots.IdentificationParameter _snapshot;
-      private Simulation _simulation;
+      protected Simulation _simulation;
       private IParameter _parameter1;
       private IParameter _parameter2;
+      private IParameter _parameter3;
       private IParameter _startValueParameter;
       protected Parameter _snapshotStartValueParameter;
       protected ParameterSelection _parameterSelection1;
       protected ParameterSelection _parameterSelection2;
+      private ParameterSelection _parameterSelection3;
+      private ParameterSelection _gfrSelection;
       protected IIdentificationParameterFactory _identificationParameterFactory;
       protected IOSPSuiteLogger _logger;
       protected ParameterIdentificationContext _parameterIdentificationContext;
@@ -33,6 +39,9 @@ namespace PKSim.Core
       private PKSimProject _project;
       protected IIdentificationParameterTask _identificationParameterTask;
       private SnapshotContext _snapshotContext;
+      private IParameter _gfrFraction;
+      private IParameter _renalClearances;
+      private ParameterSelection _renalSelection;
 
       protected override Task Context()
       {
@@ -56,24 +65,53 @@ namespace PKSim.Core
          _identificationParameter.Name = "PARAM";
          _parameter1 = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P1");
          _parameter2 = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P2");
+         _parameter3 = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P3");
+         _gfrFraction = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P4");
+         _renalClearances = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P5");
          _simulation = A.Fake<Simulation>().WithName("S");
-         _simulation.Model.Root = new Container {_parameter1, _parameter2};
+         _simulation.Model.Root = new Container {
+            _parameter1, 
+            _parameter2, 
+            new Container{ _parameter3 }.WithName(CoreConstants.ContainerName.Applications),
+            new Container
+            {
+               new Container
+               {
+                  _gfrFraction
+               }.WithName("Glomerular Filtration-GFR"),
+               new Container
+               {
+                  _renalClearances
+               }.WithName("Renal Clearances-test")
+            }.WithName("Alprazolam")
+         };
 
          _identificationParameter.Scaling = Scalings.Linear;
          _parameterSelection1 = new ParameterSelection(_simulation, _parameter1.Name);
          _parameterSelection2 = new ParameterSelection(_simulation, _parameter2.Name);
+         _parameterSelection3 = new ParameterSelection(_simulation, new ObjectPath(CoreConstants.ContainerName.Applications, _parameter3.Name));
+         _gfrSelection = new ParameterSelection(_simulation, new ObjectPath("Alprazolam", "Glomerular Filtration-GFR", _gfrFraction.Name));
+         _renalSelection = new ParameterSelection(_simulation, new ObjectPath("Alprazolam", "Renal Clearances-test", _renalClearances.Name));
          _identificationParameter.AddLinkedParameter(_parameterSelection1);
          _identificationParameter.AddLinkedParameter(_parameterSelection2);
+         _identificationParameter.AddLinkedParameter(_parameterSelection3);
+         _identificationParameter.AddLinkedParameter(_gfrSelection);
+         _identificationParameter.AddLinkedParameter(_renalSelection);
 
          _snapshotStartValueParameter = new Parameter();
          A.CallTo(() => _parameterMapper.MapToSnapshot(_startValueParameter)).Returns(_snapshotStartValueParameter);
 
          _project = new PKSimProject();
          _project.AddBuildingBlock(_simulation);
-         _snapshotContext = new SnapshotContext(_project, ProjectVersions.Current);
+         _snapshotContext = new SnapshotContext(_project, GetSnapshotContextVersion());
          _parameterIdentification = new ParameterIdentification();
          _parameterIdentificationContext = new ParameterIdentificationContext(_parameterIdentification, _snapshotContext);
          return _completed;
+      }
+
+      protected virtual ProjectVersion GetSnapshotContextVersion()
+      {
+         return ProjectVersions.Current;
       }
    }
 
@@ -165,6 +203,72 @@ namespace PKSim.Core
       public void should_log_a_warning()
       {
          A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Warning, A<string>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_updating_a_v11_snapshot : concern_for_IdentificationParameterMapper
+   {
+      private IdentificationParameter _newParameterIdentification;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _snapshot = await sut.MapToSnapshot(_identificationParameter);
+         A.CallTo(() => _identificationParameterFactory.CreateFor(A<IEnumerable<ParameterSelection>>._, _parameterIdentificationContext.ParameterIdentification)).ReturnsLazily(x => createNewIdentificationParameter(x.Arguments.Get<IEnumerable<ParameterSelection>>(0)));
+         renameApplications(_simulation.Model);
+         renameRenalClearances(_simulation.Model);
+      }
+
+      protected override ProjectVersion GetSnapshotContextVersion()
+      {
+         return ProjectVersions.V11;
+      }
+
+      private IdentificationParameter createNewIdentificationParameter(IEnumerable<ParameterSelection> parameterSelections)
+      {
+         var newIdentificationParameter = new IdentificationParameter();
+
+         parameterSelections.Each(x =>
+         {
+
+            newIdentificationParameter.AddLinkedParameter(x);
+         });
+         return newIdentificationParameter;
+      }
+
+      private void renameRenalClearances(IModel model)
+      {
+         model.Root.GetAllChildren<IContainer>().Each(container =>
+         {
+            if (container.Name.Equals("Glomerular Filtration-GFR"))
+               container.Name = "Glomerular Filtration-GFR-Alprazolam";
+
+            if (container.Name.Equals("Renal Clearances-test"))
+               container.Name = "Renal Clearances-test-Alprazolam";
+         });
+      }
+
+      private static void renameApplications(IModel model)
+      {
+         model.Root.GetAllChildren<IContainer>().Each(container =>
+         {
+            if (container.Name.Equals(CoreConstants.ContainerName.Applications))
+               container.Name = "Events";
+         });
+      }
+
+      protected override async Task Because()
+      {
+         _newParameterIdentification = await sut.MapToModel(_snapshot, _parameterIdentificationContext);
+      }
+
+      [Observation]
+      public void should_change_the_parameter_selection_paths()
+      {
+         _newParameterIdentification.AllLinkedParameters.Count.ShouldBeEqualTo(5);
+         _newParameterIdentification.AllLinkedParameters[2].PathArray.ShouldContain("Events");
+         _newParameterIdentification.AllLinkedParameters[3].PathArray.ShouldContain("Glomerular Filtration-GFR-Alprazolam");
+         _newParameterIdentification.AllLinkedParameters[4].PathArray.ShouldContain("Renal Clearances-test-Alprazolam");
       }
    }
 }

--- a/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
@@ -228,7 +228,7 @@ namespace PKSim.Core
       {
          var newIdentificationParameter = new IdentificationParameter();
 
-         parameterSelections.Each(x => { newIdentificationParameter.AddLinkedParameter(x); });
+         parameterSelections.Each(newIdentificationParameter.AddLinkedParameter);
          return newIdentificationParameter;
       }
 

--- a/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/IdentificationParameterMapperSpecs.cs
@@ -10,7 +10,6 @@ using OSPSuite.Core.Domain.ParameterIdentifications;
 using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Extensions;
-using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Snapshots.Mappers;
 using Parameter = PKSim.Core.Snapshots.Parameter;
@@ -46,8 +45,8 @@ namespace PKSim.Core
       protected override Task Context()
       {
          _parameterMapper = A.Fake<ParameterMapper>();
-         _identificationParameterFactory= A.Fake<IIdentificationParameterFactory>();
-         _logger= A.Fake<IOSPSuiteLogger>();
+         _identificationParameterFactory = A.Fake<IIdentificationParameterFactory>();
+         _logger = A.Fake<IOSPSuiteLogger>();
          _identificationParameterTask = A.Fake<IIdentificationParameterTask>();
          sut = new IdentificationParameterMapper(_parameterMapper, _identificationParameterFactory, _identificationParameterTask, _logger);
 
@@ -69,10 +68,11 @@ namespace PKSim.Core
          _gfrFraction = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P4");
          _renalClearances = DomainHelperForSpecs.ConstantParameterWithValue().WithName("P5");
          _simulation = A.Fake<Simulation>().WithName("S");
-         _simulation.Model.Root = new Container {
-            _parameter1, 
-            _parameter2, 
-            new Container{ _parameter3 }.WithName(CoreConstants.ContainerName.Applications),
+         _simulation.Model.Root = new Container
+         {
+            _parameter1,
+            _parameter2,
+            new Container { _parameter3 }.WithName(CoreConstants.ContainerName.Applications),
             new Container
             {
                new Container
@@ -228,11 +228,7 @@ namespace PKSim.Core
       {
          var newIdentificationParameter = new IdentificationParameter();
 
-         parameterSelections.Each(x =>
-         {
-
-            newIdentificationParameter.AddLinkedParameter(x);
-         });
+         parameterSelections.Each(x => { newIdentificationParameter.AddLinkedParameter(x); });
          return newIdentificationParameter;
       }
 


### PR DESCRIPTION
Fixes #3069

# Description
During snapshot load, this change finds paths where the containers will be created with different names in V12 compared to prior.

Eg. Applications are created in "Events" container and not in "Applications"
Renal clearnaces are created in a container that ends with the name of the compound.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):