### PR TITLE
PKSim.R missing one manual registration

### DIFF
--- a/src/PKSim.R/RRegister.cs
+++ b/src/PKSim.R/RRegister.cs
@@ -1,4 +1,6 @@
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Infrastructure.Import.Services;
+using OSPSuite.R.Services;
 using OSPSuite.Utility.Container;
 using PKSim.CLI.Core;
 using PKSim.Core;
@@ -27,6 +29,7 @@ namespace PKSim.R
       private static void registerCLITypes(IContainer container)
       {
          container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
+         container.Register<ICsvDynamicSeparatorSelector, ICsvSeparatorSelector, CsvSeparatorSelector>(LifeStyle.Singleton);
       }
    }
 }


### PR DESCRIPTION
Fixes #3200 pksimr missing one manual registration

# Description
One registration of a minimal implmentation is needed to run snapshots in PKSim.R

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):