### PR TITLE
Fixes #3246

### DIFF
--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -3,7 +3,6 @@ using OSPSuite.Core.Domain.ParameterIdentifications;
 using OSPSuite.Core.Domain.SensitivityAnalyses;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
-using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 
@@ -15,7 +14,6 @@ namespace PKSim.Infrastructure.Services
       private readonly ISimulationResultsLoader _simulationResultsLoader;
       private readonly ISimulationChartsLoader _simulationChartsLoader;
       private readonly IRegistrationTask _registrationTask;
-      private readonly IProgressManager _progressManager;
       private readonly ISimulationComparisonContentLoader _simulationComparisonContentLoader;
       private readonly ISimulationAnalysesLoader _simulationAnalysesLoader;
       private readonly IParameterIdentificationContentLoader _parameterIdentificationContentLoader;
@@ -29,14 +27,12 @@ namespace PKSim.Infrastructure.Services
          ISimulationAnalysesLoader simulationAnalysesLoader,
          IParameterIdentificationContentLoader parameterIdentificationContentLoader,
          ISensitivityAnalysisContentLoader sensitivityAnalysisContentLoader,
-         IRegistrationTask registrationTask,
-         IProgressManager progressManager)
+         IRegistrationTask registrationTask)
       {
          _contentLoader = contentLoader;
          _simulationResultsLoader = simulationResultsLoader;
          _simulationChartsLoader = simulationChartsLoader;
          _registrationTask = registrationTask;
-         _progressManager = progressManager;
          _simulationComparisonContentLoader = simulationComparisonContentLoader;
          _simulationAnalysesLoader = simulationAnalysesLoader;
          _parameterIdentificationContentLoader = parameterIdentificationContentLoader;
@@ -89,21 +85,16 @@ namespace PKSim.Infrastructure.Services
 
       private void loadObjectBase<T>(T objectToLoad) where T : IObjectBase
       {
-         using (var progressUpdater = _progressManager.Create())
-         {
-            progressUpdater.ReportStatusMessage(PKSimConstants.UI.LoadingObject(objectToLoad.Name));
+         //first unregistered the object to load that might contain dummy objects that should be deleted
+         _registrationTask.Unregister(objectToLoad);
 
-            //first unregistered the object to load that might contain dummy objects that should be deleted
-            _registrationTask.Unregister(objectToLoad);
+         //load object content
+         _contentLoader.LoadContentFor(objectToLoad);
 
-            //load object content
-            _contentLoader.LoadContentFor(objectToLoad);
+         _registrationTask.Register(objectToLoad);
 
-            _registrationTask.Register(objectToLoad);
-
-            //special loading steps for simulation
-            loadSimulations(objectToLoad as Simulation);
-         }
+         //special loading steps for simulation
+         loadSimulations(objectToLoad as Simulation);
       }
 
       private void loadSimulations(Simulation simulation)
@@ -123,7 +114,7 @@ namespace PKSim.Infrastructure.Services
 
          //make sure each individual gets the expression profile defined in the simulation)  
          var simulationSubject = simulation.BuildingBlock<ISimulationSubject>();
-       
+
          //this can happen for an imported simulation
          if (simulationSubject != null)
             simulation.AllBuildingBlocks<ExpressionProfile>().Each(simulationSubject.AddExpressionProfile);

--- a/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
@@ -276,18 +276,21 @@ namespace PKSim.Presentation.Presenters.Main
          updateSimulationItemsAccordingToSimulationState();
       }
 
-      private void updateSimulationItemsAccordingToSimulationState(bool isRunning = false)
+      /// <summary>
+      ///    Updates the state of all menu items related to simulation according to the current state of the simulation
+      /// </summary>
+      /// <param name="isSimulationRunning">If defined, super seeds the simulationState </param>
+      private void updateSimulationItemsAccordingToSimulationState(bool? isSimulationRunning = null)
       {
-         bool enabled = _simulationState.IsActivated && _enabled;
-         bool resultsEnabled = enabled && _simulationState.HasResult;
-         bool enablePopSimulationItems = enabled && !_simulationState.IsIndividual;
-         bool enableIndividualSimulationItems = enabled && _simulationState.IsIndividual;
-         bool enabledPKSimSimulationOnlyItems = enabled && !_simulationState.IsImported;
+         var enabled = _simulationState.IsActivated && _enabled;
+         var resultsEnabled = enabled && _simulationState.HasResult;
+         var enablePopSimulationItems = enabled && !_simulationState.IsIndividual;
+         var enableIndividualSimulationItems = enabled && _simulationState.IsIndividual;
+         var enabledPKSimSimulationOnlyItems = enabled && !_simulationState.IsImported;
+         var isRunning = enabled && (isSimulationRunning ?? _simulationState.IsRunning);
 
-         var isSimulationAlreadyRunning = (isRunning || _simulationState.IsRunning);
-         _menuBarItemRepository[MenuBarItemIds.Run].Enabled = enabled && !isSimulationAlreadyRunning;
-         _menuBarItemRepository[MenuBarItemIds.RunWithSettings].Enabled = enabled && !isSimulationAlreadyRunning; ;
-
+         _menuBarItemRepository[MenuBarItemIds.Run].Enabled = !isRunning;
+         _menuBarItemRepository[MenuBarItemIds.RunWithSettings].Enabled = !isRunning;
          _menuBarItemRepository[MenuBarItemIds.ExportActiveSimulationToMoBi].Enabled = enabled;
          _menuBarItemRepository[MenuBarItemIds.ExportActiveSimulationToPkml].Enabled = enabled;
          _menuBarItemRepository[MenuBarItemIds.ExportActiveSimulationResultsToCSV].Enabled = enabled;
@@ -305,7 +308,6 @@ namespace PKSim.Presentation.Presenters.Main
          _menuBarItemRepository[MenuBarItemIds.ImportActiveSimulationResults].Enabled = enablePopSimulationItems;
          _menuBarItemRepository[MenuBarItemIds.SavePopulationSimulationWorkflow].Enabled = enablePopSimulationItems;
          _menuBarItemRepository[MenuBarItemIds.LoadPopulationSimulationWorkflow].Enabled = enablePopSimulationItems;
-
          _menuBarItemRepository[MenuBarItemIds.ShowIndividualResults].Enabled = resultsEnabled;
          _menuBarItemRepository[MenuBarItemIds.PredictedVsObservedSimulationAnalysis].Enabled = resultsEnabled;
          _menuBarItemRepository[MenuBarItemIds.ResidualsVsTimeSimulationAnalysis].Enabled = resultsEnabled;
@@ -327,7 +329,6 @@ namespace PKSim.Presentation.Presenters.Main
       {
          enableDefaultItems();
          updateProjectItems(isEnabled: true);
-
          updateSimulationItemsFor(eventToHandle.Simulation, isRunning: false);
       }
 
@@ -336,11 +337,11 @@ namespace PKSim.Presentation.Presenters.Main
          updateSimulationItemsFor(eventToHandle.Simulation as Simulation);
       }
 
