### PR TITLE
3272-unnecessary-project-has-changed-save-changes-prompt

### DIFF
--- a/src/PKSim.Core/Helpers/ProjectChangedHelper.cs
+++ b/src/PKSim.Core/Helpers/ProjectChangedHelper.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Services;
 
 namespace PKSim.Core.Helpers
 {
    public static class ProjectChangedHelper
    {
-      public static IDisposable Scope(IProjectRetriever projectRetriever)
-         => new ScopeGuard(projectRetriever?.CurrentProject ?? throw new ArgumentNullException(nameof(projectRetriever)));
+      public static IDisposable Scope(IProject project)
+         => new ScopeGuard(project);
 
       private sealed class ScopeGuard : IDisposable
       {
@@ -17,7 +16,7 @@ namespace PKSim.Core.Helpers
 
          public ScopeGuard(IProject project)
          {
-            _project = project ?? throw new ArgumentNullException(nameof(project));
+            _project = project;
             _original = _project.HasChanged;
          }
 

--- a/src/PKSim.Core/Helpers/ProjectChangedHelper.cs
+++ b/src/PKSim.Core/Helpers/ProjectChangedHelper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+
+namespace PKSim.Core.Helpers
+{
+   public static class ProjectChangedHelper
+   {
+      public static IDisposable Scope(IProjectRetriever projectRetriever)
+         => new ScopeGuard(projectRetriever?.CurrentProject ?? throw new ArgumentNullException(nameof(projectRetriever)));
+
+      private sealed class ScopeGuard : IDisposable
+      {
+         private readonly IProject _project;
+         private readonly bool _original;
+         private bool _disposed;
+
+         public ScopeGuard(IProject project)
+         {
+            _project = project ?? throw new ArgumentNullException(nameof(project));
+            _original = _project.HasChanged;
+         }
+
+         public void Dispose()
+         {
+            if (_disposed) return;
+            _project.HasChanged = _original;
+            _disposed = true;
+         }
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
@@ -17,6 +17,7 @@ using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
+using PKSim.Core;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -39,8 +40,8 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
 
       public BuildingBlockExplorerPresenter(IBuildingBlockExplorerView view, ITreeNodeFactory treeNodeFactory, ITreeNodeContextMenuFactory treeNodeContextMenuFactory, IMultipleTreeNodeContextMenuFactory multipleTreeNodeContextMenuFactory, IBuildingBlockIconRetriever buildingBlockIconRetriever,
-         IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, IToolTipPartCreator toolTipPartCreator, IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IObservedDataInExplorerPresenter observedDataInExplorerPresenter)
-         : base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver, buildingBlockTask, RegionNames.BuildingBlockExplorer, projectRetriever, classificationPresenter, toolTipPartCreator)
+         IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, IToolTipPartCreator toolTipPartCreator, IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IObservedDataInExplorerPresenter observedDataInExplorerPresenter, IExecutionContext executionContext)
+         : base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver, buildingBlockTask, RegionNames.BuildingBlockExplorer, projectRetriever, classificationPresenter, toolTipPartCreator, executionContext)
       {
          _observedDataInExplorerPresenter = observedDataInExplorerPresenter;
          _observedDataInExplorerPresenter.InitializeWith(this, classificationPresenter, RootNodeTypes.ObservedDataFolder);

--- a/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
@@ -40,8 +40,8 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
 
       public BuildingBlockExplorerPresenter(IBuildingBlockExplorerView view, ITreeNodeFactory treeNodeFactory, ITreeNodeContextMenuFactory treeNodeContextMenuFactory, IMultipleTreeNodeContextMenuFactory multipleTreeNodeContextMenuFactory, IBuildingBlockIconRetriever buildingBlockIconRetriever,
-         IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, IToolTipPartCreator toolTipPartCreator, IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IObservedDataInExplorerPresenter observedDataInExplorerPresenter, IExecutionContext executionContext)
-         : base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver, buildingBlockTask, RegionNames.BuildingBlockExplorer, projectRetriever, classificationPresenter, toolTipPartCreator, executionContext)
+         IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, IToolTipPartCreator toolTipPartCreator, IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IObservedDataInExplorerPresenter observedDataInExplorerPresenter)
+         : base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver, buildingBlockTask, RegionNames.BuildingBlockExplorer, projectRetriever, classificationPresenter, toolTipPartCreator)
       {
          _observedDataInExplorerPresenter = observedDataInExplorerPresenter;
          _observedDataInExplorerPresenter.InitializeWith(this, classificationPresenter, RootNodeTypes.ObservedDataFolder);

--- a/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
@@ -97,7 +97,7 @@ namespace PKSim.Presentation.Presenters.Main
 
       protected void EditBuildingBlock(IPKSimBuildingBlock buildingBlock)
       {
-         using (ProjectChangedHelper.Scope(_projectRetriever))
+         using (ProjectChangedHelper.Scope(_projectRetriever.CurrentProject))
          {
             _buildingBlockTask.Edit(buildingBlock);
          }

--- a/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
@@ -10,6 +10,7 @@ using OSPSuite.Presentation.Regions;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
+using PKSim.Core;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -34,11 +35,11 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
       protected readonly IBuildingBlockIconRetriever _buildingBlockIconRetriever;
       protected readonly IBuildingBlockTask _buildingBlockTask;
-
+      protected readonly IExecutionContext _executionContext;
       protected ExplorerPresenter(TView view, ITreeNodeFactory treeNodeFactory, ITreeNodeContextMenuFactory treeNodeContextMenuFactory,
          IMultipleTreeNodeContextMenuFactory multipleTreeNodeContextMenuFactory,
          IBuildingBlockIconRetriever buildingBlockIconRetriever, IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, RegionName regionName,
-         IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IToolTipPartCreator toolTipPartCreator) :
+         IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IToolTipPartCreator toolTipPartCreator, IExecutionContext executionContext) :
          base(view, regionResolver, classificationPresenter, toolTipPartCreator, regionName, projectRetriever)
       {
          _treeNodeFactory = treeNodeFactory;
@@ -46,6 +47,7 @@ namespace PKSim.Presentation.Presenters.Main
          _multipleTreeNodeContextMenuFactory = multipleTreeNodeContextMenuFactory;
          _buildingBlockIconRetriever = buildingBlockIconRetriever;
          _buildingBlockTask = buildingBlockTask;
+         _executionContext = executionContext;
       }
 
       protected abstract ITreeNode AddBuildingBlockToTree(IPKSimBuildingBlock buildingBlock);
@@ -96,7 +98,9 @@ namespace PKSim.Presentation.Presenters.Main
 
       protected void EditBuildingBlock(IPKSimBuildingBlock buildingBlock)
       {
+         var hasChanges = _executionContext.CurrentProject.HasChanged;
          _buildingBlockTask.Edit(buildingBlock);
+         _executionContext.CurrentProject.HasChanged = hasChanges;
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/ExplorerPresenter.cs
@@ -10,8 +10,8 @@ using OSPSuite.Presentation.Regions;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
-using PKSim.Core;
 using PKSim.Core.Events;
+using PKSim.Core.Helpers;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.Services;
@@ -35,11 +35,11 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
       protected readonly IBuildingBlockIconRetriever _buildingBlockIconRetriever;
       protected readonly IBuildingBlockTask _buildingBlockTask;
-      protected readonly IExecutionContext _executionContext;
+
       protected ExplorerPresenter(TView view, ITreeNodeFactory treeNodeFactory, ITreeNodeContextMenuFactory treeNodeContextMenuFactory,
          IMultipleTreeNodeContextMenuFactory multipleTreeNodeContextMenuFactory,
          IBuildingBlockIconRetriever buildingBlockIconRetriever, IRegionResolver regionResolver, IBuildingBlockTask buildingBlockTask, RegionName regionName,
-         IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IToolTipPartCreator toolTipPartCreator, IExecutionContext executionContext) :
+         IProjectRetriever projectRetriever, IClassificationPresenter classificationPresenter, IToolTipPartCreator toolTipPartCreator) :
          base(view, regionResolver, classificationPresenter, toolTipPartCreator, regionName, projectRetriever)
       {
          _treeNodeFactory = treeNodeFactory;
@@ -47,7 +47,6 @@ namespace PKSim.Presentation.Presenters.Main
          _multipleTreeNodeContextMenuFactory = multipleTreeNodeContextMenuFactory;
          _buildingBlockIconRetriever = buildingBlockIconRetriever;
          _buildingBlockTask = buildingBlockTask;
-         _executionContext = executionContext;
       }
 
       protected abstract ITreeNode AddBuildingBlockToTree(IPKSimBuildingBlock buildingBlock);
@@ -98,9 +97,10 @@ namespace PKSim.Presentation.Presenters.Main
 
       protected void EditBuildingBlock(IPKSimBuildingBlock buildingBlock)
       {
-         var hasChanges = _executionContext.CurrentProject.HasChanged;
-         _buildingBlockTask.Edit(buildingBlock);
-         _executionContext.CurrentProject.HasChanged = hasChanges;
+         using (ProjectChangedHelper.Scope(_projectRetriever))
+         {
+            _buildingBlockTask.Edit(buildingBlock);
+         }
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/Main/SimulationExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/SimulationExplorerPresenter.cs
@@ -71,7 +71,7 @@ namespace PKSim.Presentation.Presenters.Main
          IMenuBarItemRepository menuBarItemRepository
          ) :
          base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver,
-            buildingBlockTask, RegionNames.SimulationExplorer, projectRetriever, classificationPresenter, toolTipPartCreator, executionContext)
+            buildingBlockTask, RegionNames.SimulationExplorer, projectRetriever, classificationPresenter, toolTipPartCreator)
       {
          _buildingBlockInProjectManager = buildingBlockInProjectManager;
          _parameterAnalysablesInExplorerPresenter = parameterAnalysablesInExplorerPresenter;

--- a/src/PKSim.Presentation/Presenters/Main/SimulationExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/SimulationExplorerPresenter.cs
@@ -68,9 +68,10 @@ namespace PKSim.Presentation.Presenters.Main
          IObservedDataInSimulationManager observedDataInSimulationManager,
          ISimulationComparisonTask simulationComparisonTask,
          IExecutionContext executionContext,
-         IMenuBarItemRepository menuBarItemRepository) :
+         IMenuBarItemRepository menuBarItemRepository
+         ) :
          base(view, treeNodeFactory, treeNodeContextMenuFactory, multipleTreeNodeContextMenuFactory, buildingBlockIconRetriever, regionResolver,
-            buildingBlockTask, RegionNames.SimulationExplorer, projectRetriever, classificationPresenter, toolTipPartCreator)
+            buildingBlockTask, RegionNames.SimulationExplorer, projectRetriever, classificationPresenter, toolTipPartCreator, executionContext)
       {
          _buildingBlockInProjectManager = buildingBlockInProjectManager;
          _parameterAnalysablesInExplorerPresenter = parameterAnalysablesInExplorerPresenter;

--- a/src/PKSim.Presentation/Services/ProjectTask.cs
+++ b/src/PKSim.Presentation/Services/ProjectTask.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
@@ -334,7 +333,7 @@ namespace PKSim.Presentation.Services
             // which is not loaded but AFTER the deserialization.
             // Ideally this should go down in the callstack, but we are getting a circular dependency issue.
             _workspace.Project.All<Individual>().Each(_lazyLoadTask.Load);
-            _executionContext.CurrentProject.HasChanged = false;
+            _workspace.Project.HasChanged = false;
          }
 
          try

