### PR TITLE
Fixes  #3346 When adding snapshot to pksim module add FirstIndividual for populations

### DIFF
--- a/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
@@ -137,7 +137,7 @@ namespace PKSim.CLI.Core.Services
          _logger.AddInfo($"Starting batch simulation export for file '{projectFile}'");
          try
          {
-            var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName);
+            var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName, runSimulations:false);
 
             // The workspace project will be needed to create the exported module snapshot in case PKML export is selected
             _workspace.Project = project;

--- a/src/PKSim.Core/Services/ModelCoreSimulationSnapshotUpdater.cs
+++ b/src/PKSim.Core/Services/ModelCoreSimulationSnapshotUpdater.cs
@@ -59,7 +59,7 @@ public class ModelCoreSimulationSnapshotUpdater(
          case Population population:
             addBuildingBlockAndDependents(population.FirstIndividual, project);
             project.AddBuildingBlock(population);
-            break;
+            return;
          default:
             project.AddBuildingBlock(pkSimBuildingBlock);
             return;

--- a/src/PKSim.Core/Services/ModelCoreSimulationSnapshotUpdater.cs
+++ b/src/PKSim.Core/Services/ModelCoreSimulationSnapshotUpdater.cs
@@ -56,6 +56,10 @@ public class ModelCoreSimulationSnapshotUpdater(
          case ExpressionProfile expressionProfile:
             addExpression(project, expressionProfile);
             return;
+         case Population population:
+            addBuildingBlockAndDependents(population.FirstIndividual, project);
+            project.AddBuildingBlock(population);
+            break;
          default:
             project.AddBuildingBlock(pkSimBuildingBlock);
             return;

--- a/tests/PKSim.Tests/IntegrationTests/ModelCoreSimulationSnapshotUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/ModelCoreSimulationSnapshotUpdaterSpecs.cs
@@ -22,7 +22,7 @@ using Protocol = PKSim.Core.Model.Protocol;
 
 namespace PKSim.IntegrationTests
 {
-   public abstract class concern_for_ModelCoreSimulationSnapshotUpdater : ContextForSimulationIntegration<IModelCoreSimulationSnapshotUpdater, IndividualSimulation>
+   public abstract class concern_for_ModelCoreSimulationSnapshotUpdater : ContextForSimulationIntegration<IModelCoreSimulationSnapshotUpdater>
    {
       protected Compound _compound;
       protected Individual _individual;
@@ -34,12 +34,15 @@ namespace PKSim.IntegrationTests
       protected ISimulationConfigurationTask _simulationConfigurationTask;
       protected ISimulationToModelCoreSimulationMapper _simulationMapper;
       private ExpressionProfile _expressionProfile;
+      protected Simulation _subjectSimulation;
+      protected Population _population;
 
       public override void GlobalContext()
       {
          base.GlobalContext();
          _compound = DomainFactoryForSpecs.CreateStandardCompound();
          _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _population = DomainFactoryForSpecs.CreateDefaultPopulation(_individual);
          _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(_individual);
          _protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
          _snapshotMapper = IoC.Resolve<ISnapshotMapper>();
@@ -53,30 +56,32 @@ namespace PKSim.IntegrationTests
 
          _workspace.Project.AddBuildingBlock(_compound);
          _workspace.Project.AddBuildingBlock(_individual);
+         _workspace.Project.AddBuildingBlock(_population);
          _workspace.Project.AddBuildingBlock(_protocol);
          _workspace.Project.AddBuildingBlock(_expressionProfile);
          _workspace.Project.AddObservedData(_observedData);
 
-         _simulation = DomainFactoryForSpecs.CreateSimulationWith(_individual, _compound, _protocol) as IndividualSimulation;
-         _simulation.AddUsedObservedData(UsedObservedData.From(_observedData));
-         _workspace.Project.AddBuildingBlock(_simulation);
+         _subjectSimulation = CreateSimulation();
+         _workspace.Project.AddBuildingBlock(_subjectSimulation);
       }
+
+      protected abstract Simulation CreateSimulation();
    }
 
-   public class mapping_model_core_simulation_to_project_snapshot_string : concern_for_ModelCoreSimulationSnapshotUpdater
+   public class mapping_individual_model_core_simulation_to_project_snapshot_string : concern_for_ModelCoreSimulationSnapshotUpdater
    {
       private PKSimProject _deserializedProject;
       private IModelCoreSimulation _moBiSimulation;
       protected override void Context()
       {
          base.Context();
-         var configuration = _simulationConfigurationTask.CreateFor(_simulation, shouldValidate: true, createAgingDataInSimulation: false);
-         _moBiSimulation = _simulationMapper.MapFrom(_simulation, configuration, shouldCloneModel: true);
+         var configuration = _simulationConfigurationTask.CreateFor(_subjectSimulation, shouldValidate: true, createAgingDataInSimulation: false);
+         _moBiSimulation = _simulationMapper.MapFrom(_subjectSimulation, configuration, shouldCloneModel: true);
       }
 
       protected override void Because()
       {
-         sut.AddSnapshotsToModelCoreSimulation(_simulation, _moBiSimulation);
+         sut.AddSnapshotsToModelCoreSimulation(_subjectSimulation, _moBiSimulation);
          var project = _jsonSerializer.DeserializeFromString<Project>(Encoding.UTF8.GetString(Convert.FromBase64String(_moBiSimulation.Configuration.ModuleConfigurations.Single().Module.Snapshot))).Result;
          _deserializedProject = _snapshotMapper.MapToModel(project, new ProjectContext(new PKSimProject(), runSimulations: false)).Result as PKSimProject;
       }
@@ -97,6 +102,58 @@ namespace PKSim.IntegrationTests
          _moBiSimulation.Configuration.Individual.Snapshot.ShouldNotBeEmpty();
          _moBiSimulation.Configuration.ModuleConfigurations.Single().Module.Snapshot.ShouldNotBeEmpty();
          _moBiSimulation.Configuration.ExpressionProfiles.Each(x => x.Snapshot.ShouldNotBeEmpty());
+      }
+
+      protected override Simulation CreateSimulation()
+      {
+         var simulation = DomainFactoryForSpecs.CreateSimulationWith(_individual, _compound, _protocol);
+         simulation.AddUsedObservedData(UsedObservedData.From(_observedData));
+         return simulation;
+      }
+   }
+
+   public class mapping_population_model_core_simulation_to_project_snapshot_string : concern_for_ModelCoreSimulationSnapshotUpdater
+   {
+      private PKSimProject _deserializedProject;
+      private IModelCoreSimulation _moBiSimulation;
+      protected override void Context()
+      {
+         base.Context();
+         var configuration = _simulationConfigurationTask.CreateFor(_subjectSimulation, shouldValidate: true, createAgingDataInSimulation: false);
+         _moBiSimulation = _simulationMapper.MapFrom(_subjectSimulation, configuration, shouldCloneModel: true);
+      }
+
+      protected override void Because()
+      {
+         sut.AddSnapshotsToModelCoreSimulation(_subjectSimulation, _moBiSimulation);
+         var project = _jsonSerializer.DeserializeFromString<Project>(Encoding.UTF8.GetString(Convert.FromBase64String(_moBiSimulation.Configuration.ModuleConfigurations.Single().Module.Snapshot))).Result;
+         _deserializedProject = _snapshotMapper.MapToModel(project, new ProjectContext(new PKSimProject(), runSimulations: false)).Result as PKSimProject;
+      }
+
+      [Observation]
+      public void snapshot_should_contain_building_blocks_observed_data_and_simulation()
+      {
+         _deserializedProject.All<Compound>().Count.ShouldBeEqualTo(1);
+         _deserializedProject.All<Protocol>().Count.ShouldBeEqualTo(1);
+         _deserializedProject.All<Individual>().Count.ShouldBeEqualTo(1);
+         _deserializedProject.All<PopulationSimulation>().Count.ShouldBeEqualTo(1);
+         _deserializedProject.All<Population>().Count.ShouldBeEqualTo(1);
+         _deserializedProject.AllObservedData.Count.ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void the_snapshots_should_be_set()
+      {
+         _moBiSimulation.Configuration.Individual.Snapshot.ShouldNotBeEmpty();
+         _moBiSimulation.Configuration.ModuleConfigurations.Single().Module.Snapshot.ShouldNotBeEmpty();
+         _moBiSimulation.Configuration.ExpressionProfiles.Each(x => x.Snapshot.ShouldNotBeEmpty());
+      }
+
+      protected override Simulation CreateSimulation()
+      {
+         var simulation = DomainFactoryForSpecs.CreateSimulationWith(_population, _compound, _protocol);
+         simulation.AddUsedObservedData(UsedObservedData.From(_observedData));
+         return simulation;
       }
    }
 }


### PR DESCRIPTION
Fixes #3346

# Description
For population simulations the base individual was not being added to the project when mapping PK-Sim modules

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):