### PR TITLE
pksim uistarter is not usable by mobicli

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.49" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -55,8 +55,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI.Core/Services/QualificationInputTask.cs
+++ b/src/PKSim.CLI.Core/Services/QualificationInputTask.cs
@@ -1,0 +1,85 @@
+﻿using OSPSuite.Core.Qualification;
+using OSPSuite.Core.Services;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using static OSPSuite.Assets.Error;
+using static OSPSuite.Core.Domain.Constants.Filter;
+using Project = PKSim.Core.Snapshots.Project;
+
+namespace PKSim.CLI.Core.Services
+{
+   public interface IQualificationInputTask
+   {
+      InputMapping[] ExportInputs(PKSimProject project, QualificationConfiguration configuration);
+
+      void ValidateInputs(Project snapshotProject, QualificationConfiguration configuration);
+   }
+   
+   public class QualificationInputTask : IQualificationInputTask
+   {
+      private readonly IOSPSuiteLogger _logger;
+      private readonly IMarkdownReporterTask _markdownReporterTask;
+
+      public QualificationInputTask(IOSPSuiteLogger logger, 
+         IMarkdownReporterTask markdownReporterTask)
+      {
+         _logger = logger;
+         _markdownReporterTask = markdownReporterTask;
+      }
+
+      public InputMapping[] ExportInputs(PKSimProject project, QualificationConfiguration configuration)
+      {
+         if (configuration.Inputs == null)
+            return Array.Empty<InputMapping>();
+         //            return Task.FromResult(Array.Empty<InputMapping>());
+
+         //TODO Enable parallel runs once https://github.com/Open-Systems-Pharmacology/OSPSuite.Utility/issues/26 is fixed
+         //  return Task.WhenAll(configuration.Inputs.Select(x => exportInput(project, configuration, x)));
+
+         return configuration.Inputs.Where(x => string.Equals(x.Project, project.Name)).Select(x => exportInput(project, configuration, x)).ToArray();
+      }
+
+      public void ValidateInputs(Project snapshotProject, QualificationConfiguration configuration)
+      {
+         configuration.Inputs?.Each(x =>
+         {
+            var buildingBlock = snapshotProject.BuildingBlockByTypeAndName(x.Type, x.Name);
+            if (buildingBlock == null)
+               throw new QualificationRunException(CannotFindBuildingBlockInSnapshot(x.Type.ToString(), x.Name, snapshotProject.Name));
+         });
+      }
+
+      private InputMapping exportInput(PKSimProject project, QualificationConfiguration configuration, Input input)
+      {
+         var buildingBlock = project.BuildingBlockByName(input.Name, input.Type);
+
+         var inputsFolder = configuration.InputsFolder;
+         var projectName = FileHelper.RemoveIllegalCharactersFrom(project.Name);
+         var buildingBlockName = FileHelper.RemoveIllegalCharactersFrom(input.Name);
+         var targetFolder = Path.Combine(inputsFolder, projectName, input.Type.ToString());
+         DirectoryHelper.CreateDirectory(targetFolder);
+
+         var fileFullPath = Path.Combine(targetFolder, $"{buildingBlockName}{MARKDOWN_EXTENSION}");
+
+         exportToMarkdown(buildingBlock, fileFullPath, input.SectionLevel).Wait();
+         _logger.AddDebug($"Input data for {input.Type} '{input.Name}' exported to '{fileFullPath}'", project.Name);
+
+         return new InputMapping
+         {
+            SectionId = input.SectionId,
+            SectionReference = input.SectionReference,
+            Path = relativePath(fileFullPath, configuration.OutputFolder)
+         };
+      }
+
+      private Task exportToMarkdown(object buildingBlock, string fileFullPath, int? inputSectionLevel) => _markdownReporterTask.ExportToMarkdown(buildingBlock, fileFullPath, inputSectionLevel);
+
+      private string relativePath(string path, string relativeTo) => FileHelper.CreateRelativePath(path, relativeTo, useUnixPathSeparator: true);
+   }
+}

--- a/src/PKSim.CLI.Core/Services/QualificationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/QualificationRunner.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using OSPSuite.CLI.Core.RunOptions;
+﻿using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
@@ -12,8 +9,10 @@ using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using static OSPSuite.Assets.Error;
-using static PKSim.Assets.PKSimConstants.Error;
 using Project = PKSim.Core.Snapshots.Project;
 using Simulation = PKSim.Core.Snapshots.Simulation;
 
