### PR TITLE
Remove delivery of Intel Mac native assemblies

### DIFF
--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -18,15 +18,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.FuncParser.MacOS.x64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.R" Version="12.2.17" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel.MacOS.x64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES.Ubuntu22" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES.MacOSArm64" Version="4.1.0.19" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES.MacOSx64" Version="4.1.0.19" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(PkgOSPSuite_FuncParser_Ubuntu22)\OSPSuite.FuncParserNative\bin\native\x64\Release\libOSPSuite.FuncParserNative.so" Link="libOSPSuite.FuncParserNative.so">
@@ -37,17 +34,6 @@
     </Content>
     <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES_Ubuntu22)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\libOSPSuite.SimModelSolver_CVODES.so" Link="libOSPSuite.SimModelSolver_CVODES.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="$(PkgOSPSuite_FuncParser_MacOS_x64)\OSPSuite.FuncParserNative\bin\native\x64\Release\libOSPSuite.FuncParserNative.dylib" Link="libOSPSuite.FuncParserNative.x64.dylib">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModel_MacOS_x64)\OSPSuite.SimModelNative\bin\native\x64\Release\libOSPSuite.SimModelNative.dylib" Link="libOSPSuite.SimModelNative.x64.dylib">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES_MacOSx64)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\libOSPSuite.SimModelSolver_CVODES.dylib" Link="libOSPSuite.SimModelSolver_CVODES.x64.dylib">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #3305

# Description
The GitHub runner that we use to produce the binaries will be disappearing in December. At the same time, delivering only one set of binaries for the platform eliminates the load-time native file swapping that we are doing.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe): task

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [x] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):