### PR TITLE
Fixes #3274 Move pksim R dependency generation to nightly build

### DIFF
--- a/.github/workflows/build-and-test_12.2.yml
+++ b/.github/workflows/build-and-test_12.2.yml
@@ -9,7 +9,6 @@ env:
   MAJOR: 12
   MINOR: 2
   RUN: ${{ github.run_number }}
-  TARGET_FRAMEWORK: net8
 
 jobs:
 
@@ -32,21 +31,8 @@ jobs:
       - name: Test
         run: dotnet test .\tests\**\bin\Debug\net472\PKSim*Tests.dll -v normal --no-build  --logger:"html;LogFileName=../testLog_Windows.html"
 
-      - name: Create R dependency artifact
-        run: |
-          pushd .
-          cd src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}
-          7z.exe a pk-sim-r-dependencies.zip -x@"excludedFiles.txt" * -xr!runtimes
-          popd
-
       - name: Push test log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: testLog_Windows
           path: ./testLog*.html
-
-      - name: Push R dependencies as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: PKSim R Dependencies
-          path: src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}\pk-sim-r-dependencies.zip

--- a/.github/workflows/build-nightly_12.2.yml
+++ b/.github/workflows/build-nightly_12.2.yml
@@ -10,6 +10,7 @@ env:
   MAJOR: 12
   MINOR: 2
   RUN: ${{ github.run_number }}
+  TARGET_FRAMEWORK: net8
 
 jobs:
   get-latest-commit-timespan:
@@ -87,6 +88,13 @@ jobs:
           rake "create_setup[${{env.APP_VERSION}}, Debug]"
           rake "create_portable_setup[${{env.APP_VERSION}}, Debug, pk-sim-portable-setup.zip]"
 
+      - name: Create R dependency artifact
+        run: |
+          pushd .
+          cd src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}
+          7z.exe a pk-sim-r-dependencies.zip -x@"excludedFiles.txt" * -xr!runtimes
+          popd
+
 #      - name: Sign PKSim setup with CodeSignTool
 #        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
 #        with:
@@ -109,6 +117,12 @@ jobs:
         with:
           name: PKSim Portable ${{env.APP_VERSION}}
           path: setup\PK-Sim ${{env.APP_VERSION}}
+
+      - name: Push R dependencies as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PKSim R Dependencies
+          path: src\PKSimRDependencyResolution\bin\Debug\${{env.TARGET_FRAMEWORK}}\pk-sim-r-dependencies.zip
 
   cleanup-job:
     needs: get-latest-commit-timespan


### PR DESCRIPTION
Fixes #3274

# Description
R dependencies should be produced with nightly builds so they can be released with the same binaries as the release build of PK-Sim and OSPSuite.Core.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [x] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):