@@ -24,7 +23,7 @@ namespace PKSim.CLI.Core.Services
       private readonly ICoreWorkspace _workspace;
       private readonly IWorkspacePersistor _workspacePersistor;
       private readonly IExportSimulationRunner _exportSimulationRunner;
-      private readonly IMarkdownReporterTask _markdownReporterTask;
+      private readonly IQualificationInputTask _qualificationInputTask;
 
       public QualificationRunner(ISnapshotTask snapshotTask,
          IJsonSerializer jsonSerializer,
@@ -32,28 +31,28 @@ namespace PKSim.CLI.Core.Services
          IWorkspacePersistor workspacePersistor,
          IExportSimulationRunner exportSimulationRunner,
          IDataRepositoryExportTask dataRepositoryExportTask,
-         IMarkdownReporterTask markdownReporterTask,
+         IQualificationInputTask qualificationInputTask,
          IOSPSuiteLogger logger
       ) : base(logger, dataRepositoryExportTask, jsonSerializer, snapshotTask)
       {
          _workspace = workspace;
          _workspacePersistor = workspacePersistor;
          _exportSimulationRunner = exportSimulationRunner;
-         _markdownReporterTask = markdownReporterTask;
+         _qualificationInputTask = qualificationInputTask;
       }
 
       protected override void SaveProjectContext(string projectFile) => _workspacePersistor.SaveSession(_workspace, projectFile);
 
       protected override void LoadProjectContext(PKSimProject project) => _workspace.Project = project;
 
-      protected override void ValidateInputs(Project snapshotProject, QualificationConfiguration configuration)
+      protected override void ValidateInputs(Project snapshotProject, QualificationConfiguration configuration) => 
+         _qualificationInputTask.ValidateInputs(snapshotProject, configuration);
+
+      protected override async Task<(PKSimProject, InputMapping[])> LoadProjectAndExportInputs(QualificationRunOptions runOptions, Project snapshot, QualificationConfiguration config)
       {
-         configuration.Inputs?.Each(x =>
-         {
-            var buildingBlock = snapshotProject.BuildingBlockByTypeAndName(x.Type, x.Name);
-            if (buildingBlock == null)
-               throw new QualificationRunException(CannotFindBuildingBlockInSnapshot(x.Type.ToString(), x.Name, snapshotProject.Name));
-         });
+         var project = await _snapshotTask.LoadProjectFromSnapshotAsync(snapshot, runOptions.Run);
+         
+         return (project, _qualificationInputTask.ExportInputs(project, config));
       }
 
       protected override SimulationExportMode ExportMode(QualificationRunOptions runOptions) => runOptions.Run ? SimulationExportMode.Xml | SimulationExportMode.Csv : SimulationExportMode.Pkml;
@@ -124,11 +123,6 @@ namespace PKSim.CLI.Core.Services
       {
          var referenceSimulation = snapshotProject.Simulations?.FindByName(simulationName);
          return referenceSimulation ?? throw new QualificationRunException(CannotFindSimulationInSnapshot(simulationName, snapshotProject.Name));
-      }
-
-      protected override Task ExportToMarkdown(object buildingBlock, string fileFullPath, int? inputSectionLevel)
-      {
-         return _markdownReporterTask.ExportToMarkdown(buildingBlock, fileFullPath, inputSectionLevel);
       }
    }
 }

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -56,9 +56,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />

--- a/src/PKSim.CLI/Program.cs
+++ b/src/PKSim.CLI/Program.cs
@@ -7,7 +7,6 @@ using OSPSuite.Core.Services;
 using OSPSuite.Infrastructure.Services;
 using OSPSuite.Utility.Container;
 using PKSim.CLI.Commands;
-using PKSim.CLI.Core.Services;
 using PKSim.Core;
 
 namespace PKSim.CLI

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.49" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/ProjectSnapshotToSimulationTransferMapper.cs
+++ b/src/PKSim.Core/Services/ProjectSnapshotToSimulationTransferMapper.cs
@@ -11,7 +11,7 @@ using Project = PKSim.Core.Snapshots.Project;
 
 namespace PKSim.Core.Services;
 