-      private void updateSimulationItemsFor(Simulation simulation, bool isRunning = false)
+      private void updateSimulationItemsFor(Simulation simulation, bool? isRunning = null)
       {
          var activeSimulation = _activeSubjectRetriever.Active<Simulation>();
-         bool simIsActive = (activeSimulation != null) && (activeSimulation == simulation);
-         updateSimulationStateFrom(simulation, isActiveSimulation: simIsActive);
+         var isActiveSimulation = Equals(activeSimulation, simulation);
+         updateSimulationStateFrom(simulation, isActiveSimulation);
          updateSimulationItemsAccordingToSimulationState(isRunning);
       }
 
@@ -396,7 +397,7 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(SimulationRunStartedEvent eventToHandle)
       {
-         updateSimulationItemsFor(eventToHandle.Simulation,  isRunning: true);
+         updateSimulationItemsFor(eventToHandle.Simulation, isRunning: true);
          _menuBarItemRepository[MenuBarItemIds.Stop].Enabled = true;
       }
 
@@ -410,9 +411,7 @@ namespace PKSim.Presentation.Presenters.Main
       {
          _enabled = true;
          enableDefaultItems();
-
          updateProjectItems(isEnabled: eventToHandle.ProjectLoaded);
-
          updateSimulationItemsAccordingToSimulationState();
       }
 
@@ -511,8 +510,7 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Visit(Simulation simulation)
       {
-         updateSimulationStateFrom(simulation, isActiveSimulation: true);
-         updateSimulationItemsAccordingToSimulationState();
+         updateSimulationItemsFor(simulation);
          updateResultsVisibility(shouldShowIndividualResults: _simulationState.IsIndividual);
       }
 

--- a/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
@@ -1,9 +1,7 @@
 using FakeItEasy;
-using NPOI.SS.Formula.Functions;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
-using OSPSuite.Utility.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Infrastructure.Services;
@@ -13,9 +11,8 @@ namespace PKSim.Infrastructure
    public abstract class concern_for_LazyLoadTask : ContextSpecification<ILazyLoadTask>
    {
       protected IPKSimBuildingBlock _objectToLoad;
-      protected IRegistrationTask _registrationTask;
-      protected IProgressManager _progressManager;
-      protected IProgressUpdater _progressUpdater;
+
+      protected IRegistrationTask _registrationTask; 
       protected IContentLoader _contentLoader;
       protected ISimulationResultsLoader _simulationResultsLoader;
       protected ISimulationComparisonContentLoader _simulationComparisonContentLoader;
@@ -27,8 +24,6 @@ namespace PKSim.Infrastructure
       protected override void Context()
       {
          _registrationTask = A.Fake<IRegistrationTask>();
-         _progressManager = A.Fake<IProgressManager>();
-         _progressUpdater = A.Fake<IProgressUpdater>();
          _contentLoader = A.Fake<IContentLoader>();
          _simulationChartsLoader = A.Fake<ISimulationChartsLoader>();
          _simulationResultsLoader = A.Fake<ISimulationResultsLoader>();
@@ -37,10 +32,9 @@ namespace PKSim.Infrastructure
          _parameterIdentificationContentLoader = A.Fake<IParameterIdentificationContentLoader>();
          _sensitivityAnalysisContentLoader = A.Fake<ISensitivityAnalysisContentLoader>();
 
-         A.CallTo(() => _progressManager.Create()).Returns(_progressUpdater);
          sut = new LazyLoadTask(_contentLoader, _simulationResultsLoader, _simulationChartsLoader,
             _simulationComparisonContentLoader, _simulationAnalysesLoader, _parameterIdentificationContentLoader, _sensitivityAnalysisContentLoader,
-            _registrationTask, _progressManager);
+            _registrationTask);
          _objectToLoad = A.Fake<IPKSimBuildingBlock>();
          _objectToLoad.Id = "objectId";
       }


### PR DESCRIPTION
Fixes #3246
Fixes #3163

# Description
Running a simulation=> we cannot run in again unless we activate it again by switchign tabs for instance.
Now we have a way to superseed the STATE by using the parameter given

Also fixes #3163 by simply removing the progress bar when lazy loading an object. This does not make sense any more as ONLY one progress bar can be active at a time

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):