### PR TITLE
Fixes #3003 Renaming simulation to compound name possible

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -399,6 +399,7 @@ namespace PKSim.Assets
          public const string DescriptionIsRequired = "Description is required.";
          public const string UnknownObserverBuilderType = "Observer builer type unknown.";
          public const string ImporterConfigurationNotFoundInProject = "Importer configuration for this dataset was not found in this project.\n\nThe data cannot be reloaded.";
+         public const string SimulationCannotShareNamesWithCompounds = "Simulation cannot share names with compounds";
          public static string UnableToCreateIndividual(string constraints) => $"Could not create individuals with given constraint:\n{constraints}";
          public static string UnableToCreatePopulation(string constraints) => $"Could not create population with given constraint:\n{constraints}";
          public const string FactorShouldBeBiggerThanZero = "Factor should be bigger than 0.";

--- a/src/PKSim.Presentation/DTO/Core/RenameObjectDTOFactory.cs
+++ b/src/PKSim.Presentation/DTO/Core/RenameObjectDTOFactory.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.Core.Domain;
+﻿using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Presentation.DTO;
 using PKSim.Core.Model;
@@ -20,10 +21,26 @@ namespace PKSim.Presentation.DTO.Core
 
       public override RenameObjectDTO CreateFor(IWithName objectBase)
       {
-         if (objectBase is IPKSimBuildingBlock buildingBlock)
-            return createFor(buildingBlock);
+         switch (objectBase)
+         {
+            case Simulation simulation:
+               return createFor(simulation);
+            case IPKSimBuildingBlock buildingBlock:
+               return createFor(buildingBlock);
+            default:
+               return base.CreateFor(objectBase);
+         }
+      }
 
-         return base.CreateFor(objectBase);
+      private RenameObjectDTO createFor(Simulation simulation)
+      {
+         var renameObjectDTO = new RenamePKSimSimulationDTO(simulation.Name)
+         {
+            ContainerType = ObjectTypes.Project
+         };
+         renameObjectDTO.AddUsedNames(_projectRetriever.Current.All(simulation.BuildingBlockType).AllNames());
+         renameObjectDTO.AddCompoundNames(simulation.CompoundNames);
+         return renameObjectDTO;
       }
 
       private RenameObjectDTO createFor(IPKSimBuildingBlock buildingBlock)

--- a/src/PKSim.Presentation/DTO/RenamePKSimSimulationDTO.cs
+++ b/src/PKSim.Presentation/DTO/RenamePKSimSimulationDTO.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
+using PKSim.Assets;
+
+namespace PKSim.Presentation.DTO
+{
+   public class RenamePKSimSimulationDTO : RenameObjectDTO
+   {
+      private readonly List<string> _compoundNames = new List<string>();
+
+      public RenamePKSimSimulationDTO(string name) : base(name)
+      {
+         Rules.AddRange(AllRules.All());
+      }
+
+      private static class AllRules
+      {
+         public static IEnumerable<IBusinessRule> All()
+         {
+            yield return CreateRule.For<RenamePKSimSimulationDTO>()
+               .Property(x => x.Name)
+               .WithRule((x, y) => !x._compoundNames.Contains(y))
+               .WithError(PKSimConstants.Error.SimulationCannotShareNamesWithCompounds);
+         }
+      }
+
+      public void AddCompoundNames(IReadOnlyList<string> compoundNames) => _compoundNames.AddRange(compoundNames);
+   }
+}

--- a/tests/PKSim.Tests/Presentation/RenameObjectDTOFactorySpecs.cs
+++ b/tests/PKSim.Tests/Presentation/RenameObjectDTOFactorySpecs.cs
@@ -4,8 +4,10 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
+using PKSim.Presentation.DTO;
 using RenameObjectDTOFactory = PKSim.Presentation.DTO.Core.RenameObjectDTOFactory;
 
 namespace PKSim.Presentation
@@ -24,6 +26,40 @@ namespace PKSim.Presentation
 
          _project = new PKSimProject();
          A.CallTo(() => _projectRetriever.Current).Returns(_project);
+      }
+   }
+
+   public class When_creating_a_rename_DTO_for_a_simulation : concern_for_RenameObjectDTOFactory
+   {
+      private RenameObjectDTO _dto;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IndividualSimulation>();
+         A.CallTo(() => _simulation.Name).Returns("simulation");
+         A.CallTo(() => _simulation.CompoundNames).ReturnsLazily(() => new []{"compound"});
+      }
+
+      protected override void Because()
+      {
+         _dto = sut.CreateFor(_simulation);
+      }
+
+      [Observation]
+      public void the_dto_should_be_created_for_simulation()
+      {
+         _dto.ShouldBeAnInstanceOf<RenamePKSimSimulationDTO>();
+      }
+
+      [Observation]
+      public void the_dto_should_be_invalid_when_simulation_shares_name_with_compound()
+      {
+         _dto.Name = "newName";
+         _dto.IsValid().ShouldBeTrue();
+         _dto.Name = "compound";
+         _dto.IsValid().ShouldBeFalse();
       }
    }
 


### PR DESCRIPTION
Fixes #3003

# Description
Make it not possible to rename a simulation to a name it shares with one of its compounds

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):