-public interface IProjectSnapshotToSimulationTransferMapper : IMapper<string, SimulationTransfer>;
+public interface IProjectSnapshotToSimulationTransferMapper : IMapper<string, (SimulationTransfer transfer, PKSimProject project)>;
 
 public class ProjectSnapshotToSimulationTransferMapper(
    IJsonSerializer jsonSerializer,
@@ -19,7 +19,7 @@ public class ProjectSnapshotToSimulationTransferMapper(
    ISimulationConfigurationTask simulationConfigurationTask,
    ISimulationToModelCoreSimulationMapper simulationMapper) : IProjectSnapshotToSimulationTransferMapper
 {
-   public SimulationTransfer MapFrom(string snapshotString)
+   public (SimulationTransfer transfer, PKSimProject project) MapFrom(string snapshotString)
    {
       var snapshot = jsonSerializer.DeserializeFromBase64String<Project>(snapshotString).Result;
       var project = snapshotMapper.MapToModel(snapshot, new ProjectContext(new PKSimProject(), runSimulations: false)).Result as PKSimProject;
@@ -34,9 +34,9 @@ public class ProjectSnapshotToSimulationTransferMapper(
       // The module should contain the snapshot from which it was created
       modelCoreSimulation.Configuration.ModuleConfigurations.First().Module.Snapshot = snapshotString;
 
-      return new SimulationTransfer
+      return (new SimulationTransfer
       {
          Simulation = modelCoreSimulation
-      };
+      }, project);
    }
 }

--- a/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -47,6 +47,7 @@ namespace PKSim.Core.Snapshots.Mappers
          var snapshot = await SnapshotFrom(project, x =>
          {
             x.Version = ProjectVersions.Current;
+            x.Name = SnapshotValueFor(project.Name);
             x.Description = SnapshotValueFor(project.Description);
          });
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.49" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
   </ItemGroup>
 

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.49" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.R/RRegister.cs
+++ b/src/PKSim.R/RRegister.cs
@@ -1,6 +1,4 @@
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Infrastructure.Import.Services;
-using OSPSuite.R.Services;
 using OSPSuite.Utility.Container;
 using PKSim.CLI.Core;
 using PKSim.Core;
@@ -29,7 +27,6 @@ namespace PKSim.R
       private static void registerCLITypes(IContainer container)
       {
          container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
-         container.Register<ICsvDynamicSeparatorSelector, ICsvSeparatorSelector, CsvSeparatorSelector>(LifeStyle.Singleton);
       }
    }
 }

--- a/src/PKSim.UI.Starter/CLIApplicationStartup.cs
+++ b/src/PKSim.UI.Starter/CLIApplicationStartup.cs
@@ -1,0 +1,80 @@
+﻿using OSPSuite.Assets;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+using OSPSuite.Utility.Exceptions;
+using OSPSuite.Utility.Format;
+using PKSim.CLI.Core.MinimalImplementations;
+using PKSim.Core;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+using PKSim.Presentation;
+using System;
+using System.Threading;
+using OSPSuite.Presentation;
+
+namespace PKSim.UI.Starter;
+
+public class CLIApplicationStartup : ApplicationStartup
+{
+   static IContainer _container;
+
+   public static IContainer Initialize()
+   {
+      if (_container != null)
+         return _container;
+
+      RedirectAssembly("System.ComponentModel.Annotations", new Version(4, 2, 1, 0), "b03f5f7f11d50a3a");
+      _container = initializeForStartup(IoC.Container);
+
+      return _container;
+   }
+
+   private static IContainer initializeForStartup(IContainer moBiContainer)
+   {
+      ApplicationIcons.DefaultIcon = ApplicationIcons.PKSim;
+
+      var pkSimContainer = InfrastructureRegister.Initialize(registerContainerAsStatic: false);
+
+      using (pkSimContainer.OptimizeDependencyResolution())
+      {
+         // Set SynchronizationContext using MoBi Application context before registering new DevExpress components
+         // They will create and use a new context but will not start a message loop until a UI is loaded
+         // There are some methods in the API that do not use a UI
+         var synchronizationContext = moBiContainer.Resolve<SynchronizationContext>();
+         SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+         pkSimContainer.RegisterImplementationOf(synchronizationContext);
+
+         pkSimContainer.RegisterImplementationOf(NumericFormatterOptions.Instance);
+         pkSimContainer.Register<IApplicationController, ApplicationController>(LifeStyle.Singleton);
+
+         // Full registration of PKSim Core and Infrastructure
+         pkSimContainer.AddRegister(x => x.FromType<CoreRegister>());
+         pkSimContainer.AddRegister(x => x.FromType<InfrastructureRegister>());
+         pkSimContainer.AddRegister(x => x.FromType<CLI.Core.CLIRegister>());
+
+         pkSimContainer.Register<IInteractiveSimulationRunner, InteractiveSimulationRunner>(LifeStyle.Singleton);
+         InfrastructureRegister.LoadSerializers(pkSimContainer);
+         pkSimContainer.Register<IExceptionManager, ExceptionManager>(LifeStyle.Singleton);
+         InfrastructureRegister.RegisterWorkspace(pkSimContainer);
+         
+         pkSimContainer.Register<IMRUProvider, MRUProvider>();
+
+         registerCLITypes(pkSimContainer);
+      }
+
+      return pkSimContainer;
+   }
+
+   private static void registerCLITypes(IContainer container)
+   {
+      container.Register<IProgressUpdater, NoneProgressUpdater>();
+      container.Register<IOntogenyTask, CLIIndividualOntogenyTask>();
+      container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
+      container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, IPresentationUserSettings, CLIStarterUserSettings>(LifeStyle.Singleton);
+      container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
+   }
+}

