### PR TITLE
Fixes #3202 Export of module snapshot in PKML fails during JsonSimula…

### DIFF
--- a/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading.Tasks;
 using OSPSuite.Assets.Extensions;
 using OSPSuite.CLI.Core.Services;
+using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
@@ -12,6 +13,7 @@ using OSPSuite.Utility;
 using OSPSuite.Utility.Exceptions;
 using OSPSuite.Utility.Extensions;
 using PKSim.CLI.Core.RunOptions;
+using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Core.Snapshots.Services;
 using SimulationRunOptions = PKSim.Core.Services.SimulationRunOptions;
@@ -23,18 +25,21 @@ namespace PKSim.CLI.Core.Services
       private readonly ISimulationExporter _simulationExporter;
       private readonly IOSPSuiteLogger _logger;
       private readonly ISnapshotTask _snapshotTask;
+      private readonly ICoreWorkspace _workspace;
       private readonly IList<string> _allSimulationNames = new List<string>();
       private readonly SimulationRunOptions _simulationRunOptions;
 
       public JsonSimulationRunner(
          ISimulationExporter simulationExporter,
          IOSPSuiteLogger logger,
-         ISnapshotTask snapshotTask
+         ISnapshotTask snapshotTask,
+         ICoreWorkspace workspace
       )
       {
          _simulationExporter = simulationExporter;
          _logger = logger;
          _snapshotTask = snapshotTask;
+         _workspace = workspace;
          _simulationRunOptions = new SimulationRunOptions
          {
             Validate = false,
@@ -135,6 +140,9 @@ namespace PKSim.CLI.Core.Services
          try
          {
             var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName);
+            
+            // The workspace project will be needed to create the exported module snapshot in case PKML export is selected
+            _workspace.Project = project;
             var simulations = project.All<Simulation>();
             var numberOfSimulations = simulations.Count;
             _logger.AddInfo($"{numberOfSimulations} {"simulation".PluralizeIf(numberOfSimulations)} found in file '{projectFile}'", project.Name);
@@ -158,6 +166,10 @@ namespace PKSim.CLI.Core.Services
          catch (Exception e)
          {
             _logger.AddException(e);
+         }
+         finally
+         {
+            _workspace.Project = null;
          }
       }
    }

--- a/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Threading.Tasks;
 using OSPSuite.Assets.Extensions;
 using OSPSuite.CLI.Core.Services;
-using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Services;
@@ -140,7 +139,7 @@ namespace PKSim.CLI.Core.Services
          try
          {
             var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName);
-            
+
             // The workspace project will be needed to create the exported module snapshot in case PKML export is selected
             _workspace.Project = project;
             var simulations = project.All<Simulation>();


### PR DESCRIPTION
Fixes #3202

# Description
Now that we are exporting a Module snapshot with PKML, the project needs to be retrieved at various times. We are loading the project always; the only missing part was making it available in the workspace.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):