### PR TITLE
3249 centralize on the simulation runner all the inofrmation

### DIFF
--- a/src/PKSim.Core/Services/IndividualSimulationEngine.cs
+++ b/src/PKSim.Core/Services/IndividualSimulationEngine.cs
@@ -52,10 +52,8 @@ namespace PKSim.Core.Services
          _simModelManager.SimulationProgress += simulationProgress;
          //make sure that thread methods always catch and handle any exception,
          //otherwise we risk unplanned application termination
-         var begin = SystemTime.UtcNow();
          try
          {
-            RaiseEvent(new SimulationRunStartedEvent(individualSimulation));
             await runSimulation(individualSimulation, simulationRunOptions, cancellationToken);
          }
          catch (Exception ex)
@@ -63,12 +61,6 @@ namespace PKSim.Core.Services
             terminated();
             if (!(ex is TaskCanceledException)) //do not throw if this has been canceled
                throw;
-         }
-         finally
-         {
-            var end = SystemTime.UtcNow();
-            var timeSpent = end - begin;
-            RaiseEvent(new SimulationRunFinishedEvent(individualSimulation, timeSpent));
          }
       }
 

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -1,11 +1,15 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.SimModel.Services;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
@@ -30,8 +34,9 @@ namespace PKSim.Core.Services
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IExecutionContext _executionContext;
       private readonly ConcurrentDictionary<Simulation, CancellationTokenSource> _cancellationTokenSources = new ConcurrentDictionary<Simulation, CancellationTokenSource>();
-
+      private readonly IEventPublisher _eventPublisher;
       private readonly SimulationRunOptions _simulationRunOptions;
+      protected bool _shouldRaiseEvents;
 
       public InteractiveSimulationRunner(
          ISimulationSettingsRetriever simulationSettingsRetriever,
@@ -39,7 +44,8 @@ namespace PKSim.Core.Services
          ICloner cloner,
          ISimulationAnalysisCreator simulationAnalysisCreator,
          ILazyLoadTask lazyLoadTask,
-         IExecutionContext executionContext)
+         IExecutionContext executionContext,
+         IEventPublisher eventPublisher)
       {
          _simulationSettingsRetriever = simulationSettingsRetriever;
          _simulationRunner = simulationRunner;
@@ -47,11 +53,12 @@ namespace PKSim.Core.Services
          _simulationAnalysisCreator = simulationAnalysisCreator;
          _lazyLoadTask = lazyLoadTask;
          _executionContext = executionContext;
+         _eventPublisher = eventPublisher;
 
          _simulationRunOptions = new SimulationRunOptions
          {
             CheckForNegativeValues = true,
-            RaiseEvents = true,
+            RaiseEvents = true, //This is always true, but still worth checking before rising an event since it can change.
             RunForAllOutputs = false,
             SimModelExportMode = SimModelExportMode.Optimized
          };
@@ -65,7 +72,9 @@ namespace PKSim.Core.Services
 
       private async Task runSimulationAsync(Simulation simulation, bool selectOutput)
       {
+         _shouldRaiseEvents = _simulationRunOptions.RaiseEvents;
          var cts = new CancellationTokenSource();
+         var begin = new DateTime();
          if (!_cancellationTokenSources.TryAdd(simulation, cts)) //this will prevent from running one that is already running
             return;
          try
@@ -83,7 +92,8 @@ namespace PKSim.Core.Services
 
                _executionContext.PublishEvent(new SimulationOutputSelectionsChangedEvent(simulation));
             }
-
+            begin = SystemTime.UtcNow();
+            _eventPublisher.PublishEvent(new SimulationRunStartedEvent(simulation));
             await _simulationRunner.RunSimulation(simulation, _simulationRunOptions, cts.Token);
 
             addAnalysableToSimulationIfRequired(simulation);
@@ -92,10 +102,13 @@ namespace PKSim.Core.Services
          {
             if (_cancellationTokenSources.ContainsKey(simulation))
             {
+               var end = SystemTime.UtcNow();
+               var timeSpent = end - begin;
                if (_cancellationTokenSources.TryRemove(simulation, out var ctsToDispose))
                {
                   ctsToDispose.Dispose();
                }
+               _eventPublisher.PublishEvent(new SimulationRunFinishedEvent(simulation, timeSpent));
             }
          }
       }