--- a/src/PKSim.Presentation/Services/ProjectTask.cs
+++ b/src/PKSim.Presentation/Services/ProjectTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
@@ -329,11 +330,11 @@ namespace PKSim.Presentation.Services
          void openProject()
          {
             _workspace.OpenProject(projectFile);
-
             // Since the individuals are lazy loaded, and the deserialization is relying on the context.CurrentProject
             // which is not loaded but AFTER the deserialization.
             // Ideally this should go down in the callstack, but we are getting a circular dependency issue.
             _workspace.Project.All<Individual>().Each(_lazyLoadTask.Load);
+            _executionContext.CurrentProject.HasChanged = false;
          }
 
          try

--- a/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
@@ -14,6 +14,7 @@ using OSPSuite.Presentation.Regions;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Extensions;
+using PKSim.Core;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -54,6 +55,7 @@ namespace PKSim.Presentation
       protected IClassificationPresenter _classificationPresenter;
       private IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
       private IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
+      private IExecutionContext _executionContext;
 
       protected override void Context()
       {
@@ -77,8 +79,9 @@ namespace PKSim.Presentation
          _projectRetriever = A.Fake<IProjectRetriever>();
          _classificationPresenter = A.Fake<IClassificationPresenter>();
          _multipleTreeNodeContextMenuFactory = A.Fake<IMultipleTreeNodeContextMenuFactory>();
+         _executionContext = A.Fake<IExecutionContext>();
          sut = new BuildingBlockExplorerPresenter(_view, _treeNodeFactory, _contextMenuFactory, _multipleTreeNodeContextMenuFactory, _buildingBlockIconRetriever, _regionResolver,
-            _buildingBlockTask, _toolTipCreator, _projectRetriever, _classificationPresenter, _observedDataInExplorerPresenter);
+            _buildingBlockTask, _toolTipCreator, _projectRetriever, _classificationPresenter, _observedDataInExplorerPresenter, _executionContext);
 
          _compoundFolderNode = new RootNode(PKSimRootNodeTypes.CompoundFolder);
          _individualFolderNode = new RootNode(PKSimRootNodeTypes.IndividualFolder);

