### PR TITLE
Fixes #3229 User settings in PKSim.CLI only enable a single core

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.127" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -60,8 +60,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/MinimalImplementations/CLIUserSettings.cs
+++ b/src/PKSim.CLI.Core/MinimalImplementations/CLIUserSettings.cs
@@ -21,12 +21,13 @@ namespace PKSim.CLI.Core.MinimalImplementations
       public string DefaultFractionUnboundName { get; set; }
       public string DefaultSolubilityName { get; set; }
       public OutputSelections OutputSelections { get; set; }
-      public int MaximumNumberOfCoresToUse { get; set; } = Math.Max(Environment.ProcessorCount - 1, 1);
+      public int MaximumNumberOfCoresToUse { get; set; }
       public PopulationAnalysisType DefaultPopulationAnalysis { get; set; }
       public string TemplateDatabasePath { get; set; }
 
       public void ResetToDefault()
       {
+         MaximumNumberOfCoresToUse = Math.Max(Environment.ProcessorCount - 1, 1);
          AbsTol = CoreConstants.DEFAULT_ABS_TOL;
          RelTol = CoreConstants.DEFAULT_REL_TOL;
          NumberOfBins = CoreConstants.DEFAULT_NUMBER_OF_BINS;

--- a/src/PKSim.CLI.Core/MinimalImplementations/CLIUserSettings.cs
+++ b/src/PKSim.CLI.Core/MinimalImplementations/CLIUserSettings.cs
@@ -4,6 +4,7 @@ using OSPSuite.Utility.Validation;
 using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Model;
+using System;
 
 namespace PKSim.CLI.Core.MinimalImplementations
 {
@@ -20,7 +21,7 @@ namespace PKSim.CLI.Core.MinimalImplementations
       public string DefaultFractionUnboundName { get; set; }
       public string DefaultSolubilityName { get; set; }
       public OutputSelections OutputSelections { get; set; }
-      public int MaximumNumberOfCoresToUse { get; set; }
+      public int MaximumNumberOfCoresToUse { get; set; } = Math.Max(Environment.ProcessorCount - 1, 1);
       public PopulationAnalysisType DefaultPopulationAnalysis { get; set; }
       public string TemplateDatabasePath { get; set; }
 

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -55,9 +55,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.127" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.127" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
   </ItemGroup>
 

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/Presenters/Populations/PopulationDistributionPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Populations/PopulationDistributionPresenter.cs
@@ -1,25 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using PKSim.Assets;
-using PKSim.Core;
-using PKSim.Core.Model;
-using PKSim.Core.Repositories;
-using PKSim.Core.Services;
-using PKSim.Presentation.Views.Populations;
+﻿using OSPSuite.Assets;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.PKAnalyses;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
+using PKSim.Assets;
+using PKSim.Core;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Presentation.Views.Populations;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
 using DistributionSettings = PKSim.Core.Chart.DistributionSettings;
 
 namespace PKSim.Presentation.Presenters.Populations
 {
    public interface IPopulationDistributionPresenter :
       IPresenter<IPopulationParameterDistributionView>,
-      ICanCopyToClipboard
+      ICanExportCharts
    {
       Color StartColorFor(string series);
       Color EndColorFor(string series);
@@ -42,6 +43,7 @@ namespace PKSim.Presentation.Presenters.Populations
       private readonly IDisplayUnitRetriever _displayUnitRetriever;
       private readonly IPKParameterRepository _pkParameterRepository;
       private readonly IApplicationSettings _applicationSettings;
+      private readonly IDialogCreator _dialogCreator;
 
       public PopulationDistributionPresenter(
          IPopulationParameterDistributionView view,
@@ -49,7 +51,8 @@ namespace PKSim.Presentation.Presenters.Populations
          IRepresentationInfoRepository representationInfoRepository,
          IDisplayUnitRetriever displayUnitRetriever,
          IPKParameterRepository pkParameterRepository,
-         IApplicationSettings applicationSettings)
+         IApplicationSettings applicationSettings, 
+         IDialogCreator dialogCreator)
          : base(view)
       {
          _distributionDataCreator = distributionDataCreator;
@@ -57,6 +60,7 @@ namespace PKSim.Presentation.Presenters.Populations
          _displayUnitRetriever = displayUnitRetriever;
          _pkParameterRepository = pkParameterRepository;
          _applicationSettings = applicationSettings;
+         _dialogCreator = dialogCreator;
       }
 
       public void Plot(IVectorialParametersContainer vectorialParametersContainer, IParameter parameter, DistributionSettings settings = null, IDimension dimension = null, Unit displayUnit = null)
@@ -157,6 +161,15 @@ namespace PKSim.Presentation.Presenters.Populations
       public void ResetPlot()
       {
          _view.ResetPlot();
+      }
+
+      public void ExportToPng()
+      {
+         var fileName = _dialogCreator.AskForFileToSave(Captions.ExportChartToPng, Constants.Filter.DIAGRAM_IMAGE_FILTER, Constants.DirectoryKey.REPORT);
+         if (string.IsNullOrEmpty(fileName))
+            return;
+
+         _view.ExportToPng(fileName, _applicationSettings.WatermarkTextToUse);
       }
 
       public void CopyToClipboard()

--- a/src/PKSim.Presentation/Presenters/Protocols/ProtocolChartPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/ProtocolChartPresenter.cs
@@ -1,5 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
+using OSPSuite.Assets;
 using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
@@ -14,12 +13,14 @@ using PKSim.Core.Repositories;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.DTO.Protocols;
 using PKSim.Presentation.Views.Protocols;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PKSim.Presentation.Presenters.Protocols
 {
    public interface IProtocolChartPresenter : 
       IPresenter<IProtocolChartView>,
-      ICanCopyToClipboard
+      ICanExportCharts
    {
       void PlotProtocol(Protocol protocol);
       void PlotProtocols(ICache<Compound, Protocol> protocols);
@@ -34,18 +35,20 @@ namespace PKSim.Presentation.Presenters.Protocols
       private readonly IDimensionRepository _dimensionRepository;
       private IProtocolChartData _protocolChartData;
       private readonly IApplicationSettings _applicationSettings;
+      private readonly IDialogCreator _dialogCreator;
 
       public ProtocolChartPresenter(
          IProtocolChartView view,
          IProtocolToSchemaItemsMapper schemaItemsMapper,
          ISchemaItemToSchemaItemDTOMapper schemaItemDTOMapper,
          IDimensionRepository dimensionRepository, 
-         IApplicationSettings applicationSettings) : base(view)
+         IApplicationSettings applicationSettings, IDialogCreator dialogCreator) : base(view)
       {
          _schemaItemsMapper = schemaItemsMapper;
          _schemaItemDTOMapper = schemaItemDTOMapper;
          _dimensionRepository = dimensionRepository;
          _applicationSettings = applicationSettings;
+         _dialogCreator = dialogCreator;
       }
 
       public void PlotProtocol(Protocol protocol)
@@ -103,6 +106,15 @@ namespace PKSim.Presentation.Presenters.Protocols
       private IReadOnlyList<SchemaItemDTO> schemaItemsDTOFrom(Protocol protocol)
       {
          return _schemaItemsMapper.MapFrom(protocol).MapAllUsing(_schemaItemDTOMapper);
+      }
+
+      public void ExportToPng()
+      {
+         var fileName = _dialogCreator.AskForFileToSave(Captions.ExportChartToPng, Constants.Filter.DIAGRAM_IMAGE_FILTER, Constants.DirectoryKey.REPORT);
+         if (string.IsNullOrEmpty(fileName))
+            return;
+
+         _view.ExportToPng(fileName, _applicationSettings.WatermarkTextToUse);
       }
 
       public void CopyToClipboard()

--- a/src/PKSim.Presentation/Views/Populations/IPopulationParameterDistributionView.cs
+++ b/src/PKSim.Presentation/Views/Populations/IPopulationParameterDistributionView.cs
@@ -13,5 +13,6 @@ namespace PKSim.Presentation.Views.Populations
       void Plot(ContinuousDistributionData dataToPlot, DistributionSettings settings);
       void Plot(DiscreteDistributionData dataToPlot, DistributionSettings settings);
       void ResetPlot();
+      void ExportToPng(string fileName, string watermark);
    }
 }

--- a/src/PKSim.Presentation/Views/Protocols/IProtocolChartView.cs
+++ b/src/PKSim.Presentation/Views/Protocols/IProtocolChartView.cs
@@ -14,5 +14,6 @@ namespace PKSim.Presentation.Views.Protocols
       string YAxisTitle { get; set; }
       string Y2AxisTitle { get; set; }
       double BarWidth { get; set; }
+      void ExportToPng(string filePath, string watermark);
    }
 }