@@ -122,6 +135,11 @@ namespace PKSim.Core.Services
          if (simulation == null || !simulation.HasResults) return;
          if (simulation.Analyses.Count() != 0) return;
          _simulationAnalysisCreator.CreateAnalysisFor(simulation);
+      }
+      private void raiseEvent<T>(T eventToPublish)
+      {
+         if (_shouldRaiseEvents)
+            _eventPublisher.PublishEvent(eventToPublish);
       }
 
       public void StopSimulation(Simulation simulation)

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -79,11 +79,10 @@ namespace PKSim.Core.Services
       {
          _shouldRaiseEvents = _simulationRunOptions.RaiseEvents;
          var cts = new CancellationTokenSource();
-         var begin = new DateTime();
-
-         if (!_cancellationTokenSources.TryAdd(simulation, cts))
+         if (!_cancellationTokenSources.TryAdd(simulation, cts)) //this will prevent from running one that is already running
             return;
 
+         var begin = new DateTime();
          try
          {
             _lazyLoadTask.Load(simulation);
@@ -97,10 +96,10 @@ namespace PKSim.Core.Services
                simulation.OutputSelections.UpdatePropertiesFrom(outputSelections, _cloner);
                mappingsNotSelected(simulation).Each(simulation.OutputMappings.Remove);
 
-               _executionContext.PublishEvent(new SimulationOutputSelectionsChangedEvent(simulation));
+               raiseEvent(new SimulationOutputSelectionsChangedEvent(simulation));
             }
             begin = SystemTime.UtcNow();
-            _executionContext.PublishEvent(new SimulationRunStartedEvent(simulation));
+            raiseEvent(new SimulationRunStartedEvent(simulation));
             await _simulationRunner.RunSimulation(simulation, _simulationRunOptions, cts.Token);
 
             addAnalysableToSimulationIfRequired(simulation);
@@ -113,7 +112,7 @@ namespace PKSim.Core.Services
                var timeSpent = end - begin;
                if (_cancellationTokenSources.TryRemove(simulation, out var ctsToDispose))
                   ctsToDispose.Dispose();
-               _executionContext.PublishEvent(new SimulationRunFinishedEvent(simulation, timeSpent));
+               raiseEvent(new SimulationRunFinishedEvent(simulation, timeSpent));
             }
          }
       }
@@ -164,7 +163,7 @@ namespace PKSim.Core.Services
          {
             cts.Cancel();
             cts.Dispose();
-            _executionContext.PublishEvent(new SimulationRunCanceledEvent(simulation));
+            raiseEvent(new SimulationRunCanceledEvent(simulation));
          }
       }
 

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -39,7 +39,6 @@ namespace PKSim.Core.Services
       private readonly ConcurrentDictionary<Simulation, CancellationTokenSource> _cancellationTokenSources = new ConcurrentDictionary<Simulation, CancellationTokenSource>();
       private readonly IEventPublisher _eventPublisher;
       private readonly SimulationRunOptions _simulationRunOptions;
-      protected bool _shouldRaiseEvents;
 
       public int ActiveSimulationsCount => _cancellationTokenSources.Count;
       public IReadOnlyCollection<Simulation> ActiveSimulations => _cancellationTokenSources.Keys.ToList().AsReadOnly();
@@ -77,7 +76,6 @@ namespace PKSim.Core.Services
 
       private async Task runSimulationAsync(Simulation simulation, bool selectOutput)
       {
-         _shouldRaiseEvents = _simulationRunOptions.RaiseEvents;
          var cts = new CancellationTokenSource();
          if (!_cancellationTokenSources.TryAdd(simulation, cts)) //this will prevent from running one that is already running
             return;
@@ -142,7 +140,7 @@ namespace PKSim.Core.Services
       }
       private void raiseEvent<T>(T eventToPublish)
       {
-         if (_shouldRaiseEvents)
+         if (_simulationRunOptions.RaiseEvents)
             _executionContext.PublishEvent(eventToPublish);
       }
 

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -23,6 +23,9 @@ namespace PKSim.Core.Services
       void StopAllSimulations();
       bool IsSimulationRunning(Simulation simulation);
       bool IsSimulationIdle(Simulation simulation);
+      int ActiveSimulationsCount { get; }
+      IReadOnlyCollection<Simulation> ActiveSimulations { get; }
+      bool AnySimulationRunning { get; }
    }
 
    public class InteractiveSimulationRunner : IInteractiveSimulationRunner
