### PR TITLE
Fixes #3349 Disable simulations runs when loading snapshots

### DIFF
--- a/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
+++ b/src/PKSim.CLI.Core/Services/JsonSimulationRunner.cs
@@ -132,7 +132,7 @@ namespace PKSim.CLI.Core.Services
          _logger.AddInfo($"Starting batch simulation export for file '{projectFile}'");
          try
          {
-            var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName);
+            var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(projectFile.FullName, runSimulations:false);
             var simulations = project.All<Simulation>();
             var numberOfSimulations = simulations.Count;
             _logger.AddInfo($"{numberOfSimulations} {"simulation".PluralizeIf(numberOfSimulations)} found in file '{projectFile}'", project.Name);

--- a/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Services;
+using PKSim.CLI.Core.RunOptions;
+using PKSim.CLI.Core.Services;
+using PKSim.Core;
+using PKSim.Core.Snapshots.Services;
+
+namespace PKSim.CLI
+{
+   public abstract class concern_for_JsonSimulationRunner : ContextSpecificationAsync<JsonSimulationRunner>
+   {
+      protected JsonRunOptions _runOptions;
+      protected ISnapshotTask _snapshotTask;
+      protected IOSPSuiteLogger _logger;
+      protected ISimulationExporter _simulationExporter;
+
+      protected override Task Context()
+      {
+         _runOptions = new JsonRunOptions
+         {
+            InputFolder = DomainHelperForSpecs.PATH_TO_DATA,
+            OutputFolder = "c:/tests/temp"
+         };
+         _snapshotTask = A.Fake<ISnapshotTask>();
+         _logger = A.Fake<IOSPSuiteLogger>();
+         _simulationExporter = A.Fake<ISimulationExporter>();
+         sut = new JsonSimulationRunner(_simulationExporter, _logger, _snapshotTask);
+         return Task.CompletedTask;
+      }
+   }
+
+   public class When_loading_snapshot_for_json_run : concern_for_JsonSimulationRunner
+   {
+      protected override Task Because()
+      {
+         return sut.RunBatchAsync(_runOptions);
+      }
+
+      [Observation]
+      public void the_snapshot_is_imported_without_running_simulations()
+      {
+         A.CallTo(() => _snapshotTask.LoadProjectFromSnapshotFileAsync(A<string>._, false)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
@@ -5,6 +6,7 @@ using OSPSuite.Core.Services;
 using PKSim.CLI.Core.RunOptions;
 using PKSim.CLI.Core.Services;
 using PKSim.Core;
+using PKSim.Core.Model;
 using PKSim.Core.Snapshots.Services;
 
 namespace PKSim.CLI
@@ -27,6 +29,11 @@ namespace PKSim.CLI
          _logger = A.Fake<IOSPSuiteLogger>();
          _simulationExporter = A.Fake<ISimulationExporter>();
          sut = new JsonSimulationRunner(_simulationExporter, _logger, _snapshotTask);
+         
+         var project = A.Fake<PKSimProject>();
+         A.CallTo(() => project.All<Simulation>()).Returns(new List<Simulation>());
+         A.CallTo(() => _snapshotTask.LoadProjectFromSnapshotFileAsync(A<string>._, false)).Returns(project);
+         
          return Task.CompletedTask;
       }
    }

--- a/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
+++ b/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
@@ -26,7 +26,7 @@ namespace PKSim.Core
       private static Dimension _fractionDimension;
 
       private static readonly string PATH_TO_SRC = "..\\..\\..\\..\\..\\src\\";
-      private static readonly string PATH_TO_DATA = "..\\..\\..\\Data\\";
+      public static readonly string PATH_TO_DATA = "..\\..\\..\\Data\\";
       private static readonly string PATH_TO_TEMPLATES = "..\\..\\..\\Templates\\";
 
       public static string FilePathFor(string fileNameWithExtension)


### PR DESCRIPTION
Fixes #3349

# Description
Snapshot from a project are running twice when using the JSONSimulationRunner

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):