--- a/src/PKSim.UI.Starter/CLIStarterUserSettings.cs
+++ b/src/PKSim.UI.Starter/CLIStarterUserSettings.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OSPSuite.Assets;
+using OSPSuite.Core.Comparison;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Presenters.ParameterIdentifications;
+using OSPSuite.Presentation.Presenters.SensitivityAnalyses;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Presentation.Settings;
+using PKSim.CLI.Core.MinimalImplementations;
+using PKSim.Core.Model;
+using PKSim.Presentation;
+
+namespace PKSim.UI.Starter;
+
+public class CLIStarterUserSettings : CLIUserSettings, IUserSettings
+{
+   public IList<string> ProjectFiles { get; set; } = new List<string>();
+   public string DefaultChartEditorLayout { get; set; }
+   public string ActiveSkin { get; set; }
+   public Scalings DefaultChartYScaling { get; set; }
+   public IconSize IconSizeTreeView { get; set; }
+   public IconSize IconSizeTab { get; set; }
+   public IconSize IconSizeContextMenu { get; set; }
+   public uint DecimalPlace { get; set; }
+   public bool AllowsScientificNotation { get; set; }
+   public uint MRUListItemCount { get; set; }
+   public ComparerSettings ComparerSettings { get; set; }
+   public string MainViewLayout { get; set; }
+   public string RibbonLayout { get; set; }
+   public int LayoutVersion { get; set; }
+   public Color ChangedColor { get; set; }
+   public Color FormulaColor { get; set; }
+   public Color ChartBackColor { get; set; }
+   public Color ChartDiagramBackColor { get; set; }
+   public bool ColorGroupObservedDataFromSameFolder { get; set; }
+   public DisplayUnitsManager DisplayUnits { get; set; } = new DisplayUnitsManager();
+   public Color DisabledColor { get; set; }
+   public ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
+   public string LastIgnoredVersion { get; set; }
+
+   public IDiagramOptions DiagramOptions { get; set; }
+
+   public string ChartEditorLayout { get; set; }
+
+   public DirectoryMapSettings DirectoryMapSettings { get; } = new DirectoryMapSettings();
+   public IEnumerable<DirectoryMap> UsedDirectories { get; } = Enumerable.Empty<DirectoryMap>();
+   public bool ShowUpdateNotification { get; set; }
+   public bool ShouldRestoreWorkspaceLayout { get; set; }
+
+   public JournalPageEditorSettings JournalPageEditorSettings { get; set; } = new JournalPageEditorSettings();
+   public ParameterIdentificationFeedbackEditorSettings ParameterIdentificationFeedbackEditorSettings { get; set; } = new ParameterIdentificationFeedbackEditorSettings();
+   public SensitivityAnalysisFeedbackEditorSettings SensitivityAnalysisFeedbackEditorSettings { get; set; } = new SensitivityAnalysisFeedbackEditorSettings();
+
+   public void RestoreLayout()
+   {
+      /*nothing to do*/
+   }
+
+   public void SaveLayout()
+   {
+      /*nothing to do*/
+   }
+
+   public void ResetLayout()
+   {
+      /*nothing to do*/
+   }
+
+   public ViewLayout PreferredViewLayout { get; set; } = ViewLayouts.TabbedView;
+   public LoadTemplateWithReference LoadTemplateWithReference { get; set; } = LoadTemplateWithReference.Load;
+}