@@ -38,14 +41,17 @@ namespace PKSim.Core.Services
       private readonly SimulationRunOptions _simulationRunOptions;
       protected bool _shouldRaiseEvents;
 
+      public int ActiveSimulationsCount => _cancellationTokenSources.Count;
+      public IReadOnlyCollection<Simulation> ActiveSimulations => _cancellationTokenSources.Keys.ToList().AsReadOnly();
+      public bool AnySimulationRunning => ActiveSimulationsCount > 0;
+
       public InteractiveSimulationRunner(
          ISimulationSettingsRetriever simulationSettingsRetriever,
          ISimulationRunner simulationRunner,
          ICloner cloner,
          ISimulationAnalysisCreator simulationAnalysisCreator,
          ILazyLoadTask lazyLoadTask,
-         IExecutionContext executionContext,
-         IEventPublisher eventPublisher)
+         IExecutionContext executionContext)
       {
          _simulationSettingsRetriever = simulationSettingsRetriever;
          _simulationRunner = simulationRunner;
@@ -53,7 +59,6 @@ namespace PKSim.Core.Services
          _simulationAnalysisCreator = simulationAnalysisCreator;
          _lazyLoadTask = lazyLoadTask;
          _executionContext = executionContext;
-         _eventPublisher = eventPublisher;
 
          _simulationRunOptions = new SimulationRunOptions
          {
@@ -75,8 +80,10 @@ namespace PKSim.Core.Services
          _shouldRaiseEvents = _simulationRunOptions.RaiseEvents;
          var cts = new CancellationTokenSource();
          var begin = new DateTime();
-         if (!_cancellationTokenSources.TryAdd(simulation, cts)) //this will prevent from running one that is already running
+
+         if (!_cancellationTokenSources.TryAdd(simulation, cts))
             return;
+
          try
          {
             _lazyLoadTask.Load(simulation);
@@ -93,7 +100,7 @@ namespace PKSim.Core.Services
                _executionContext.PublishEvent(new SimulationOutputSelectionsChangedEvent(simulation));
             }
             begin = SystemTime.UtcNow();
-            _eventPublisher.PublishEvent(new SimulationRunStartedEvent(simulation));
+            _executionContext.PublishEvent(new SimulationRunStartedEvent(simulation));
             await _simulationRunner.RunSimulation(simulation, _simulationRunOptions, cts.Token);
 
             addAnalysableToSimulationIfRequired(simulation);
@@ -105,10 +112,8 @@ namespace PKSim.Core.Services
                var end = SystemTime.UtcNow();
                var timeSpent = end - begin;
                if (_cancellationTokenSources.TryRemove(simulation, out var ctsToDispose))
-               {
                   ctsToDispose.Dispose();
-               }
-               _eventPublisher.PublishEvent(new SimulationRunFinishedEvent(simulation, timeSpent));
+               _executionContext.PublishEvent(new SimulationRunFinishedEvent(simulation, timeSpent));
             }
          }
       }
@@ -117,7 +122,7 @@ namespace PKSim.Core.Services
          simulation.OutputMappings.Where(outputMapping => !outputMappingIsSelected(simulation, outputMapping)).ToList();
 
       private static bool outputMappingIsSelected(Simulation simulation, OutputMapping outputMapping) =>
-         simulation.OutputSelections.AllOutputs.Any(quantitySelection => Equals(quantitySelection.Path, outputMapping.OutputPath));
+         simulation.OutputSelections.AllOutputs.Any(q => Equals(q.Path, outputMapping.OutputPath));
 
       private bool outputSelectionRequired(Simulation simulation, bool selectOutput)
       {
@@ -139,7 +144,7 @@ namespace PKSim.Core.Services
       private void raiseEvent<T>(T eventToPublish)
       {
          if (_shouldRaiseEvents)
-            _eventPublisher.PublishEvent(eventToPublish);
+            _executionContext.PublishEvent(eventToPublish);
       }
 
       public void StopSimulation(Simulation simulation)
@@ -150,9 +155,7 @@ namespace PKSim.Core.Services
       public void StopAllSimulations()
       {
          foreach (var simulation in _cancellationTokenSources.Keys.ToList())
-         {
             tryCancelAndDispose(simulation);
-         }
       }
 
       private void tryCancelAndDispose(Simulation simulation)

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -96,6 +95,7 @@ namespace PKSim.Core.Services
 
                raiseEvent(new SimulationOutputSelectionsChangedEvent(simulation));
             }