--- a/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
@@ -55,7 +55,6 @@ namespace PKSim.Presentation
       protected IClassificationPresenter _classificationPresenter;
       private IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
       private IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
-      private IExecutionContext _executionContext;
 
       protected override void Context()
       {
@@ -79,7 +78,6 @@ namespace PKSim.Presentation
          _projectRetriever = A.Fake<IProjectRetriever>();
          _classificationPresenter = A.Fake<IClassificationPresenter>();
          _multipleTreeNodeContextMenuFactory = A.Fake<IMultipleTreeNodeContextMenuFactory>();
-         _executionContext = A.Fake<IExecutionContext>();
          sut = new BuildingBlockExplorerPresenter(_view, _treeNodeFactory, _contextMenuFactory, _multipleTreeNodeContextMenuFactory, _buildingBlockIconRetriever, _regionResolver,
             _buildingBlockTask, _toolTipCreator, _projectRetriever, _classificationPresenter, _observedDataInExplorerPresenter);
 

--- a/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
@@ -81,7 +81,7 @@ namespace PKSim.Presentation
          _multipleTreeNodeContextMenuFactory = A.Fake<IMultipleTreeNodeContextMenuFactory>();
          _executionContext = A.Fake<IExecutionContext>();
          sut = new BuildingBlockExplorerPresenter(_view, _treeNodeFactory, _contextMenuFactory, _multipleTreeNodeContextMenuFactory, _buildingBlockIconRetriever, _regionResolver,
-            _buildingBlockTask, _toolTipCreator, _projectRetriever, _classificationPresenter, _observedDataInExplorerPresenter, _executionContext);
+            _buildingBlockTask, _toolTipCreator, _projectRetriever, _classificationPresenter, _observedDataInExplorerPresenter);
 
          _compoundFolderNode = new RootNode(PKSimRootNodeTypes.CompoundFolder);
          _individualFolderNode = new RootNode(PKSimRootNodeTypes.IndividualFolder);


### PR DESCRIPTION
Fixes #3272

# Description

No changes should be set to the HasChanged variable when either opening a project or a simulation from the project.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):