### PR TITLE
update core

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -21,16 +21,13 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-
       - name: Restore dependencies
         run: |
           nuget sources add -username Open-Systems-Pharmacology -password ${{ secrets.GITHUB_TOKEN }} -name OSP-GitHub-Packages -source "https://nuget.pkg.github.com/Open-Systems-Pharmacology/index.json"
           dotnet restore
 
       - name: Build
-        run: msbuild PKSim.sln /p:Version=12.1.9999
+        run: dotnet build PKSim.sln /p:Version=12.1.9999
 
       - name: Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,16 +21,13 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-
       - name: Restore dependencies
         run: |
           nuget sources add -username Open-Systems-Pharmacology -password ${{ secrets.GITHUB_TOKEN }} -name OSP-GitHub-Packages -source "https://nuget.pkg.github.com/Open-Systems-Pharmacology/index.json"
           dotnet restore
 
       - name: Build
-        run: msbuild PKSim.sln /p:Version=12.1.9999
+        run: dotnet build PKSim.sln /p:Version=12.1.9999
 
       - name: Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -50,9 +50,6 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-
       - name: Restore dependencies
         run: |
           nuget sources add -username Open-Systems-Pharmacology -password ${{ secrets.GITHUB_TOKEN }} -name OSP-GitHub-Packages -source "https://nuget.pkg.github.com/Open-Systems-Pharmacology/index.json"
@@ -65,7 +62,7 @@ jobs:
       - name: Build
         run: |
           rake "update_go_license[ApplicationStartup.cs, ${{ secrets.GO_DIAGRAM_KEY }}]"
-          msbuild PKSim.sln /p:Version=${{env.APP_VERSION}}
+          dotnet build PKSim.sln /p:Version=${{env.APP_VERSION}}
 
       - name : Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'true'
-      
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
 
       - name: Restore dependencies
         run: |
@@ -23,7 +20,7 @@ jobs:
           nuget restore
 
       - name: Build
-        run: msbuild PKSim.sln /p:Version=12.1.999
+        run: dotnet build PKSim.sln /p:Version=12.1.999
 
         
       - name: Cover and report

--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.108" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -60,8 +60,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -60,8 +60,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -55,9 +55,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -55,9 +55,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.108" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.107" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.107" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.108" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
   </ItemGroup>
 

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -41,9 +41,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -41,9 +41,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.107" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.108" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -56,14 +56,14 @@
   <ItemGroup>
      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -55,14 +55,14 @@
   <ItemGroup>
      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -10,6 +10,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <Version Condition="'$(Version)' == ''">12.1.0</Version>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -72,14 +72,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.103" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -72,14 +72,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.107" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.108" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.x64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.R" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.R" Version="12.1.107" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.x64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.x64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.R" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.R" Version="12.1.108" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.x64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.108" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -24,11 +24,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
+		<PackageReference Include="OSPSuite.Assets" Version="12.1.108" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="12.1.107" />
+		<PackageReference Include="OSPSuite.Core" Version="12.1.108" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" />
-		<PackageReference Include="OSPSuite.UI" Version="12.1.107" />
+		<PackageReference Include="OSPSuite.UI" Version="12.1.108" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -24,11 +24,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="12.1.103" />
+		<PackageReference Include="OSPSuite.Assets" Version="12.1.107" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="12.1.103" />
+		<PackageReference Include="OSPSuite.Core" Version="12.1.107" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" />
-		<PackageReference Include="OSPSuite.UI" Version="12.1.103" />
+		<PackageReference Include="OSPSuite.UI" Version="12.1.107" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
This removes the dependency on msbuild so that we can skip it for CI builds. It seems like the latest github hosted runners have a mismatch where there's a newer SDK installed compared to the version of Visual Studio making it impossible to build unless you specify the exact SDK to use.

But that means that devs all need to have the same version of Visual Studio at all times and this must be updated in lock-step with the CI updates. :(