+
             begin = SystemTime.UtcNow();
             raiseEvent(new SimulationRunStartedEvent(simulation));
             await _simulationRunner.RunSimulation(simulation, _simulationRunOptions, cts.Token);
@@ -138,6 +138,7 @@ namespace PKSim.Core.Services
          if (simulation.Analyses.Count() != 0) return;
          _simulationAnalysisCreator.CreateAnalysisFor(simulation);
       }
+
       private void raiseEvent<T>(T eventToPublish)
       {
          if (_simulationRunOptions.RaiseEvents)

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
-using OSPSuite.Utility;
 using OSPSuite.Utility.Events;
 using PKSim.Assets;
-using PKSim.Core.Events;
 using PKSim.Core.Model;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PKSim.Core.Services
 {
@@ -69,19 +67,15 @@ namespace PKSim.Core.Services
 
          _shouldRaiseEvents = simulationRunOptions.RaiseEvents;
 
-         var begin = SystemTime.UtcNow();
          try
          {
             var populationData = _populationExporter.CreatePopulationDataFor(populationSimulation);
             var modelCoreSimulation = _modelCoreSimulationMapper.MapFrom(populationSimulation, shouldCloneModel: false);
             var runOptions = new RunOptions {NumberOfCoresToUse = _userSettings.MaximumNumberOfCoresToUse};
-            var simulationRunStartedEvent = new SimulationRunStartedEvent(populationSimulation);
-            RaiseEvent(simulationRunStartedEvent);
             var populationRunResults = await _populationRunner.RunPopulationAsync(modelCoreSimulation, runOptions, populationData, populationSimulation.AgingData.ToDataTable(), cancellationToken: cancellationToken);
             _simulationResultsSynchronizer.Synchronize(populationSimulation, populationRunResults.Results);
             _populationSimulationAnalysisSynchronizer.UpdateAnalysesDefinedIn(populationSimulation);
             RaiseEvent(new SimulationResultsUpdatedEvent(populationSimulation));
-
          }
          catch (OperationCanceledException)
          {
@@ -92,12 +86,6 @@ namespace PKSim.Core.Services
          {
             simulationTerminated();
             throw;
-         }
-         finally
-         {
-            var end = SystemTime.UtcNow();
-            var timeSpent = end - begin;
-            RaiseEvent(new SimulationRunFinishedEvent(populationSimulation, timeSpent));
          }
       }
 

--- a/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
@@ -288,7 +288,7 @@ namespace PKSim.Presentation.Presenters.Main
          var enablePopSimulationItems = enabled && !_simulationState.IsIndividual;
          var enableIndividualSimulationItems = enabled && _simulationState.IsIndividual;
          var enabledPKSimSimulationOnlyItems = enabled && !_simulationState.IsImported;
-         var isRunning = enabled && (_simulationState.IsRunning);
+         var isRunning = enabled && _simulationState.IsRunning;
 
          _menuBarItemRepository[MenuBarItemIds.Run].Enabled = !isRunning;
          _menuBarItemRepository[MenuBarItemIds.RunWithSettings].Enabled = !isRunning;

--- a/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/MenuAndToolBarPresenter.cs
@@ -48,7 +48,8 @@ namespace PKSim.Presentation.Presenters.Main
       IListener<ParameterIdentificationTerminatedEvent>,
       IListener<SensitivityAnalysisStartedEvent>,
       IListener<SensitivityAnalysisTerminatedEvent>,
-      IListener<AllSimulationsFinishedEvent>
+      IListener<AllSimulationsFinishedEvent>,
+      IListener<SimulationRunCanceledEvent>
    {
    }
 
@@ -287,7 +288,7 @@ namespace PKSim.Presentation.Presenters.Main
          var enablePopSimulationItems = enabled && !_simulationState.IsIndividual;
          var enableIndividualSimulationItems = enabled && _simulationState.IsIndividual;
          var enabledPKSimSimulationOnlyItems = enabled && !_simulationState.IsImported;
-         var isRunning = enabled && (isSimulationRunning ?? _simulationState.IsRunning);
+         var isRunning = enabled && (_simulationState.IsRunning);
 
          _menuBarItemRepository[MenuBarItemIds.Run].Enabled = !isRunning;
          _menuBarItemRepository[MenuBarItemIds.RunWithSettings].Enabled = !isRunning;
@@ -589,6 +590,13 @@ namespace PKSim.Presentation.Presenters.Main
       public void Handle(AllSimulationsFinishedEvent eventToHandle)
       {
          _menuBarItemRepository[MenuBarItemIds.Stop].Enabled = false;
+      }
+
+      public void Handle(SimulationRunCanceledEvent eventToHandle)
+      {
+         enableDefaultItems();
+         updateProjectItems(isEnabled: true);
+         updateSimulationItemsFor(eventToHandle.Simulation, isRunning: false);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -52,7 +52,7 @@ namespace PKSim.Presentation.Presenters.Main
       public event EventHandler StatusChanged = delegate { };
       private readonly IEventPublisher _eventPublisher;
       private readonly IInteractiveSimulationRunner _interactiveSimulationRunner;
-
+      private string countMessage => _interactiveSimulationRunner.ActiveSimulationsCount == 1 ? string.Empty : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
       public StatusBarPresenter(
          IStatusBarView view, 
          IApplicationConfiguration applicationConfiguration, 
@@ -161,7 +161,7 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(ProgressingEvent eventToHandle)
       {
-         var message = _interactiveSimulationRunner.ActiveSimulationsCount == 0 ? string.Empty : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
+         var message = countMessage;
          update(StatusBarElements.ProgressBar)
             .WithValue(eventToHandle.ProgressPercent);
 
@@ -239,13 +239,13 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(ProgressDoneWithMessageEvent eventToHandle)
       {
-         var message = $"{_interactiveSimulationRunner.ActiveSimulationsCount} {eventToHandle.Message}";
-
          if (_interactiveSimulationRunner.ActiveSimulationsCount == 0)
          {
             resetCountersAndHideBar();
             return;
          }
+         
+         var message = $"{countMessage} {eventToHandle.Message}";
 
          update(StatusBarElements.ProgressStatus)
             .WithCaption($"{message}");

--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -50,10 +50,8 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IApplicationConfiguration _applicationConfiguration;
       private int _numberOfReportsBeingCreated;
       public event EventHandler StatusChanged = delegate { };
-      //private readonly ConcurrentDictionary<string, bool> _runningSimulationsDictionary = new ConcurrentDictionary<string, bool>();
       private readonly IEventPublisher _eventPublisher;
       private readonly IInteractiveSimulationRunner _interactiveSimulationRunner;
-      //private int activeSimulationsCount => _runningSimulationsDictionary.Count(x => x.Value);
 
       public StatusBarPresenter(
          IStatusBarView view, 

--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -16,6 +16,7 @@ using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Events;
+using PKSim.Core.Services;
 using PKSim.Presentation.Core;
 
 namespace PKSim.Presentation.Presenters.Main
@@ -49,15 +50,21 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IApplicationConfiguration _applicationConfiguration;
       private int _numberOfReportsBeingCreated;
       public event EventHandler StatusChanged = delegate { };
-      private readonly ConcurrentDictionary<string, bool> _runningSimulationsDictionary = new ConcurrentDictionary<string, bool>();
+      //private readonly ConcurrentDictionary<string, bool> _runningSimulationsDictionary = new ConcurrentDictionary<string, bool>();
       private readonly IEventPublisher _eventPublisher;
-      private int activeSimulationsCount => _runningSimulationsDictionary.Count(x => x.Value);
+      private readonly IInteractiveSimulationRunner _interactiveSimulationRunner;
+      //private int activeSimulationsCount => _runningSimulationsDictionary.Count(x => x.Value);
 
-      public StatusBarPresenter(IStatusBarView view, IApplicationConfiguration applicationConfiguration, IEventPublisher envEventPublisher)
+      public StatusBarPresenter(
+         IStatusBarView view, 
+         IApplicationConfiguration applicationConfiguration, 
+         IEventPublisher envEventPublisher,
+         IInteractiveSimulationRunner interactiveSimulationRunner)
       {
          _view = view;
          _applicationConfiguration = applicationConfiguration;
          _eventPublisher = envEventPublisher;
+         _interactiveSimulationRunner = interactiveSimulationRunner;
       }
 
       public void Initialize()
@@ -142,14 +149,13 @@ namespace PKSim.Presentation.Presenters.Main
             .And.Visible(true);
 
          update(StatusBarElements.ProgressStatus)
-            .WithCaption($"{_runningSimulationsDictionary.Count} {eventToHandle.Message}")
+            .WithCaption($"{_interactiveSimulationRunner.ActiveSimulationsCount} {eventToHandle.Message}")
             .And.Visible(true);
       }
 
       public void Handle(SimulationRunCanceledEvent eventToHandle)
       {
-         _runningSimulationsDictionary[eventToHandle.Simulation.Id] = false;
-         if (activeSimulationsCount == 0)
+         if (_interactiveSimulationRunner.ActiveSimulationsCount == 0)
          {
             resetCountersAndHideBar();
          }
@@ -157,11 +163,12 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(ProgressingEvent eventToHandle)
       {
+         var message = _interactiveSimulationRunner.ActiveSimulationsCount == 0 ? string.Empty : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
          update(StatusBarElements.ProgressBar)
             .WithValue(eventToHandle.ProgressPercent);
 
          update(StatusBarElements.ProgressStatus)
-            .WithCaption($"{activeSimulationsCount} {eventToHandle.Message}");
+            .WithCaption($"{message} {eventToHandle.Message}");
       }
 
       public void Handle(ProgressDoneEvent eventToHandle)
@@ -171,15 +178,13 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(SimulationRunStartedEvent eventToHandle)
       {
-         _runningSimulationsDictionary[eventToHandle.Simulation.Id] = true;
          setProgressBarVisibility();
       }
 
       public void Handle(SimulationRunFinishedEvent eventToHandle)
       {
-         _runningSimulationsDictionary[eventToHandle.Simulation.Id] = false;
          setProgressBarVisibility();
-         if (activeSimulationsCount == 0)
+         if (_interactiveSimulationRunner.ActiveSimulationsCount == 0)
          {
             resetCountersAndHideBar();
          }
@@ -187,7 +192,6 @@ namespace PKSim.Presentation.Presenters.Main
 
       private void resetCountersAndHideBar()
       {
-         _runningSimulationsDictionary.Clear();
          setProgressBarVisibility();
          _eventPublisher.PublishEvent(new AllSimulationsFinishedEvent());
       }
@@ -237,9 +241,9 @@ namespace PKSim.Presentation.Presenters.Main
 
       public void Handle(ProgressDoneWithMessageEvent eventToHandle)
       {
-         var message = $"{activeSimulationsCount} {eventToHandle.Message}";
+         var message = $"{_interactiveSimulationRunner.ActiveSimulationsCount} {eventToHandle.Message}";
 
-         if (activeSimulationsCount == 0)
+         if (_interactiveSimulationRunner.ActiveSimulationsCount == 0)
          {
             resetCountersAndHideBar();
             return;
@@ -264,6 +268,7 @@ namespace PKSim.Presentation.Presenters.Main
 
       private void setProgressBarVisibility()
       {
+         var activeSimulationsCount = _interactiveSimulationRunner.ActiveSimulationsCount;
          if (activeSimulationsCount > 1)
          {
             update(StatusBarElements.ProgressBar)

--- a/tests/PKSim.Tests/Core/IndividualSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/IndividualSimulationEngineSpecs.cs
@@ -72,13 +72,6 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_notify_the_simulation_started_and_finishing_event()
-      {
-         A.CallTo(() => _eventPublisher.PublishEvent(A<SimulationRunStartedEvent>._)).MustHaveHappened();
-         A.CallTo(() => _eventPublisher.PublishEvent(A<SimulationRunFinishedEvent>._)).MustHaveHappened();
-      }
-
-      [Observation]
       public void should_notify_the_simulation_results_updated_event()
       {
          A.CallTo(() => _eventPublisher.PublishEvent(A<SimulationResultsUpdatedEvent>._)).MustHaveHappened();

--- a/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
+using OSPSuite.Utility.Events;
 using PKSim.Core.Chart;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -21,6 +22,8 @@ namespace PKSim.Core
       protected ISimulationRunner _simulationRunner;
       protected ILazyLoadTask _lazyLoadTask;
       protected IExecutionContext _executionContext;
+      protected IInteractiveSimulationRunner _interactiveSimulationRunner;
+      protected IEventPublisher _eventPublisher;
 
       protected override Task Context()
       {
@@ -30,7 +33,9 @@ namespace PKSim.Core
          _simulationRunner = A.Fake<ISimulationRunner>();
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _executionContext = A.Fake<IExecutionContext>();
-         sut = new InteractiveSimulationRunner(_simulationSettingsRetriever, _simulationRunner, _cloner, _simulationAnalysisCreator, _lazyLoadTask, _executionContext);
+         _interactiveSimulationRunner = A.Fake<IInteractiveSimulationRunner>();
+         _eventPublisher = A.Fake<IEventPublisher>();
+         sut = new InteractiveSimulationRunner(_simulationSettingsRetriever, _simulationRunner, _cloner, _simulationAnalysisCreator, _lazyLoadTask, _executionContext, _eventPublisher);
          return _completed;
       }
    }

--- a/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/Core/InteractiveSimulationRunnerSpecs.cs
@@ -8,6 +8,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
 using OSPSuite.Utility.Events;
 using PKSim.Core.Chart;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using SimulationRunOptions = PKSim.Core.Services.SimulationRunOptions;
@@ -23,7 +24,6 @@ namespace PKSim.Core
       protected ILazyLoadTask _lazyLoadTask;
       protected IExecutionContext _executionContext;
       protected IInteractiveSimulationRunner _interactiveSimulationRunner;
-      protected IEventPublisher _eventPublisher;
 
       protected override Task Context()
       {
@@ -34,8 +34,7 @@ namespace PKSim.Core
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _executionContext = A.Fake<IExecutionContext>();
          _interactiveSimulationRunner = A.Fake<IInteractiveSimulationRunner>();
-         _eventPublisher = A.Fake<IEventPublisher>();
-         sut = new InteractiveSimulationRunner(_simulationSettingsRetriever, _simulationRunner, _cloner, _simulationAnalysisCreator, _lazyLoadTask, _executionContext, _eventPublisher);
+         sut = new InteractiveSimulationRunner(_simulationSettingsRetriever, _simulationRunner, _cloner, _simulationAnalysisCreator, _lazyLoadTask, _executionContext);
          return _completed;
       }
    }
@@ -62,6 +61,13 @@ namespace PKSim.Core
       protected override Task Because()
       {
          return sut.RunSimulation(_simulation, true);
+      }
+
+      [Observation]
+      public void should_notify_the_simulation_started_and_finishing_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationRunStartedEvent>._)).MustHaveHappened();
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationRunFinishedEvent>._)).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -93,13 +93,6 @@ namespace PKSim.Core
       {
          A.CallTo(() => _populationSimulationAnalysisSynchronizer.UpdateAnalysesDefinedIn(_populationSimulation)).MustHaveHappened();
       }
-
-      [Observation]
-      public void should_raise_events_for_simulation_start_and_end()
-      {
-         A.CallTo(() => _eventPublisher.PublishEvent(A<SimulationRunStartedEvent>._)).MustHaveHappened();
-         A.CallTo(() => _eventPublisher.PublishEvent(A<SimulationRunFinishedEvent>._)).MustHaveHappened();
-      }
    }
 
    public class When_the_simulation_run_options_indicate_the_events_should_not_be_raised : concern_for_PopulationSimulationEngine

--- a/tests/PKSim.Tests/Presentation/StatusBarPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/StatusBarPresenterSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
+using PKSim.Core.Services;
 
 namespace PKSim.Presentation
 {
@@ -14,12 +15,15 @@ namespace PKSim.Presentation
       private IStatusBarView _statusBarView;
       private IApplicationConfiguration _applicationConfiguration;
       private IEventPublisher _eventPublisher;
+      private IInteractiveSimulationRunner _interactiveSimulationRunner;
+
       protected override void Context()
       {
          _eventPublisher = A.Fake<IEventPublisher>();
          _statusBarView = A.Fake<IStatusBarView>();
          _applicationConfiguration = A.Fake<IApplicationConfiguration>();
-         sut = new StatusBarPresenter(_statusBarView, _applicationConfiguration, _eventPublisher);
+         _interactiveSimulationRunner = A.Fake<IInteractiveSimulationRunner>();
+         sut = new StatusBarPresenter(_statusBarView, _applicationConfiguration, _eventPublisher, _interactiveSimulationRunner);
       }
 
       protected override void Because()


### PR DESCRIPTION
Fixes #3249

# Description

Centralize all the infromation for running simulations on just one class.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [x] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):