### PR TITLE
Fixes #3313 Reference concentration units are not updated in invidual after reset

### DIFF
--- a/src/PKSim.Core/Commands/ResetExpressionParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetExpressionParameterCommand.cs
@@ -1,3 +1,4 @@
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -19,5 +20,10 @@ public class ResetExpressionParameterCommand : ResetParameterCommand
 
       var updateTask = context.Resolve<IExpressionProfileUpdater>();
       updateTask.SynchronizeAllSimulationSubjectsWithExpressionProfile(expressionProfile);
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+   {
+      return new SetExpressionProfileValueCommand(_parameter, _oldValue).AsInverseFor(this);
    }
 }

--- a/src/PKSim.Core/Commands/ResetExpressionParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetExpressionParameterCommand.cs
@@ -1,0 +1,23 @@
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+
+namespace PKSim.Core.Commands;
+
+public class ResetExpressionParameterCommand : ResetParameterCommand
+{
+   public ResetExpressionParameterCommand(IParameter parameter) : base(parameter)
+   {
+   }
+
+   protected override void UpdateDependenciesOnParameter(IParameter parameter, IExecutionContext context)
+   {
+      base.UpdateDependenciesOnParameter(parameter, context);
+
+      if (context.BuildingBlockContaining(parameter) is not ExpressionProfile expressionProfile)
+         return;
+
+      var updateTask = context.Resolve<IExpressionProfileUpdater>();
+      updateTask.SynchronizeAllSimulationSubjectsWithExpressionProfile(expressionProfile);
+   }
+}

--- a/src/PKSim.Core/Commands/ResetParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetParameterCommand.cs
@@ -2,6 +2,7 @@ using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
+using PKSim.Core.Services;
 
 namespace PKSim.Core.Commands
 {
@@ -27,6 +28,17 @@ namespace PKSim.Core.Commands
          resetValueOriginForDefaultParameter(parameter, context);
       }
 
+      protected override void UpdateDependenciesOnParameter(IParameter parameter, IExecutionContext context)
+      {
+         base.UpdateDependenciesOnParameter(parameter, context);
+
+         if (context.BuildingBlockContaining(parameter) is not ExpressionProfile expressionProfile) 
+            return;
+         
+         var updateTask = context.Resolve<IExpressionProfileUpdater>();
+         updateTask.SynchronizeAllSimulationSubjectsWithExpressionProfile(expressionProfile);
+      }
+
       private void resetValueOriginForDefaultParameter(IParameter parameter, IExecutionContext context)
       {
          var valueOriginRepository = context.Resolve<IValueOriginRepository>();
@@ -34,7 +46,7 @@ namespace PKSim.Core.Commands
          var valueOrigin = valueOriginRepository.ValueOriginFor(parameter);
          parameter.UpdateValueOriginFrom(valueOrigin);
 
-         //reset only available for trully default parameter with a default value
+         //reset only available for truly default parameter with a default value
          parameter.IsDefault = true;
       }
 

--- a/src/PKSim.Core/Commands/ResetParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetParameterCommand.cs
@@ -2,7 +2,6 @@ using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
-using PKSim.Core.Services;
 
 namespace PKSim.Core.Commands
 {
@@ -28,16 +27,7 @@ namespace PKSim.Core.Commands
          resetValueOriginForDefaultParameter(parameter, context);
       }
 
-      protected override void UpdateDependenciesOnParameter(IParameter parameter, IExecutionContext context)
-      {
-         base.UpdateDependenciesOnParameter(parameter, context);
 
-         if (context.BuildingBlockContaining(parameter) is not ExpressionProfile expressionProfile) 
-            return;
-         
-         var updateTask = context.Resolve<IExpressionProfileUpdater>();
-         updateTask.SynchronizeAllSimulationSubjectsWithExpressionProfile(expressionProfile);
-      }
 
       private void resetValueOriginForDefaultParameter(IParameter parameter, IExecutionContext context)
       {

--- a/src/PKSim.Core/Commands/ResetParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetParameterCommand.cs
@@ -27,8 +27,6 @@ namespace PKSim.Core.Commands
          resetValueOriginForDefaultParameter(parameter, context);
       }
 
