### PR TITLE
3220 cannot recreate module for a population simulation

### DIFF
--- a/src/PKSim.UI.Starter/ApplicationStartup.cs
+++ b/src/PKSim.UI.Starter/ApplicationStartup.cs
@@ -48,6 +48,9 @@ namespace PKSim.UI.Starter
 
          using (pkSimContainer.OptimizeDependencyResolution())
          {
+            // Set SynchronizationContext using MoBi Application context before registering new DevExpress components
+            // They will create and use a new context but will not start a message loop until a UI is loaded
+            // There are some methods in the API that do not use a UI
             var synchronizationContext = moBiContainer.Resolve<SynchronizationContext>();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
             pkSimContainer.RegisterImplementationOf(synchronizationContext);

--- a/src/PKSim.UI.Starter/ApplicationStartup.cs
+++ b/src/PKSim.UI.Starter/ApplicationStartup.cs
@@ -71,7 +71,6 @@ namespace PKSim.UI.Starter
             pkSimContainer.RegisterImplementationOf(moBiContainer.Resolve<IJournalPresenter>());
 
             pkSimContainer.RegisterImplementationOf(NumericFormatterOptions.Instance);
-            // pkSimContainer.RegisterImplementationOf(SynchronizationContext.Current);
             pkSimContainer.Register<IApplicationController, ApplicationController>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreWorkspace, OSPSuite.Core.IWorkspace, IWorkspace, Workspace>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, IPresentationUserSettings, IUserSettings, UserSettings>(LifeStyle.Singleton);

--- a/src/PKSim.UI.Starter/ApplicationStartup.cs
+++ b/src/PKSim.UI.Starter/ApplicationStartup.cs
@@ -48,6 +48,10 @@ namespace PKSim.UI.Starter
 
          using (pkSimContainer.OptimizeDependencyResolution())
          {
+            var synchronizationContext = moBiContainer.Resolve<SynchronizationContext>();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            pkSimContainer.RegisterImplementationOf(synchronizationContext);
+            
             // Register base DevExpress components
             pkSimContainer.RegisterImplementationOf(new DockManager());
             pkSimContainer.RegisterImplementationOf(new RibbonBarManager(new RibbonControl()));
@@ -64,7 +68,7 @@ namespace PKSim.UI.Starter
             pkSimContainer.RegisterImplementationOf(moBiContainer.Resolve<IJournalPresenter>());
 
             pkSimContainer.RegisterImplementationOf(NumericFormatterOptions.Instance);
-            pkSimContainer.RegisterImplementationOf(SynchronizationContext.Current);
+            // pkSimContainer.RegisterImplementationOf(SynchronizationContext.Current);
             pkSimContainer.Register<IApplicationController, ApplicationController>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreWorkspace, OSPSuite.Core.IWorkspace, IWorkspace, Workspace>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, IPresentationUserSettings, IUserSettings, UserSettings>(LifeStyle.Singleton);

--- a/tests/PKSim.UI.Tests/StarterTests/ApplicationStartupSpecs.cs
+++ b/tests/PKSim.UI.Tests/StarterTests/ApplicationStartupSpecs.cs
@@ -24,7 +24,7 @@ namespace PKSim.UI.StarterTests
       {
          SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
          IoC.InitializeWith(new CastleWindsorContainer());
-
+         IoC.RegisterImplementationOf(SynchronizationContext.Current);
          // To initialize the local container, the application starter will take some components from the
          // static container
          IoC.Container.RegisterImplementationOf(A.Fake<IMainViewPresenter>());


### PR DESCRIPTION
Fixes #3220

# Description
All the async/await had deadlocked when being called through the starter. As far as I can tell, that's because the WinForms component registration sets a new `WindowsFormsSynchronizationContext` but does not start the message loop.

So, I could get it to work if I opened a PK-Sim UI first (from MoBi), for example, by creating a new expression. That would start the message loop, and then when I loaded the module snapshot, there was no deadlock.

It also worked if I started the `HeavyWorkManager` on the PK-Sim side, but that meant that if another starter method was introduced, it would also have to start the message loop.

After some experimentation, it seems that the future proof way is to register the already created `WindowsFormsSynchronizationContext` from MoBi, with message loop running.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):