--- a/src/PKSim.UI.Starter/ExpressionProfileCreator.cs
+++ b/src/PKSim.UI.Starter/ExpressionProfileCreator.cs
@@ -36,7 +36,7 @@ namespace PKSim.UI.Starter
 
       private static object createExpressionProfile<T>() where T : IndividualMolecule
       {
-         var container = ApplicationStartup.Initialize();
+         var container = UIApplicationStartup.Initialize();
 
          using (var presenter = container.Resolve<ICreateExpressionProfilePresenter>())
          {
@@ -51,7 +51,7 @@ namespace PKSim.UI.Starter
 
       public static object GetExpressionDatabaseQuery(ExpressionProfileBuildingBlock buildingBlock)
       {
-         var container = ApplicationStartup.Initialize();
+         var container = UIApplicationStartup.Initialize();
 
          var expressionProfileProteinDatabaseTask = container.Resolve<IExpressionProfileProteinDatabaseTask>();
          loadApplicationSettings(container);

--- a/src/PKSim.UI.Starter/IndividualCreator.cs
+++ b/src/PKSim.UI.Starter/IndividualCreator.cs
@@ -10,7 +10,7 @@ namespace PKSim.UI.Starter
    {
       public static object CreateIndividual()
       {
-         var container = ApplicationStartup.Initialize();
+         var container = UIApplicationStartup.Initialize();
 
          using (var presenter = container.Resolve<ICreateIndividualPresenter>())
          {

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI.Starter/SimulationTransferConstructor.cs
+++ b/src/PKSim.UI.Starter/SimulationTransferConstructor.cs
@@ -1,17 +1,29 @@
-﻿using PKSim.Core.Services;
+﻿using OSPSuite.Core.Qualification;
+using PKSim.CLI.Core.Services;
+using PKSim.Core.Services;
 
-namespace PKSim.UI.Starter
+namespace PKSim.UI.Starter;
+
+public static class SimulationTransferConstructor
 {
-   public static class SimulationTransferConstructor
+   public static object CreateSimulationTransfer(string projectSnapshot)
    {
-      public static object CreateSimulationTransfer(string projectSnapshot)
-      {
-         var container = ApplicationStartup.Initialize();
-         var projectSnapshotToSimulationTransferMapper = container.Resolve<IProjectSnapshotToSimulationTransferMapper>();
-         var moBiExportTask = container.Resolve<IMoBiExportTask>();
+      var container = CLIApplicationStartup.Initialize();
+      var projectSnapshotToSimulationTransferMapper = container.Resolve<IProjectSnapshotToSimulationTransferMapper>();
 
-         var simulationTransfer = projectSnapshotToSimulationTransferMapper.MapFrom(projectSnapshot);
-         return moBiExportTask.Serialize(simulationTransfer);
-      }
+      return projectSnapshotToSimulationTransferMapper.MapFrom(projectSnapshot).transfer;
+   }
+
+   public static object CreateSimulationTransferAndExportInputs(string projectSnapshot, QualificationConfiguration qualificationConfiguration)
+   {
+      var container = CLIApplicationStartup.Initialize();
+      var projectSnapshotToSimulationTransferMapper = container.Resolve<IProjectSnapshotToSimulationTransferMapper>();
+      var qualificationInputTask = container.Resolve<IQualificationInputTask>();
+
+      var (simulationTransfer, project) = projectSnapshotToSimulationTransferMapper.MapFrom(projectSnapshot);
+
+      var inputMappings = qualificationInputTask.ExportInputs(project, qualificationConfiguration);
+      
+      return (simulationTransfer, inputMappings);
    }
 }

--- a/src/PKSim.UI.Starter/UIApplicationStartup.cs
+++ b/src/PKSim.UI.Starter/UIApplicationStartup.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading;
-using DevExpress.LookAndFeel;
+﻿using DevExpress.LookAndFeel;
 using DevExpress.XtraBars;
 using DevExpress.XtraBars.Docking;
 using DevExpress.XtraBars.Ribbon;
@@ -21,11 +19,13 @@ using PKSim.Core;
 using PKSim.Core.Services;
 using PKSim.Infrastructure;
 using PKSim.Presentation;
+using System;
+using System.Threading;
 using PresenterRegister = OSPSuite.Presentation.PresenterRegister;
 
 namespace PKSim.UI.Starter
 {
-   public class ApplicationStartup : Core.ApplicationStartup
+   public class UIApplicationStartup : ApplicationStartup
    {
       static IContainer _container;
 

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,14 +46,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.4" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -73,14 +73,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSim/Properties/launchSettings.json
+++ b/src/PKSim/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "PKSim": {
-      "commandName": "Project",
-      "commandLineArgs": "--dev"
-    }
-  }
-}

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/CLI/QualificationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/CLI/QualificationRunnerSpecs.cs
@@ -37,12 +37,13 @@ namespace PKSim.CLI
       protected QualificationRunOptions _runOptions;
       protected QualificationConfiguration _qualificationConfiguration;
       private Func<string, string> _oldCreateDirectory;
-      protected List<string> _createdDirectories = new List<string>();
+      protected List<string> _createdDirectories = [];
       private Func<string, bool> _oldFileExists;
       private Func<string, bool> _oldDirectoryExists;
       private Action<string, bool> _oldDeleteDirectory;
       protected IDataRepositoryExportTask _dataRepositoryTask;
       protected IMarkdownReporterTask _markdownReporterTask;
+      protected IQualificationInputTask _qualificationInputTask;
 
       public override async Task GlobalContext()
       {
@@ -68,8 +69,9 @@ namespace PKSim.CLI
          _logger = A.Fake<IOSPSuiteLogger>();
          _dataRepositoryTask = A.Fake<IDataRepositoryExportTask>();
          _markdownReporterTask = A.Fake<IMarkdownReporterTask>();
+         _qualificationInputTask = new QualificationInputTask(_logger, _markdownReporterTask);
 
-         sut = new QualificationRunner(_snapshotTask, _jsonSerializer, _workspace, _workspacePersistor, _exportSimulationRunner, _dataRepositoryTask, _markdownReporterTask, _logger);
+         sut = new QualificationRunner(_snapshotTask, _jsonSerializer, _workspace, _workspacePersistor, _exportSimulationRunner, _dataRepositoryTask, _qualificationInputTask, _logger);
 
          _runOptions = new QualificationRunOptions();
          _qualificationConfiguration = new QualificationConfiguration();

--- a/tests/PKSim.Tests/IntegrationTests/ProjectSnapshotToSimulationMapperSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/ProjectSnapshotToSimulationMapperSpecs.cs
@@ -52,7 +52,7 @@ namespace PKSim.IntegrationTests
    {
       protected override void Because()
       {
-         _simulationTransfer = sut.MapFrom(_snapshotString);
+         (_simulationTransfer, _) = sut.MapFrom(_snapshotString);
       }
 
       [Observation]

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -18,8 +18,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -25,11 +25,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.49" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.47" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.49" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">

--- a/tests/PKSim.UI.Tests/StarterTests/ApplicationStartupSpecs.cs
+++ b/tests/PKSim.UI.Tests/StarterTests/ApplicationStartupSpecs.cs
@@ -32,7 +32,7 @@ namespace PKSim.UI.StarterTests
          IoC.Container.RegisterImplementationOf(A.Fake<IJournalPresenter>());
          IoC.Container.RegisterImplementationOf(new BaseShell() as IShell);
 
-         _container = ApplicationStartup.Initialize();
+         _container = UIApplicationStartup.Initialize();
       }
    }
 


### PR DESCRIPTION
Fixes #3240
Fixes #3242

# Description
When MoBi.CLI dynamically loads and access CLI only methods from a PK-Sim assembly, the registration has to be a little different.

The MoBi container will not have any Windows Forms/DevExpress components registered as well as a UserSettings that is defined in a UI project. That is only registered when dynamicaly loading PK-Sim assemblies from a MoBi GUI process.

Also, export the building block markdown where required when rebuilding a PK-Sim module.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):