### PR TITLE
3250 status bar presenter changes

### DIFF
--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -166,17 +166,19 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(ProgressDoneEvent eventToHandle)
       {
-         hideProgressBar();
+         setProgressBarVisibility();
       }
 
       public void Handle(SimulationRunStartedEvent eventToHandle)
       {
          _runningSimulationsDictionary[eventToHandle.Simulation.Id] = true;
+         setProgressBarVisibility();
       }
 
       public void Handle(SimulationRunFinishedEvent eventToHandle)
       {
          _runningSimulationsDictionary[eventToHandle.Simulation.Id] = false;
+         setProgressBarVisibility();
          if (activeSimulationsCount == 0)
          {
             resetCountersAndHideBar();
@@ -186,7 +188,7 @@ namespace PKSim.Presentation.Presenters.Main
       private void resetCountersAndHideBar()
       {
          _runningSimulationsDictionary.Clear();
-         hideProgressBar();
+         setProgressBarVisibility();
          _eventPublisher.PublishEvent(new AllSimulationsFinishedEvent());
       }
 
@@ -196,7 +198,7 @@ namespace PKSim.Presentation.Presenters.Main
          update(StatusBarElements.Version)
             .WithCaption($"{_applicationConfiguration.FullVersionDisplay}");
 
-         hideProgressBar();
+         setProgressBarVisibility();
       }
 
       public void Handle(JournalLoadedEvent journalLoadedEvent)
@@ -260,15 +262,29 @@ namespace PKSim.Presentation.Presenters.Main
             .WithCaption(caption);
       }
 
-      private void hideProgressBar()
+      private void setProgressBarVisibility()
       {
-         update(StatusBarElements.ProgressBar)
-            .Visible(false)
-            .And.WithValue(0);
+         if (activeSimulationsCount > 1)
+         {
+            update(StatusBarElements.ProgressBar)
+               .Visible(false)
+               .And.WithValue(0);
+         }
+         else if(activeSimulationsCount == 1)
+         {
+            update(StatusBarElements.ProgressBar)
+               .Visible(true);
+         }
 
-         update(StatusBarElements.ProgressStatus)
-            .WithCaption(string.Empty)
-            .And.Visible(false);
+         if (activeSimulationsCount == 0)
+         {
+            update(StatusBarElements.ProgressBar)
+               .Visible(false);
+
+            update(StatusBarElements.ProgressStatus)
+               .WithCaption(string.Empty)
+               .And.Visible(false);
+         }
       }
 
       public void Handle(StatusMessageEvent eventToHandle)


### PR DESCRIPTION
Fixes #3250 

# Description

Only show progress bar when one simulation is running, otherwise show the status message 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):