-
-
       private void resetValueOriginForDefaultParameter(IParameter parameter, IExecutionContext context)
       {
          var valueOriginRepository = context.Resolve<IValueOriginRepository>();

--- a/src/PKSim.Core/Commands/ResetParameterCommand.cs
+++ b/src/PKSim.Core/Commands/ResetParameterCommand.cs
@@ -7,7 +7,7 @@ namespace PKSim.Core.Commands
 {
    public class ResetParameterCommand : EditParameterCommand
    {
-      private double _oldValue;
+      protected double _oldValue;
 
       public ResetParameterCommand(IParameter parameter) : base(parameter)
       {

--- a/src/PKSim.Core/Services/ParameterTask.cs
+++ b/src/PKSim.Core/Services/ParameterTask.cs
@@ -403,6 +403,9 @@ namespace PKSim.Core.Services
 
       public ICommand ResetParameter(IParameter parameter)
       {
+         if (parameter.IsExpressionProfile())
+            return new ResetExpressionParameterCommand(parameter).Run(_executionContext);
+
          return new ResetParameterCommand(parameter).Run(_executionContext);
       }
 

--- a/src/PKSim.Presentation/Services/EditParameterPresenterTask.cs
+++ b/src/PKSim.Presentation/Services/EditParameterPresenterTask.cs
@@ -3,7 +3,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.DTO;
-using OSPSuite.Presentation.Presenters.Parameters;
 using PKSim.Core.Services;
 using PKSim.Presentation.Presenters.Parameters;
 

--- a/tests/PKSim.Tests/Core/ParameterTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterTaskSpecs.cs
@@ -444,7 +444,53 @@ namespace PKSim.Core
          _result.ShouldBeAnInstanceOf<SetParameterUnitStructureChangeCommand>();
       }
    }
+
+   public class When_asked_to_reset_an_expression_parameter_to_its_original_value : concern_for_ParameterTask
+   {
+      private ICommand _result;
+      private IParameter _para1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _para1 = DomainHelperForSpecs.ConstantParameterWithValue(1).WithName(CoreConstants.Parameters.INITIAL_CONCENTRATION);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.ResetParameter(_para1);
+      }
+
+      [Observation]
+      public void should_return_the_underlying_command_used_to_reset_the_parameters()
+      {
+         _result.ShouldBeAnInstanceOf<ResetExpressionParameterCommand>();
+      }
+   }
    
+   public class When_asked_to_reset_a_parameter_to_its_original_value : concern_for_ParameterTask
+   {
+      private ICommand _result;
+      private IParameter _para1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _para1 = DomainHelperForSpecs.ConstantParameterWithValue(1).WithName("para1");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.ResetParameter(_para1);
+      }
+
+      [Observation]
+      public void should_return_the_underlying_command_used_to_reset_the_parameters()
+      {
+         _result.ShouldBeAnInstanceOf<ResetParameterCommand>();
+      }
+   }
+
    public class When_asked_to_reset_a_set_of_parameters_to_their_original_values : concern_for_ParameterTask
    {
       private ICommand _result;

--- a/tests/PKSim.Tests/Core/ResetExpressionParameterCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/ResetExpressionParameterCommandSpecs.cs
@@ -85,7 +85,7 @@ namespace PKSim.Core
       }
    }
 
-   public class When_executing_the_reset_command_for_a_default__expression_parameter : concern_for_ResetExpressionParameterCommand
+   public class When_executing_the_reset_command_for_a_default_expression_parameter : concern_for_ResetExpressionParameterCommand
    {
       private ValueOrigin _databaseValueOrigin;
       private ExpressionProfile _expressionProfile;

--- a/tests/PKSim.Tests/Core/ResetExpressionParameterCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/ResetExpressionParameterCommandSpecs.cs
@@ -1,4 +1,4 @@
-using FakeItEasy;
+﻿using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -11,7 +11,7 @@ using PKSim.Core.Services;
 
 namespace PKSim.Core
 {
-   public abstract class concern_for_ResetParameterCommand : ContextSpecification<ResetParameterCommand>
+   public abstract class concern_for_ResetExpressionParameterCommand : ContextSpecification<ResetExpressionParameterCommand>
    {
       protected IParameter _parameterToReset;
       protected IExecutionContext _executionContext;
@@ -39,11 +39,11 @@ namespace PKSim.Core
          _parameterInContainerRepository = A.Fake<IValueOriginRepository>();
          A.CallTo(() => _executionContext.Resolve<IValueOriginRepository>()).Returns(_parameterInContainerRepository);
 
-         sut = new ResetParameterCommand(_parameterToReset);
+         sut = new ResetExpressionParameterCommand(_parameterToReset);
       }
    }
 
-   public class When_executing_the_reset_command_for_a_non_default_parameter : concern_for_ResetParameterCommand
+   public class When_executing_the_reset_command_for_a_non_default_expression_parameter : concern_for_ResetExpressionParameterCommand
    {
       protected override void Context()
       {
@@ -85,12 +85,12 @@ namespace PKSim.Core
       }
    }
 
-   public class When_executing_the_reset_command_for_a_default_parameter : concern_for_ResetParameterCommand
+   public class When_executing_the_reset_command_for_a_default__expression_parameter : concern_for_ResetExpressionParameterCommand
    {
       private ValueOrigin _databaseValueOrigin;
       private ExpressionProfile _expressionProfile;
       private IExpressionProfileUpdater _expressionProfileUpdater;
-      
+
       protected override void Context()
       {
          base.Context();
@@ -136,9 +136,15 @@ namespace PKSim.Core
          _parameterToReset.ValueOrigin.Method.ShouldBeEqualTo(ValueOriginDeterminationMethods.InVivo);
          _parameterToReset.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Database);
       }
+
+      [Observation]
+      public void the_expression_update_task_should_be_used_to_synchronize_simulation_subjects()
+      {
+         A.CallTo(() => _expressionProfileUpdater.SynchronizeAllSimulationSubjectsWithExpressionProfile(_expressionProfile)).MustHaveHappened();
+      }
    }
 
