### PR TITLE
#3278 progress bar events

### DIFF
--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -52,7 +52,10 @@ namespace PKSim.Presentation.Presenters.Main
       public event EventHandler StatusChanged = delegate { };
       private readonly IEventPublisher _eventPublisher;
       private readonly IInteractiveSimulationRunner _interactiveSimulationRunner;
-      private string countMessage => _interactiveSimulationRunner.ActiveSimulationsCount == 1 ? string.Empty : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
+      private string countMessage => (_interactiveSimulationRunner.ActiveSimulationsCount == 1 || _interactiveSimulationRunner.ActiveSimulationsCount == 0) 
+         ? string.Empty 
+         : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
+
       public StatusBarPresenter(
          IStatusBarView view, 
          IApplicationConfiguration applicationConfiguration, 
@@ -147,7 +150,7 @@ namespace PKSim.Presentation.Presenters.Main
             .And.Visible(true);
 
          update(StatusBarElements.ProgressStatus)
-            .WithCaption($"{_interactiveSimulationRunner.ActiveSimulationsCount} {eventToHandle.Message}")
+            .WithCaption($"{countMessage} {eventToHandle.Message}")
             .And.Visible(true);
       }
 

--- a/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/StatusBarPresenter.cs
@@ -52,9 +52,7 @@ namespace PKSim.Presentation.Presenters.Main
       public event EventHandler StatusChanged = delegate { };
       private readonly IEventPublisher _eventPublisher;
       private readonly IInteractiveSimulationRunner _interactiveSimulationRunner;
-      private string countMessage => (_interactiveSimulationRunner.ActiveSimulationsCount == 1 || _interactiveSimulationRunner.ActiveSimulationsCount == 0) 
-         ? string.Empty 
-         : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
+      private string countMessage => (_interactiveSimulationRunner.ActiveSimulationsCount <= 1) ? string.Empty : _interactiveSimulationRunner.ActiveSimulationsCount.ToString();
 
       public StatusBarPresenter(
          IStatusBarView view, 


### PR DESCRIPTION
Fixes #3278 

# Description

Progress bar is missleading for some cases other than simulations run.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

<img width="497" height="105" alt="Screenshot 2025-11-03 091143" src="https://github.com/user-attachments/assets/85895d04-1d7d-401a-adb1-e65db9389d5d" />
<img width="456" height="147" alt="Screenshot 2025-11-03 091121" src="https://github.com/user-attachments/assets/427c0911-dfab-42cf-885f-243631fd1a16" />
<img width="431" height="135" alt="Screenshot 2025-11-03 091101" src="https://github.com/user-attachments/assets/de17b3f0-b888-42ab-9637-ecf4b4f05046" />
<img width="451" height="144" alt="Screenshot 2025-11-03 091213" src="https://github.com/user-attachments/assets/8100552d-8c5d-49c8-8435-d63dcff26936" />



# Questions (if appropriate):