--- a/src/PKSim.R/Bootstrap/ApplicationStartup.cs
+++ b/src/PKSim.R/Bootstrap/ApplicationStartup.cs
@@ -73,7 +73,7 @@ namespace PKSim.R.Bootstrap
       private void registerMinimalImplementations(IContainer container)
       {
          container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
-         container.Register<ICoreUserSettings, CLIUserSettings>();
+         container.Register<ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
          container.Register<IProgressUpdater, NoneProgressUpdater>();
          container.Register<IDisplayUnitRetriever, CLIDisplayUnitRetriever>();
          container.Register<IOntogenyTask, CLIIndividualOntogenyTask>();

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -41,9 +41,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.127" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -56,14 +56,14 @@
   <ItemGroup>
      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.UI/Views/Populations/PopulationParameterDistributionView.cs
+++ b/src/PKSim.UI/Views/Populations/PopulationParameterDistributionView.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.UI.Services;
+﻿using System.Drawing.Imaging;
+using OSPSuite.UI.Services;
 using PKSim.Presentation.Presenters.Populations;
 using PKSim.Presentation.Views.Populations;
 using OSPSuite.Core.Chart;
@@ -36,14 +37,10 @@ namespace PKSim.UI.Views.Populations
          chart.Plot(dataToPlot, settings);
       }
 
