### PR TITLE
Fixes #3132 Population simulations: wrong (geo)SD calculation?

### DIFF
--- a/src/PKSim.Core/Services/PKAnalysesTask.cs
+++ b/src/PKSim.Core/Services/PKAnalysesTask.cs
@@ -918,7 +918,7 @@ namespace PKSim.Core.Services
          var results = new List<PopulationPKAnalysis>();
          selectedStatistics.Each(statisticalAnalysis =>
          {
-            var aggregated = _statisticalDataCalculator.StatisticalDataFor(matrix, statisticalAnalysis).ToList();
+            var aggregated = _statisticalDataCalculator.StatisticalDataFor(matrix, statisticalAnalysis, StatisticalDataCalculator.DeviationModes.Value).ToList();
             aggregated.Each((agg, index) =>
             {
                var name = correctNameFromMetric(_representationInfoRepository.DisplayNameFor(statisticalAnalysis), aggregated.Count > 1, index == 0, captionPrefix);

--- a/src/PKSim.Core/Services/StatisticalDataCalculator.cs
+++ b/src/PKSim.Core/Services/StatisticalDataCalculator.cs
@@ -1,22 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using OSPSuite.Core.Extensions;
+using OSPSuite.Core.Maths;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
 using PKSim.Core.Model.PopulationAnalyses;
-using OSPSuite.Core.Extensions;
-using OSPSuite.Core.Maths;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static PKSim.Core.Services.StatisticalDataCalculator;
 
 namespace PKSim.Core.Services
 {
    public interface IStatisticalDataCalculator
    {
-      IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation);
+      IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode = DeviationModes.Range);
    }
 
    public class StatisticalDataCalculator : IStatisticalDataCalculator
    {
-      public IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation)
+      public enum DeviationModes
+      {
+         Range,
+         Value
+      }
+
+      public IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode = DeviationModes.Range)
       {
          var percentileSelection = statisticalAggregation as PercentileStatisticalAggregation;
          if (percentileSelection != null)
@@ -32,10 +39,16 @@ namespace PKSim.Core.Services
                yield return calculateArithmeticMeanFor(sortedResults);
                break;
             case StatisticalAggregationType.ArithmeticStandardDeviation:
-               var aritMean = calculateArithmeticMeanFor(sortedResults);
-               var aritStd = calculateArithmeticStandardDeviationFor(sortedResults);
-               yield return calculateLowerArithmeticStandardDeviationFor(aritMean, aritStd);
-               yield return calculateUpperArithmeticStandardDeviationFor(aritMean, aritStd);
+               var arithmeticStd = calculateArithmeticStandardDeviationFor(sortedResults);
+
+               if (deviationMode == DeviationModes.Value)
+                  yield return arithmeticStd;
+               else
+               {
+                  var aritMean = calculateArithmeticMeanFor(sortedResults);
+                  yield return calculateLowerArithmeticStandardDeviationFor(aritMean, arithmeticStd);
+                  yield return calculateUpperArithmeticStandardDeviationFor(aritMean, arithmeticStd);
+               }
                break;
             case StatisticalAggregationType.GeometricMean:
                yield return calculateGeometricMeanFor(sortedResults);
@@ -49,10 +62,16 @@ namespace PKSim.Core.Services
                yield return calculatePercentileFor(97.5f, sortedResults);
                break;
             case StatisticalAggregationType.GeometricStandardDeviation:
-               var geoMean = calculateGeometricMeanFor(sortedResults);
+               
                var geoStd = calculateGeometricStandardDeviationFor(sortedResults);
-               yield return calculateLowerGeometricStandardDeviationFor(geoMean, geoStd);
-               yield return calculateUpperGeometricStandardDeviationFor(geoMean, geoStd);
+               if (deviationMode == DeviationModes.Value)
+                  yield return geoStd;
+               else
+               {
+                  var geoMean = calculateGeometricMeanFor(sortedResults);
+                  yield return calculateLowerGeometricStandardDeviationFor(geoMean, geoStd);
+                  yield return calculateUpperGeometricStandardDeviationFor(geoMean, geoStd);
+               }
                break;
             case StatisticalAggregationType.Min:
                yield return calculateMinFor(sortedResults);

--- a/src/PKSim.Core/Services/StatisticalDataCalculator.cs
+++ b/src/PKSim.Core/Services/StatisticalDataCalculator.cs
@@ -12,18 +12,24 @@ namespace PKSim.Core.Services
 {
    public interface IStatisticalDataCalculator
    {
-      IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode = DeviationModes.Range);
+      IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode);
    }
 
    public class StatisticalDataCalculator : IStatisticalDataCalculator
    {
       public enum DeviationModes
       {
+         /// <summary>
+         /// The deviation will be represented by two values as a range around the mean
+         /// </summary>
          Range,
+         /// <summary>
+         /// The deviation will be represented by a single value
+         /// </summary>
          Value
       }
 
-      public IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode = DeviationModes.Range)
+      public IEnumerable<float[]> StatisticalDataFor(FloatMatrix sortedResults, StatisticalAggregation statisticalAggregation, DeviationModes deviationMode)
       {
          var percentileSelection = statisticalAggregation as PercentileStatisticalAggregation;
          if (percentileSelection != null)

--- a/src/PKSim.Core/Services/TimeProfileChartsDataCreator.cs
+++ b/src/PKSim.Core/Services/TimeProfileChartsDataCreator.cs
@@ -242,7 +242,7 @@ namespace PKSim.Core.Services
 
       private IReadOnlyList<TimeProfileYValue> getResultsFor(StatisticalAggregation statisticalAggregation, FloatMatrix quantityResults)
       {
-         var curveValues = _statisticalDataCalculator.StatisticalDataFor(quantityResults, statisticalAggregation).ToList();
+         var curveValues = _statisticalDataCalculator.StatisticalDataFor(quantityResults, statisticalAggregation, StatisticalDataCalculator.DeviationModes.Range).ToList();
          //line curve
          if (curveValues.Count == 1)
             return timeProfilePointValues(curveValues[0]);

--- a/tests/PKSim.Tests/Core/StatisticalDataCalculatorSpecs.cs
+++ b/tests/PKSim.Tests/Core/StatisticalDataCalculatorSpecs.cs
@@ -35,6 +35,64 @@ namespace PKSim.Core
       }
    }
 
+   public class When_calculation_arithmetic_deviation_for_as_value : concern_for_StatisticalDataCalculator
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _selection = new PredefinedStatisticalAggregation { Method = StatisticalAggregationType.ArithmeticStandardDeviation };
+      }
+
+      protected override void Because()
+      {
+         _results = sut.StatisticalDataFor(_floatMatrix, _selection, StatisticalDataCalculator.DeviationModes.Value).ToList();
+      }
+
+      [Observation]
+      public void the_results_should_be_the_standard_deviation()
+      {
+         _results[0][0].ShouldBeEqualTo(_values1.ArithmeticStandardDeviation());
+         _results[0][1].ShouldBeEqualTo(_values2.ArithmeticStandardDeviation());
+         _results[0][2].ShouldBeEqualTo(_values3.ArithmeticStandardDeviation());
+      }
+
+      [Observation]
+      public void the_results_should_contain_the_standard_deviation_only()
+      {
+         _results.Count.ShouldBeEqualTo(1);
+         _results[0].Length.ShouldBeEqualTo(3);
+      }
+   }
+
+   public class When_calculation_geometric_deviation_for_as_value : concern_for_StatisticalDataCalculator
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _selection = new PredefinedStatisticalAggregation { Method = StatisticalAggregationType.GeometricStandardDeviation };
+      }
+
+      protected override void Because()
+      {
+         _results = sut.StatisticalDataFor(_floatMatrix, _selection, StatisticalDataCalculator.DeviationModes.Value).ToList();
+      }
+
+      [Observation]
+      public void the_results_should_be_the_standard_deviation()
+      {
+         _results[0][0].ShouldBeEqualTo(_values1.GeometricStandardDeviation());
+         _results[0][1].ShouldBeEqualTo(_values2.GeometricStandardDeviation());
+         _results[0][2].ShouldBeEqualTo(_values3.GeometricStandardDeviation());
+      }
+
+      [Observation]
+      public void the_results_should_contain_the_standard_deviation_only()
+      {
+         _results.Count.ShouldBeEqualTo(1);
+         _results[0].Length.ShouldBeEqualTo(3);
+      }
+   }
+
    public class When_calculating_the_statistics_for_a_given_percentile : concern_for_StatisticalDataCalculator
    {
       protected override void Context()

--- a/tests/PKSim.Tests/Core/StatisticalDataCalculatorSpecs.cs
+++ b/tests/PKSim.Tests/Core/StatisticalDataCalculatorSpecs.cs
@@ -31,7 +31,7 @@ namespace PKSim.Core
 
       protected override void Because()
       {
-         _results = sut.StatisticalDataFor(_floatMatrix, _selection).ToList();
+         _results = sut.StatisticalDataFor(_floatMatrix, _selection, StatisticalDataCalculator.DeviationModes.Range).ToList();
       }
    }
 


### PR DESCRIPTION
Fixes #3132

# Description
Now you can request the deviations in two different ways from `StatisticalDataCalculator`. Default is two values as a range around the mean. Otherwise as a single value.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):