### PR TITLE
Fixes #3258 Disable code signing until the final certificate arrives.

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -87,10 +87,10 @@ jobs:
           rake "create_setup[${{env.APP_VERSION}}, Debug]"
           rake "create_portable_setup[${{env.APP_VERSION}}, Debug, pk-sim-portable-setup.zip]"
 
-      - name: Sign PKSim setup with CodeSignTool
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
-        with:
-          file_path: ./setup/deploy/PK-Sim.${{ env.APP_VERSION }}.msi
+#      - name: Sign PKSim setup with CodeSignTool
+#        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+#        with:
+#          file_path: ./setup/deploy/PK-Sim.${{ env.APP_VERSION }}.msi
 
       - name: Push test log as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #3258 Disable code signing until the final certificate arrives.

# Description

Forgot to disable the signing of the setup, so nightly failed

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [X] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):