### PR TITLE
Fixes #3340 Ontogeny not properly updated in simulations after changing in Expression Profile

### DIFF
--- a/src/PKSim.Core/Commands/SetOntogenyInMoleculeCommand.cs
+++ b/src/PKSim.Core/Commands/SetOntogenyInMoleculeCommand.cs
@@ -5,7 +5,7 @@ using PKSim.Core.Services;
 
 namespace PKSim.Core.Commands
 {
-   public class SetOntogenyInMoleculeCommand : BuildingBlockChangeCommand
+   public class SetOntogenyInMoleculeCommand : BuildingBlockStructureChangeCommand
    {
       private readonly string _moleculeId;
       private readonly Ontogeny _newOntogeny;

--- a/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
+++ b/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
@@ -207,7 +207,7 @@ namespace PKSim.Core
       {
          if (_concentrationDimension == null)
          {
-            _concentrationDimension = new Dimension(new BaseDimensionRepresentation {AmountExponent = 3, LengthExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
+            _concentrationDimension = new Dimension(new BaseDimensionRepresentation {AmountExponent = 3, LengthExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION, "ï¿½mol/l");
             _concentrationDimension.AddUnit(new Unit("mol/l", 1E6, 0));
          }
 
@@ -218,7 +218,7 @@ namespace PKSim.Core
       {
          if (_massConcentrationDimension == null)
          {
-            _massConcentrationDimension = new Dimension(new BaseDimensionRepresentation {MassExponent = 3, LengthExponent = -1}, Constants.Dimension.MASS_CONCENTRATION, "µg/l");
+            _massConcentrationDimension = new Dimension(new BaseDimensionRepresentation {MassExponent = 3, LengthExponent = -1}, Constants.Dimension.MASS_CONCENTRATION, "ï¿½g/l");
             _massConcentrationDimension.AddUnit(new Unit("g/l", 1E6, 0));
          }
 

--- a/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
+++ b/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
@@ -207,7 +207,7 @@ namespace PKSim.Core
       {
          if (_concentrationDimension == null)
          {
-            _concentrationDimension = new Dimension(new BaseDimensionRepresentation {AmountExponent = 3, LengthExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION, "�mol/l");
+            _concentrationDimension = new Dimension(new BaseDimensionRepresentation {AmountExponent = 3, LengthExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
             _concentrationDimension.AddUnit(new Unit("mol/l", 1E6, 0));
          }
 
@@ -218,7 +218,7 @@ namespace PKSim.Core
       {
          if (_massConcentrationDimension == null)
          {
-            _massConcentrationDimension = new Dimension(new BaseDimensionRepresentation {MassExponent = 3, LengthExponent = -1}, Constants.Dimension.MASS_CONCENTRATION, "�g/l");
+            _massConcentrationDimension = new Dimension(new BaseDimensionRepresentation {MassExponent = 3, LengthExponent = -1}, Constants.Dimension.MASS_CONCENTRATION, "µg/l");
             _massConcentrationDimension.AddUnit(new Unit("g/l", 1E6, 0));
          }
 

--- a/tests/PKSim.Tests/IntegrationTests/IndividualSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/IndividualSpecs.cs
@@ -46,7 +46,7 @@ namespace PKSim.IntegrationTests
          bsa.ShouldNotBeNull();
 
          bsa.Formula.IsExplicit().ShouldBeTrue();
-         bsa.DisplayUnit = bsa.Dimension.Unit("m�");
+         bsa.DisplayUnit = bsa.Dimension.Unit("m²");
          sut.Organism.Parameter(CoreConstants.Parameters.WEIGHT).Value = 73;
          sut.Organism.Parameter(CoreConstants.Parameters.HEIGHT).Value = 17.6;
          bsa.ValueInDisplayUnit.ShouldBeEqualTo(1.89, 1e-2);

--- a/tests/PKSim.Tests/IntegrationTests/IndividualSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/IndividualSpecs.cs
@@ -13,6 +13,7 @@ using PKSim.Core.Services;
 using PKSim.Infrastructure;
 using PKSim.Infrastructure.ProjectConverter;
 using IContainer = OSPSuite.Core.Domain.IContainer;
+using IFormulaFactory = PKSim.Core.Model.IFormulaFactory;
 
 namespace PKSim.IntegrationTests
 {
@@ -45,7 +46,7 @@ namespace PKSim.IntegrationTests
          bsa.ShouldNotBeNull();
 
          bsa.Formula.IsExplicit().ShouldBeTrue();
-         bsa.DisplayUnit = bsa.Dimension.Unit("m²");
+         bsa.DisplayUnit = bsa.Dimension.Unit("mï¿½");
          sut.Organism.Parameter(CoreConstants.Parameters.WEIGHT).Value = 73;
          sut.Organism.Parameter(CoreConstants.Parameters.HEIGHT).Value = 17.6;
          bsa.ValueInDisplayUnit.ShouldBeEqualTo(1.89, 1e-2);
@@ -254,6 +255,48 @@ namespace PKSim.IntegrationTests
          _allRemovedContainers.ShouldOnlyContain(new List<IContainer>(_allMoleculeContainers){_enzyme}); 
          _allMoleculeContainers = sut.AllMoleculeContainersFor(_enzyme);
          _allMoleculeContainers.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_updating_ontogeny_in_expression_profile_used_in_individual : concern_for_Individual
+   {
+      private const string _enzymeName = "CYP";
+      private int _previousIndividualStructureVersion;
+      private ExpressionProfile _expressionProfile;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+
+         sut = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(sut, _enzymeName);
+
+         _previousIndividualStructureVersion = sut.StructureVersion;
+      }
+
+      protected override void Because()
+      {
+         var ontogenyTask = IoC.Resolve<IOntogenyTask>();
+         ontogenyTask.SetOntogenyForMolecule(_expressionProfile.Molecule, new UserDefinedOntogeny { Table = createOntogenyTable() }, sut);
+      }
+
+      private DistributedTableFormula createOntogenyTable()
+      {
+         const double yearInMinutes = 365.25 * 24 * 60;
+         var formulaFactory = IoC.Resolve<IFormulaFactory>();
+         var tableFormula = formulaFactory.CreateDistributedTableFormula();
+
+         tableFormula.AddPoint(0, 0.1, new DistributionMetaData());
+         tableFormula.AddPoint(yearInMinutes, 0.5, new DistributionMetaData());
+         tableFormula.AddPoint(30 * yearInMinutes, 0.5, new DistributionMetaData());
+
+         return tableFormula;
+      }
+
+      [Observation]
+      public void should_increment_structure_version_of_individual_after_ontogeny_switch()
+      {
+         _previousIndividualStructureVersion.ShouldBeSmallerThan(sut.StructureVersion);
       }
    }
 }


### PR DESCRIPTION
Fixes #3340 Ontogeny not properly updated in simulations after changing in Expression Profile

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):