### PR TITLE
Fixes #3216 Error when reloading observed data

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -398,6 +398,7 @@ namespace PKSim.Assets
          public const string ValueIsRequired = "Value is required.";
          public const string DescriptionIsRequired = "Description is required.";
          public const string UnknownObserverBuilderType = "Observer builer type unknown.";
+         public const string ImporterConfigurationNotFoundInProject = "Importer configuration for this dataset was not found in this project.\n\nThe data cannot be reloaded.";
          public static string UnableToCreateIndividual(string constraints) => $"Could not create individuals with given constraint:\n{constraints}";
          public static string UnableToCreatePopulation(string constraints) => $"Could not create population with given constraint:\n{constraints}";
          public const string FactorShouldBeBiggerThanZero = "Factor should be bigger than 0.";

--- a/src/PKSim.Core/Services/IImportObservedDataTask.cs
+++ b/src/PKSim.Core/Services/IImportObservedDataTask.cs
@@ -13,6 +13,6 @@ namespace PKSim.Core.Services
       void AddObservedDataFromConfigurationToProject(ImporterConfiguration configuration);
       void AddObservedDataFromConfigurationToProjectForDataRepository(ImporterConfiguration configuration, string dataRepositoryName);
       ImporterConfiguration OpenXmlConfiguration();
-      void AddAndReplaceObservedDataFromConfigurationToProject(ImporterConfiguration configuration, IReadOnlyList<DataRepository> observedDataFromSameFile);
+      void AddAndReplaceObservedDataFromConfigurationToProject(string configurationId, IReadOnlyList<DataRepository> observedDataFromSameFile);
    }
 }

--- a/src/PKSim.Infrastructure/Services/ImportObservedDataTask.cs
+++ b/src/PKSim.Infrastructure/Services/ImportObservedDataTask.cs
@@ -96,8 +96,16 @@ namespace PKSim.Infrastructure.Services
          }
       }
 
-      public void AddAndReplaceObservedDataFromConfigurationToProject(ImporterConfiguration configuration, IReadOnlyList<DataRepository> observedDataFromSameFile)
+      public void AddAndReplaceObservedDataFromConfigurationToProject(string configurationId, IReadOnlyList<DataRepository> observedDataFromSameFile)
       {
+         var configuration = _executionContext.Project.ImporterConfigurationBy(configurationId);
+
+         if (configuration == null)
+         {
+            _dialogCreator.MessageBoxError(PKSimConstants.Error.ImporterConfigurationNotFoundInProject);
+            return;
+         }
+
          var importedObservedData = getObservedDataFromImporter(configuration, null, false, false);
          var reloadDataSets = _dataImporter.CalculateReloadDataSetsFromConfiguration(importedObservedData.ToList(), observedDataFromSameFile);
 

--- a/src/PKSim.Presentation/UICommands/ReloadAllObservedDataCommand.cs
+++ b/src/PKSim.Presentation/UICommands/ReloadAllObservedDataCommand.cs
@@ -35,8 +35,7 @@ namespace PKSim.Presentation.UICommands
          var observedDataFromSameFile =
             project.AllObservedData.Where(r => !string.IsNullOrEmpty(r.ConfigurationId) && r.ConfigurationId == configurationId ); //actually the question here is: configID means they come from the same file right?
 
-         var configuration = project.ImporterConfigurationBy(configurationId);
-         _importObservedDataTask.AddAndReplaceObservedDataFromConfigurationToProject(configuration, observedDataFromSameFile.ToList());
+         _importObservedDataTask.AddAndReplaceObservedDataFromConfigurationToProject(configurationId, observedDataFromSameFile.ToList());
       }
    }
 }

--- a/tests/PKSim.Tests/Infrastructure/ImportObservedDataTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/ImportObservedDataTaskSpecs.cs
@@ -26,11 +26,12 @@ namespace PKSim.Infrastructure
 
       protected IDataImporter _dataImporter;
       protected IDialogCreator _dialogCreator;
+      protected IExecutionContext _executionContext;
 
       protected override void Context()
       {
          _dataImporter = A.Fake<IDataImporter>();
-         var executionContext = A.Fake<IExecutionContext>();
+         _executionContext = A.Fake<IExecutionContext>();
          var buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
          var speciesRepository = A.Fake<ISpeciesRepository>();
          var defaultIndividualRetriever = A.Fake<IDefaultIndividualRetriever>();
@@ -62,20 +63,52 @@ namespace PKSim.Infrastructure
             .Returns(new List<DataRepository>()); 
 
          sut = new ImportObservedDataTask(
-            _dataImporter, executionContext, buildingBlockRepository, speciesRepository,
+            _dataImporter, _executionContext, buildingBlockRepository, speciesRepository,
             defaultIndividualRetriever, representationInfoRepository, observedDataTask,
             parameterChangeUpdater, _dialogCreator, container, modelingXmlSerializerRepository,
             eventPublisher, _parameterIdentificationTask, _coreWorkspace);
       }
    }
 
-   public class When_adding_and_replacing_observed_data_from_configuration_to_project
-      : concern_for_ImportObservedDataTask
+   public class When_adding_and_replacing_observed_data_from_configuration_to_project_and_the_configuration_is_not_found
+   : concern_for_ImportObservedDataTask
    {
       private IReadOnlyList<DataRepository> _observedDataFromSameFile;
+      private readonly string _configurationId = "configurationId";
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedDataFromSameFile = new List<DataRepository>();
+         A.CallTo(() => _executionContext.Project.ImporterConfigurationBy(_configurationId)).Returns(null);
+      }
 
       protected override void Because()
       {
+         sut.AddAndReplaceObservedDataFromConfigurationToProject(_configurationId, _observedDataFromSameFile);
+      }
+
+      [Observation]
+      public void the_dialog_creator_indicates_error()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(Assets.PKSimConstants.Error.ImporterConfigurationNotFoundInProject)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_set_has_not_changed_to_true()
+      {
+         _coreWorkspace.Project.HasChanged.ShouldBeEqualTo(false);
+      }
+   }
+
+   public class When_adding_and_replacing_observed_data_from_configuration_to_project : concern_for_ImportObservedDataTask
+   {
+      private IReadOnlyList<DataRepository> _observedDataFromSameFile;
+      private readonly string _configurationId = "configurationId";
+
+      protected override void Context()
+      {
+         base.Context();
          var overwrittenDataSet = A.Fake<DataRepository>();
          var fakeCol = A.Fake<DataColumn>();
 
@@ -107,8 +140,12 @@ namespace PKSim.Infrastructure
                A<string>._, A<string>._, A<string>._, A<string>._, A<string>._))
             .Returns("dummy.csv");
 
-         sut.AddAndReplaceObservedDataFromConfigurationToProject(
-            A.Fake<ImporterConfiguration>(), _observedDataFromSameFile);
+         A.CallTo(() => _executionContext.Project.ImporterConfigurationBy(_configurationId)).Returns(A.Fake<ImporterConfiguration>());
+      }
+
+      protected override void Because()
+      {
+         sut.AddAndReplaceObservedDataFromConfigurationToProject(_configurationId, _observedDataFromSameFile);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #3216

# Description
Adding an error message if the configuration id is not found in the project when reloading observed data

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="451" height="170" alt="image" src="https://github.com/user-attachments/assets/4b99b0a4-72ce-41e7-a64f-ff20da0981c8" />

# Questions (if appropriate):