### PR TITLE
Disable code signing

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -39,11 +39,11 @@ jobs:
     needs: get-latest-commit-timespan
     if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN < 86400
     runs-on: windows-latest
-    env:
-      ES_USERNAME: ${{ secrets.ES_USERNAME }}
-      ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
-      ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
-      ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+#    env:
+#      ES_USERNAME: ${{ secrets.ES_USERNAME }}
+#      ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+#      ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
+#      ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -67,20 +67,20 @@ jobs:
       - name : Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"
 
-      - name: Sign PKSim.exe with CodeSignTool
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
-        with:
-          file_path: ./src/PKSim/bin/Debug/net472/PKSim.exe
+#      - name: Sign PKSim.exe with CodeSignTool
+#        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+#        with:
+#          file_path: ./src/PKSim/bin/Debug/net472/PKSim.exe
           
-      - name: Sign PKSim.BatchTool.exe with CodeSignTool
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
-        with:
-          file_path: ./src/PKSim/bin/Debug/net472/PKSim.BatchTool.exe
+#      - name: Sign PKSim.BatchTool.exe with CodeSignTool
+#        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+#        with:
+#          file_path: ./src/PKSim/bin/Debug/net472/PKSim.BatchTool.exe
           
-      - name: Sign PKSim.CLI.exe with CodeSignTool
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
-        with:
-          file_path: ./src/PKSim/bin/Debug/net472/PKSim.CLI.exe
+#      - name: Sign PKSim.CLI.exe with CodeSignTool
+#        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+#        with:
+#          file_path: ./src/PKSim/bin/Debug/net472/PKSim.CLI.exe
           
       - name: Create Setup
         run: |


### PR DESCRIPTION
Fixes #3258 Disable code signing until the final certificate arrives.

# Description

Commenting the code signing out till the final certificate arrives.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [X] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):