### PR TITLE
#874 Parameter identification running error on close project

### DIFF
--- a/src/PKSim.Presentation/Services/ProjectTask.cs
+++ b/src/PKSim.Presentation/Services/ProjectTask.cs
@@ -6,6 +6,7 @@ using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Core.Journal;
 using OSPSuite.Core.Services;
@@ -50,6 +51,7 @@ namespace PKSim.Presentation.Services
       private readonly ISnapshotTask _snapshotTask;
       private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
       private readonly ILazyLoadTask _lazyLoadTask;
+      private readonly IParameterIdentificationRunner _parameterIdentificationRunner;
 
       public ProjectTask(IWorkspace workspace,
          IApplicationController applicationController,
@@ -62,7 +64,8 @@ namespace PKSim.Presentation.Services
          IJournalRetriever journalRetriever,
          ISnapshotTask snapshotTask,
          IBuildingBlockInProjectManager buildingBlockInProjectManager,
-         ILazyLoadTask lazyLoadTask
+         ILazyLoadTask lazyLoadTask,
+         IParameterIdentificationRunner parameterIdentificationRunner
       )
       {
          _workspace = workspace;
@@ -77,6 +80,7 @@ namespace PKSim.Presentation.Services
          _snapshotTask = snapshotTask;
          _buildingBlockInProjectManager = buildingBlockInProjectManager;
          _lazyLoadTask = lazyLoadTask;
+         _parameterIdentificationRunner = parameterIdentificationRunner;
       }
 
       public void NewProject()
@@ -108,6 +112,12 @@ namespace PKSim.Presentation.Services
 
       private bool shouldCloseProject()
       {
+         if (_parameterIdentificationRunner.IsRunning)
+         {
+            showRunningParameterIdentificationWarnings();
+            return false;
+         }
+
          if (!_workspace.ProjectHasChanged) return true;
 
          var viewResult = _dialogCreator.MessageBoxYesNoCancel(PKSimConstants.UI.SaveProjectChanges);
@@ -120,6 +130,12 @@ namespace PKSim.Presentation.Services
             default:
                return true;
          }
+      }
+
+      private void showRunningParameterIdentificationWarnings()
+      {
+         var parameterIdentifications = _parameterIdentificationRunner.RunningParameterIdentifications.ToList();
+         _dialogCreator.MessageBoxInfo(Captions.ParameterIdentification.ParameterIdentificationsAreRunning(parameterIdentifications.AllNames()));
       }
 
       public bool SaveCurrentProject()

--- a/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
@@ -1152,7 +1152,6 @@ namespace PKSim.Presentation
       }
    }
 
-
    public class When_asked_to_close_a_project_that_has_parameter_identifications_running : concern_for_ProjectTask
    {
       private string _message;

--- a/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.ParameterIdentifications;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Journal;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
@@ -42,6 +45,7 @@ namespace PKSim.Presentation
       protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
       protected Simulation _simulation;
       protected ILazyLoadTask _lazyLoadTask;
+      protected IParameterIdentificationRunner _parameterIdentificationRunner;
 
       public override Task GlobalContext()
       {
@@ -61,12 +65,12 @@ namespace PKSim.Presentation
          _heavyWorkManager = new HeavyWorkManagerForSpecs();
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _simulation = new IndividualSimulation();
-
+         _parameterIdentificationRunner = A.Fake<IParameterIdentificationRunner>();
          _project.AddBuildingBlock(_simulation);
 
          sut = new ProjectTask(_workspace, _applicationController, _dialogCreator,
             _executionContext, _heavyWorkManager, _workspaceLayoutUpdater, _userSettings,
-            _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask);
+            _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask, _parameterIdentificationRunner);
 
          _oldFileExitst = FileHelper.FileExists;
 
@@ -272,7 +276,7 @@ namespace PKSim.Presentation
       protected override Task Context()
       {
          sut = new ProjectTask(_workspace, _applicationController, _dialogCreator,
-            _executionContext, new HeavyWorkManagerFailingForSpecs(), _workspaceLayoutUpdater, _userSettings, _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask);
+            _executionContext, new HeavyWorkManagerFailingForSpecs(), _workspaceLayoutUpdater, _userSettings, _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask, _parameterIdentificationRunner);
 
          A.CallTo(() => _workspace.ProjectHasChanged).Returns(true);
          _project.FilePath = FileHelper.GenerateTemporaryFileName();
@@ -626,7 +630,7 @@ namespace PKSim.Presentation
       protected override Task Context()
       {
          sut = new ProjectTask(_workspace, _applicationController, _dialogCreator,
-            _executionContext, new HeavyWorkManagerFailingForSpecs(), _workspaceLayoutUpdater, _userSettings, _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask);
+            _executionContext, new HeavyWorkManagerFailingForSpecs(), _workspaceLayoutUpdater, _userSettings, _journalTask, _journalRetriever, _snapshotTask, _buildingBlockInProjectManager, _lazyLoadTask, _parameterIdentificationRunner);
 
          A.CallTo(() => _workspace.ProjectHasChanged).Returns(true);
          _project.FilePath = FileHelper.GenerateTemporaryFileName();
@@ -1145,6 +1149,45 @@ namespace PKSim.Presentation
       public void should_overwrite_the_current_project()
       {
          A.CallTo(() => _workspace.LoadProject(_newProject)).MustHaveHappened();
+      }
+   }
+
+
+   public class When_asked_to_close_a_project_that_has_parameter_identifications_running : concern_for_ProjectTask
+   {
+      private string _message;
+      private readonly string _parameterIdentificationName = "PI 1";
+      protected override Task Context()
+      {
+         var parameterIdentification = new ParameterIdentification();
+         parameterIdentification.Name = _parameterIdentificationName;
+         var lstParameterIdentificationsRunning = new List<ParameterIdentification> { parameterIdentification };
+         _project.HasChanged = false;
+         A.CallTo(() => _parameterIdentificationRunner.IsRunning).Returns(true);
+         A.CallTo(() => _parameterIdentificationRunner.RunningParameterIdentifications)
+            .Returns(lstParameterIdentificationsRunning);
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._))
+            .Invokes(x => _message = x.GetArgument<string>(0));
+
+         return _completed;
+      }
+
+      protected override Task Because()
+      {
+         sut.CloseCurrentProject();
+         return _completed;
+      }
+
+      [Observation]
+      public void should_display_a_warning_to_the_user_with_the_name_of_the_running_parameter_identification()
+      {
+         _message.Contains(_parameterIdentificationName).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_call_confirmation_dialog()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNoCancel(PKSimConstants.UI.SaveProjectChanges, ViewResult.Yes)).MustNotHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #874 

# Description

When parameter identification is running, the attemp to close the current project or main window should not be allowed until it is stopped or finished.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):