-      public void ResetPlot()
-      {
-         chart.ResetPlot();
-      }
+      public void ResetPlot() => chart.ResetPlot();
 
-      public void CopyToClipboard(string watermark)
-      {
-         chart.CopyToClipboard(watermark);
-      }
+      public void ExportToPng(string filePath, string watermark) => chart.ExportChartToImageFile(watermark, filePath, ImageFormat.Png);
+
+      public void CopyToClipboard(string watermark) => chart.CopyToClipboard(watermark);
    }
 }

--- a/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
+++ b/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
@@ -1,11 +1,13 @@
 using DevExpress.Utils;
 using DevExpress.XtraCharts;
 using OSPSuite.Core.Chart;
+using OSPSuite.Core.Domain;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
 using PKSim.Presentation.Presenters.Protocols;
 using PKSim.Presentation.Views.Protocols;
+using System.Drawing.Imaging;
 
 namespace PKSim.UI.Views.Protocols
 {
@@ -33,6 +35,7 @@ namespace PKSim.UI.Views.Protocols
       {
          _presenter = presenter;
          chart.AddCopyToClipboardPopupMenu(presenter);
+         chart.AddExportToPngPopupMenu(presenter);
       }
 
       public void Clear()
@@ -122,9 +125,9 @@ namespace PKSim.UI.Views.Protocols
          _toolTipController.HideHint();
       }
 
-      public void CopyToClipboard(string watermark)
-      {
-         chart.CopyToClipboard(watermark);
-      }
+      public void CopyToClipboard(string watermark) => chart.CopyToClipboard(watermark);
+
+      public void ExportToPng(string filePath, string watermark) => 
+         chart.ExportChartToImageFile(watermark, filePath, ImageFormat.Png);
    }
 }

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -72,14 +72,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.126" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.127" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.x64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.R" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.R" Version="12.1.127" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.x64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.127" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/Presentation/PopulationParameterDistributionPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/PopulationParameterDistributionPresenterSpecs.cs
@@ -24,16 +24,18 @@ namespace PKSim.Presentation
       protected IDisplayUnitRetriever _displayUnitRetriever;
       protected IPKParameterRepository _pkParameterRepository;
       protected IApplicationSettings _applicationSettings;
+      private IDialogCreator _dialogCreator;
 
       protected override void Context()
       {
          _view = A.Fake<IPopulationParameterDistributionView>();
+         _dialogCreator = A.Fake<IDialogCreator>();
          _distributionDataCreator = A.Fake<IDistributionDataCreator>();
          _representationInfoRepository = A.Fake<IRepresentationInfoRepository>();
          _displayUnitRetriever = A.Fake<IDisplayUnitRetriever>();
          _pkParameterRepository = A.Fake<IPKParameterRepository>();
          _applicationSettings = A.Fake<IApplicationSettings>();
-         sut = new PopulationDistributionPresenter(_view, _distributionDataCreator, _representationInfoRepository, _displayUnitRetriever, _pkParameterRepository, _applicationSettings);
+         sut = new PopulationDistributionPresenter(_view, _distributionDataCreator, _representationInfoRepository, _displayUnitRetriever, _pkParameterRepository, _applicationSettings, _dialogCreator);
       }
    }
 

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -24,11 +24,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="12.1.126" />
+		<PackageReference Include="OSPSuite.Assets" Version="12.1.127" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="12.1.126" />
+		<PackageReference Include="OSPSuite.Core" Version="12.1.127" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" />
-		<PackageReference Include="OSPSuite.UI" Version="12.1.126" />
+		<PackageReference Include="OSPSuite.UI" Version="12.1.127" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
Fixes #3229

# Description
Enable more cores for snapshot evaluation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="666" height="886" alt="image" src="https://github.com/user-attachments/assets/f4d67bc3-856b-4718-9da3-4da3c3b668b8" />

# Questions (if appropriate):