-   public class When_executing_the_inverse_command_of_the_reset_parameter_command : concern_for_ResetParameterCommand
+   public class When_executing_the_inverse_command_of_the_reset_expression_parameter_command : concern_for_ResetExpressionParameterCommand
    {
       protected override void Context()
       {

--- a/tests/PKSim.Tests/Core/ResetParameterCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/ResetParameterCommandSpecs.cs
@@ -7,7 +7,6 @@ using OSPSuite.Core.Domain.UnitSystem;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
-using PKSim.Core.Services;
 
 namespace PKSim.Core
 {
@@ -88,8 +87,6 @@ namespace PKSim.Core
    public class When_executing_the_reset_command_for_a_default_parameter : concern_for_ResetParameterCommand
    {
       private ValueOrigin _databaseValueOrigin;
-      private ExpressionProfile _expressionProfile;
-      private IExpressionProfileUpdater _expressionProfileUpdater;
       
       protected override void Context()
       {
@@ -104,12 +101,7 @@ namespace PKSim.Core
             Source = ValueOriginSources.Database
          };
 
-         _expressionProfile = new ExpressionProfile();
-         _expressionProfileUpdater = A.Fake<IExpressionProfileUpdater>();
-
          A.CallTo(() => _parameterInContainerRepository.ValueOriginFor(_parameterToReset)).Returns(_databaseValueOrigin);
-         A.CallTo(() => _executionContext.BuildingBlockContaining(_parameterToReset)).Returns(_expressionProfile);
-         A.CallTo(() => _executionContext.Resolve<IExpressionProfileUpdater>()).Returns(_expressionProfileUpdater);
       }
 
       protected override void Because()

--- a/tests/PKSim.Tests/Core/ResetParameterCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/ResetParameterCommandSpecs.cs
@@ -7,6 +7,7 @@ using OSPSuite.Core.Domain.UnitSystem;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
+using PKSim.Core.Services;
 
 namespace PKSim.Core
 {
@@ -87,7 +88,9 @@ namespace PKSim.Core
    public class When_executing_the_reset_command_for_a_default_parameter : concern_for_ResetParameterCommand
    {
       private ValueOrigin _databaseValueOrigin;
-
+      private ExpressionProfile _expressionProfile;
+      private IExpressionProfileUpdater _expressionProfileUpdater;
+      
       protected override void Context()
       {
          base.Context();
@@ -100,9 +103,13 @@ namespace PKSim.Core
             Method = ValueOriginDeterminationMethods.InVivo,
             Source = ValueOriginSources.Database
          };
-         
+
+         _expressionProfile = new ExpressionProfile();
+         _expressionProfileUpdater = A.Fake<IExpressionProfileUpdater>();
 
          A.CallTo(() => _parameterInContainerRepository.ValueOriginFor(_parameterToReset)).Returns(_databaseValueOrigin);
+         A.CallTo(() => _executionContext.BuildingBlockContaining(_parameterToReset)).Returns(_expressionProfile);
+         A.CallTo(() => _executionContext.Resolve<IExpressionProfileUpdater>()).Returns(_expressionProfileUpdater);
       }
 
       protected override void Because()
@@ -129,6 +136,12 @@ namespace PKSim.Core
          _parameterToReset.ValueOrigin.Method.ShouldBeEqualTo(ValueOriginDeterminationMethods.InVivo);
          _parameterToReset.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Database);
       }
+
+      [Observation]
+      public void the_expression_update_task_should_be_used_to_synchronize_simulation_subjects()
+      {
+         A.CallTo(() => _expressionProfileUpdater.SynchronizeAllSimulationSubjectsWithExpressionProfile(_expressionProfile)).MustHaveHappened();
+      }
    }
 
    public class When_executing_the_inverse_command_of_the_reset_parameter_command : concern_for_ResetParameterCommand
@@ -145,7 +158,7 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_simply_set_the_value_of_the_parameter_again_using_a_set_command()
+      public void should_set_the_value_of_the_parameter_again_using_a_set_command()
       {
          _parameterToReset.Value.ShouldBeEqualTo(25);
          _parameterToReset.IsFixedValue.ShouldBeTrue();


### PR DESCRIPTION
Fixes #3313 

# Description
The reset command does not update simulation subjects when resetting an expression parameter.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):