### PR TITLE
Fixes #2964 Error when selecting user defined variability in pregnancy models

### DIFF
--- a/src/PKSim.Infrastructure/ProjectConverter/v11/Converter10to11.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v11/Converter10to11.cs
@@ -32,6 +32,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
       private readonly ICloner _cloner;
       private readonly IContainerTask _containerTask;
       private readonly Converter100To110 _coreConverter;
+      private readonly IEntityPathResolver _entityPathResolver;
       private bool _converted;
 
       public Converter10to11(
@@ -43,7 +44,8 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
          IDefaultIndividualRetriever defaultIndividualRetriever,
          ICloner cloner,
          IContainerTask containerTask,
-         Converter100To110 coreConverter
+         Converter100To110 coreConverter,
+         IEntityPathResolver entityPathResolver
       )
       {
          _expressionProfileFactory = expressionProfileFactory;
@@ -55,6 +57,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
          _cloner = cloner;
          _containerTask = containerTask;
          _coreConverter = coreConverter;
+         _entityPathResolver = entityPathResolver;
       }
 
       public bool IsSatisfiedBy(int version) => version == ProjectVersions.V10;
@@ -109,8 +112,6 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
          originParameterElement.SetAttributeValue("value", value);
          originParameterElement.SetAttributeValue("unit", unit);
          originDataElement.Add(originParameterElement);
-
-         return;
       }
 
       public void Visit(Individual individual)
@@ -124,6 +125,12 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
          addExpressionProfilesUsedBySimulationSubjectToProject(population);
          makeInitialConcentrationParametersNotVariableInPopulation(population);
          convertIndividual(population.FirstIndividual);
+         convertPopulation(population);
+      }
+
+      private void convertPopulation(Population population)
+      {
+         population.AllVectorialParameters(_entityPathResolver).Where(x => x.BuildingBlockType.Is(PKSimBuildingBlockType.Individual) && x.IsDistributed()).Each(x => x.IsChangedByCreateIndividual = true);
       }
 
       private void convertIndividual(Individual individual)
@@ -138,15 +145,15 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
 
       private void updateFractionOfBloodForSampling(Individual individual)
       {
-         var defaultHuman = _defaultIndividualRetriever.DefaultHuman();
-         var oneStandardFractionOfBloodParameter = defaultHuman.GetAllChildren<IParameter>(x => x.IsNamed(FRACTION_OF_BLOOD_FOR_SAMPLING)).First();
+         var defaultIndividual = _defaultIndividualRetriever.DefaultIndividualFor(individual.Population);
+         var oneStandardFractionOfBloodParameter = defaultIndividual.GetAllChildren<IParameter>(x => x.IsNamed(FRACTION_OF_BLOOD_FOR_SAMPLING)).First();
          var allFractionOfBloodParameters = individual.GetAllChildren<IParameter>(x => x.IsNamed(FRACTION_OF_BLOOD_FOR_SAMPLING));
          allFractionOfBloodParameters.Each(x => { x.Info.UpdatePropertiesFrom(oneStandardFractionOfBloodParameter.Info); });
       }
 
       private void updateIsChangedByCreatedIndividualFlag(Individual individual)
       {
-         var defaultHuman = _defaultIndividualRetriever.DefaultHuman();
+         var defaultHuman = _defaultIndividualRetriever.DefaultIndividualFor(individual.Population);
          var allIsChangedByIndividualParameter = _containerTask.CacheAllChildrenSatisfying<IParameter>(defaultHuman, x => x.IsChangedByCreateIndividual);
          var allParameters = _containerTask.CacheAllChildren<IParameter>(individual);
          allIsChangedByIndividualParameter.KeyValues.Each(kv =>
@@ -173,8 +180,8 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
          if (gfr == null || bsa == null)
             return;
 
-         var defaultHuman = _defaultIndividualRetriever.DefaultHuman();
-         var parameter = defaultHuman.Organism.EntityAt<IParameter>(KIDNEY, E_GFR);
+         var defaultIndividual = _defaultIndividualRetriever.DefaultIndividualFor(individual.Population);
+         var parameter = defaultIndividual.Organism.EntityAt<IParameter>(KIDNEY, E_GFR);
          kidney.Add(_cloner.Clone(parameter));
       }
 
@@ -200,9 +207,9 @@ namespace PKSim.Infrastructure.ProjectConverter.v11
                .Each(x => x.IsFixedValue = false);
 
             expressionProfile.Individual.AllMoleculeParametersFor(expressionProfile.Molecule)
-                 .Where(x => !x.Editable)
-                 .Where(x => !x.IsDefault)
-                 .Each(x => x.IsDefault = true);
+               .Where(x => !x.Editable)
+               .Where(x => !x.IsDefault)
+               .Each(x => x.IsDefault = true);
 
             //only add at the end once the expression profile has been updated
             simulationSubject.AddExpressionProfile(expressionProfile);

--- a/tests/PKSim.Tests/ProjectConverter/v11/Converter10to11Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v11/Converter10to11Specs.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core;
 using PKSim.Core.Model;
@@ -66,6 +68,39 @@ namespace PKSim.ProjectConverter.v11
          var pop = _allPopulations.FindByName("Pop");
          var ind = pop.FirstIndividual;
          ind.OriginData.Population.ShouldNotBeNull();
+      }
+   }
+
+   public class When_converting_pregnant_population_v10_to_v11 : ContextWithLoadedProject<Converter10to11>
+   {
+      private List<Population> _allPopulations;
+      private IContainerTask _containerTask;
+      private List<Individual> _allIndividuals;
+      private IEntityPathResolver _entityPathResolver;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         LoadProject("pregnant_populations_V10");
+         _entityPathResolver = IoC.Resolve<EntityPathResolver>();
+         _containerTask = IoC.Resolve<IContainerTask>();
+         _allPopulations = All<Population>();
+         _allIndividuals = All<Individual>();
+
+         _allIndividuals.Each(Load);
+         _allPopulations.Each(Load);
+      }
+
+      [Observation]
+      public void pregnant_individual_volume_parameters_are_updated_to_IsChangedByCreateIndividual()
+      {
+         _allIndividuals.All(ind => _containerTask.CacheAllChildrenSatisfying<IParameter>(ind, x => x.Name.Equals("Volume")).All(x => x.IsChangedByCreateIndividual)).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void fetal_hematocrit_parameters_are_updated_to_IsChangedByCreateIndividual()
+      {
+         _allPopulations.All(pop => pop.AllVectorialParameters(_entityPathResolver).Where(x => x.Name.Equals("Fetal Hematocrit")).All(x => x.IsChangedByCreateIndividual)).ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
Fixes #2964

# Description
During project conversion some parameters should have the property `IsChangedByCreateIndividual` to match how it was originally created pre V11.

In V11 this became a settable property.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):