### PR TITLE
#3361 improve and change info message

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2602,7 +2602,7 @@ namespace PKSim.Assets
 
                var idsSuffix = failedCount > MaxFailedIndexesToShow ? $" of {failedCount}" : string.Empty;
 
-               message += $"{Environment.NewLine}Failing individual numbers (first {indexesToShow.Count}{idsSuffix}) {string.Join(", ", indexesToShow)}";
+               message += $"{Environment.NewLine}Failing individual ids (first {indexesToShow.Count}{idsSuffix}) {string.Join(", ", indexesToShow)}";
             }
 
             return message;

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2582,7 +2582,7 @@ namespace PKSim.Assets
          public static string LinkedExpressionProfileIs(string expressionProfileName) => $"Using expression profile <b>{expressionProfileName}</b>";
 
          public static string ChildPughScoreFor(string score) => $"Child-Pugh {score}";
-
+         private const int MaxFailedIdsToShow = 20;
          public static string PopulationSimulationFailed(IReadOnlyCollection<int> failedIds, int totalCount, string simulationName)
          {
             if (totalCount == 0)
@@ -2597,12 +2597,12 @@ namespace PKSim.Assets
             {
                var idsToShow = failedIds
                   .OrderBy(id => id)
-                  .Take(20)
+                  .Take(MaxFailedIdsToShow)
                   .ToList();
 
                message +=
-                  $"{Environment.NewLine}Failing individual IDs (first {idsToShow.Count}" +
-                  $"{(failedCount > 20 ? " of " + failedCount : string.Empty)}): " +
+                  $"{Environment.NewLine}Failing individual Indexes (first {idsToShow.Count}" +
+                  $"{(failedCount > MaxFailedIdsToShow ? " of " + failedCount : string.Empty)}): " +
                   string.Join(", ", idsToShow);
             }
 

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2600,7 +2600,7 @@ namespace PKSim.Assets
                   .Take(MaxFailedIndexesToShow)
                   .ToList();
 
-               var idsSuffix = failedCount > 20 ? $" of {failedCount}" : string.Empty;
+               var idsSuffix = failedCount > MaxFailedIndexesToShow ? $" of {failedCount}" : string.Empty;
 
                message += $"{Environment.NewLine}Failing individual numbers (first {indexesToShow.Count}{idsSuffix}) {string.Join(", ", indexesToShow)}";
             }

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using OSPSuite.Assets;
 using OSPSuite.Assets.Extensions;
-using OSPSuite.Core.Domain;
 using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Assets
@@ -925,7 +924,7 @@ namespace PKSim.Assets
          public static string SnapshotDuplicateEntryByName(string name, string type) =>
             $"Another {type} named '{name}' already exists in the project. Snapshot file is corrupted.";
 
-         public static string EffectiveMolWeightMustBeGreaterThan(double valueInDisplayUnit, string displayUnit) => 
+         public static string EffectiveMolWeightMustBeGreaterThan(double valueInDisplayUnit, string displayUnit) =>
             $"Effective mol weight must be greater than or equal to {valueInDisplayUnit} {displayUnit}";
       }
 
@@ -2584,16 +2583,31 @@ namespace PKSim.Assets
 
          public static string ChildPughScoreFor(string score) => $"Child-Pugh {score}";
 
-         public static string PopulationSimulationSuccessful(int successCount, int totalCount, string simulationName)
+         public static string PopulationSimulationFailed(IReadOnlyCollection<int> failedIds, int totalCount, string simulationName)
          {
-            //Probably this is never the case, but we have to prevent dividing by zero anyways. 
             if (totalCount == 0)
                return $"No simulations were run for {simulationName}.";
 
-            var rate = (double)successCount / totalCount * 100;
-            return $"{successCount} out of {totalCount} were successful for simulation {simulationName} ({rate:F1}% success rate).";
-         }
+            var failedCount = failedIds?.Count ?? 0;
+            var successRate = (double)(totalCount - failedCount) / totalCount * 100;
 
+            var message = $"{failedCount} out of {totalCount} individuals failed for simulation {simulationName} ({successRate:F1}% success rate).";
+
+            if (failedCount > 0)
+            {
+               var idsToShow = failedIds
+                  .OrderBy(id => id)
+                  .Take(20)
+                  .ToList();
+
+               message +=
+                  $"{Environment.NewLine}Failing individual IDs (first {idsToShow.Count}" +
+                  $"{(failedCount > 20 ? " of " + failedCount : string.Empty)}): " +
+                  string.Join(", ", idsToShow);
+            }
+
+            return message;
+         }
       }
 
       public static class Reporting

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2580,29 +2580,29 @@ namespace PKSim.Assets
          public static readonly string DidYouReallyBackupProject = "Did you really make a backup of your project?";
 
          public static string LinkedExpressionProfileIs(string expressionProfileName) => $"Using expression profile <b>{expressionProfileName}</b>";
-
+         
          public static string ChildPughScoreFor(string score) => $"Child-Pugh {score}";
-         private const int MaxFailedIdsToShow = 20;
-         public static string PopulationSimulationFailed(IReadOnlyCollection<int> failedIds, int totalCount, string simulationName)
+         private const int MaxFailedIndexesToShow = 20;
+         public static string PopulationSimulationFailed(IReadOnlyCollection<int> failedIndexes, int totalCount, string simulationName)
          {
             if (totalCount == 0)
                return $"No simulations were run for {simulationName}.";
 
-            var failedCount = failedIds?.Count ?? 0;
+            var failedCount = failedIndexes?.Count ?? 0;
             var successRate = (double)(totalCount - failedCount) / totalCount * 100;
 
             var message = $"{failedCount} out of {totalCount} individuals failed for simulation {simulationName} ({successRate:F1}% success rate).";
 
             if (failedCount > 0)
             {
-               var idsToShow = failedIds
-                  .OrderBy(id => id)
-                  .Take(MaxFailedIdsToShow)
+               var indexesToShow = failedIndexes
+                  .OrderBy(index => index)
+                  .Take(MaxFailedIndexesToShow)
                   .ToList();
 
                var idsSuffix = failedCount > 20 ? $" of {failedCount}" : string.Empty;
 
-               message += $"{Environment.NewLine}Failing individual numbers (first {idsToShow.Count}{idsSuffix}) {string.Join(", ", idsToShow)}";
+               message += $"{Environment.NewLine}Failing individual numbers (first {indexesToShow.Count}{idsSuffix}) {string.Join(", ", indexesToShow)}";
             }
 
             return message;

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2600,10 +2600,9 @@ namespace PKSim.Assets
                   .Take(MaxFailedIdsToShow)
                   .ToList();
 
-               message +=
-                  $"{Environment.NewLine}Failing individual Indexes (first {idsToShow.Count}" +
-                  $"{(failedCount > MaxFailedIdsToShow ? " of " + failedCount : string.Empty)}): " +
-                  string.Join(", ", idsToShow);
+               var idsSuffix = failedCount > 20 ? $" of {failedCount}" : string.Empty;
+
+               message += $"{Environment.NewLine}Failing individual numbers (first {idsToShow.Count}{idsSuffix}) {string.Join(", ", idsToShow)}";
             }
 
             return message;

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,9 +104,22 @@ namespace PKSim.Core.Services
          if (!failingSimulations.Any())
             return;
 
+         var failingInfoSet = new HashSet<IndividualRunInfo>(failingSimulations);
+         var failingIds = new List<int>();
+         var totalIndividuals = populationRunResults.IndividualRunInfos.Count();
 
-         var successfulCount = populationRunResults.IndividualRunInfos.Count() - failingSimulations.Count();
-         var message = PKSimConstants.UI.PopulationSimulationSuccessful(successfulCount, populationRunResults.IndividualRunInfos.Count(),populationSimulation.Name);
+         for (int id = 0; id < totalIndividuals; id++)
+         {
+            var runInfo = populationRunResults.IndividualRunInfoFor(id);
+
+            if (failingInfoSet.Contains(runInfo))
+            {
+               failingIds.Add(id);
+            }
+         } 
+
+         var message = PKSimConstants.UI.PopulationSimulationFailed(failingIds, totalIndividuals, populationSimulation.Name);
+
          _dialogCreator.MessageBoxInfo(message);
       }
 

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
@@ -5,13 +9,7 @@ using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Events;
 using PKSim.Assets;
-using PKSim.Core.Extensions;
 using PKSim.Core.Model;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace PKSim.Core.Services
 {

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
@@ -10,7 +5,13 @@ using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Events;
 using PKSim.Assets;
+using PKSim.Core.Extensions;
 using PKSim.Core.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PKSim.Core.Services
 {
@@ -99,26 +100,9 @@ namespace PKSim.Core.Services
 
       private void evaluateResultsAndShowMessage(PopulationSimulation populationSimulation, PopulationRunResults populationRunResults)
       {
-         var failingSimulations = populationRunResults.IndividualRunInfos.Where(x => x.Success != true).ToList();
+         var failingIndividuals = populationRunResults.IndividualRunInfos.Where(x => !x.Success).Select(runInfo => populationRunResults.IndividualRunInfos.IndexOf(runInfo)).ToList();
 
-         if (!failingSimulations.Any())
-            return;
-
-         var failingInfoSet = new HashSet<IndividualRunInfo>(failingSimulations);
-         var failingIds = new List<int>();
-         var totalIndividuals = populationRunResults.IndividualRunInfos.Count();
-
-         for (int id = 0; id < totalIndividuals; id++)
-         {
-            var runInfo = populationRunResults.IndividualRunInfoFor(id);
-
-            if (failingInfoSet.Contains(runInfo))
-            {
-               failingIds.Add(id);
-            }
-         }
-
-         var message = PKSimConstants.UI.PopulationSimulationFailed(failingIds, totalIndividuals, populationSimulation.Name);
+         var message = PKSimConstants.UI.PopulationSimulationFailed(failingIndividuals, populationRunResults.IndividualRunInfos.Count(), populationSimulation.Name);
 
          _dialogCreator.MessageBoxInfo(message);
       }

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -104,10 +104,20 @@ namespace PKSim.Core.Services
          if (!failingSimulations.Any())
             return;
 
+         var failingInfoSet = new HashSet<IndividualRunInfo>(failingSimulations);
+         var failingIds = new List<int>();
          var totalIndividuals = populationRunResults.IndividualRunInfos.Count();
-         var failingIds = failingSimulations
-            .Select(info => info.IndividualId)
-            .ToList();
+
+         for (int id = 0; id < totalIndividuals; id++)
+         {
+            var runInfo = populationRunResults.IndividualRunInfoFor(id);
+
+            if (failingInfoSet.Contains(runInfo))
+            {
+               failingIds.Add(id);
+            }
+         }
+
          var message = PKSimConstants.UI.PopulationSimulationFailed(failingIds, totalIndividuals, populationSimulation.Name);
 
          _dialogCreator.MessageBoxInfo(message);

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -100,7 +100,12 @@ namespace PKSim.Core.Services
 
       private void evaluateResultsAndShowMessage(PopulationSimulation populationSimulation, PopulationRunResults populationRunResults)
       {
-         var failingIndividuals = populationRunResults.IndividualRunInfos.Where(x => !x.Success).Select(runInfo => populationRunResults.IndividualRunInfos.IndexOf(runInfo)).ToList();
+         var failingIndividuals = populationRunResults.IndividualRunInfos.Select((runInfo, index) => new { runInfo, index })
+            .Where(x => !x.runInfo.Success)
+            .Select(x => x.index).ToList();
+
+         if (!failingIndividuals.Any())
+            return;
 
          var message = PKSimConstants.UI.PopulationSimulationFailed(failingIndividuals, populationRunResults.IndividualRunInfos.Count(), populationSimulation.Name);
 

--- a/src/PKSim.Core/Services/PopulationSimulationEngine.cs
+++ b/src/PKSim.Core/Services/PopulationSimulationEngine.cs
@@ -104,20 +104,10 @@ namespace PKSim.Core.Services
          if (!failingSimulations.Any())
             return;
 
-         var failingInfoSet = new HashSet<IndividualRunInfo>(failingSimulations);
-         var failingIds = new List<int>();
          var totalIndividuals = populationRunResults.IndividualRunInfos.Count();
-
-         for (int id = 0; id < totalIndividuals; id++)
-         {
-            var runInfo = populationRunResults.IndividualRunInfoFor(id);
-
-            if (failingInfoSet.Contains(runInfo))
-            {
-               failingIds.Add(id);
-            }
-         } 
-
+         var failingIds = failingSimulations
+            .Select(info => info.IndividualId)
+            .ToList();
          var message = PKSimConstants.UI.PopulationSimulationFailed(failingIds, totalIndividuals, populationSimulation.Name);
 
          _dialogCreator.MessageBoxInfo(message);

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -128,12 +128,9 @@ namespace PKSim.Core
       protected override async Task Context()
       {
          await base.Context();
-         var individualResult = new IndividualResults();
-         individualResult.Id = 1;
-         var individualResult2 = new IndividualResults();
-         individualResult2.Id = 2;
+         var individualResult = new IndividualResults { Id = 0, IndividualId = 0 };
          _runResults.Add(individualResult);
-         _runResults.AddFailure(2, "Failed Simulation");
+         _runResults.AddFailure(1, "Failed Simulation");
 
          A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._))
             .Invokes(x => _message = x.GetArgument<string>(0));
@@ -153,7 +150,7 @@ namespace PKSim.Core
       [Observation]
       public void should_show_message_with_simulations_failed()
       {
-         _message.Contains("1 out of 2 were successful for simulation").ShouldBeTrue();
+         _message.Contains("1 out of 2 individuals failed for simulation").ShouldBeTrue();
       }
    }
 

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -172,17 +172,14 @@ namespace PKSim.Core
          _runResults.Add(individualResult2);
          _runResults.Add(individualResult3);
 
-         // Mark failures for ids 2 and 3
          _runResults.AddFailure(1, "Failed Individual 1");
          _runResults.AddFailure(2, "Failed Individual 2");
 
-         // Capture the message shown to the user
          A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._))
             .Invokes(call => _message = call.GetArgument<string>(0));
 
          _simulationRunOptions = new SimulationRunOptions { RaiseEvents = false };
 
-         // Ensure the population runner returns our prepared results
          A.CallTo(_populationRunner)
             .WithReturnType<Task<PopulationRunResults>>()
             .WithAnyArguments()

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -156,4 +156,50 @@ namespace PKSim.Core
          _message.Contains("1 out of 2 were successful for simulation").ShouldBeTrue();
       }
    }
+
+   public class When_the_population_run_has_multiple_failures_ids_are_listed_in_message : concern_for_PopulationSimulationEngine
+   {
+      private string _message;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+
+         var individualResult1 = new IndividualResults { Id = 0 ,IndividualId = 0};
+         var individualResult2 = new IndividualResults { Id = 1 ,IndividualId = 1};
+         var individualResult3 = new IndividualResults { Id = 2 ,IndividualId = 2};
+         _runResults.Add(individualResult1);
+         _runResults.Add(individualResult2);
+         _runResults.Add(individualResult3);
+
+         // Mark failures for ids 2 and 3
+         _runResults.AddFailure(1, "Failed Individual 1");
+         _runResults.AddFailure(2, "Failed Individual 2");
+
+         // Capture the message shown to the user
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._))
+            .Invokes(call => _message = call.GetArgument<string>(0));
+
+         _simulationRunOptions = new SimulationRunOptions { RaiseEvents = false };
+
+         // Ensure the population runner returns our prepared results
+         A.CallTo(_populationRunner)
+            .WithReturnType<Task<PopulationRunResults>>()
+            .WithAnyArguments()
+            .Returns(_runResults);
+      }
+
+      protected override Task Because()
+      {
+         return sut.RunAsync(_populationSimulation, _simulationRunOptions);
+      }
+
+      [Observation]
+      public void should_list_failing_simulation_ids_in_message()
+      {
+         _message.ShouldNotBeNull();
+         _message.Contains("1").ShouldBeTrue();
+         _message.Contains("2").ShouldBeTrue();
+      }
+   }
 }

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -137,7 +137,7 @@ namespace PKSim.Core
          _simulationRunOptions = new SimulationRunOptions { RaiseEvents = false };
 
          A.CallTo(_populationRunner)
-            .WithReturnType<Task<PopulationRunResults>>() 
+            .WithReturnType<Task<PopulationRunResults>>()
             .WithAnyArguments()
             .Returns(_runResults);
       }
@@ -162,9 +162,9 @@ namespace PKSim.Core
       {
          await base.Context();
 
-         var individualResult1 = new IndividualResults { Id = 0 ,IndividualId = 0};
-         var individualResult2 = new IndividualResults { Id = 1 ,IndividualId = 1};
-         var individualResult3 = new IndividualResults { Id = 2 ,IndividualId = 2};
+         var individualResult1 = new IndividualResults { Id = 0, IndividualId = 0 };
+         var individualResult2 = new IndividualResults { Id = 1, IndividualId = 1 };
+         var individualResult3 = new IndividualResults { Id = 2, IndividualId = 2 };
          _runResults.Add(individualResult1);
          _runResults.Add(individualResult2);
          _runResults.Add(individualResult3);
@@ -189,7 +189,7 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_list_failing_simulation_ids_in_message()
+      public void should_list_failing_individual_ids_in_message()
       {
          _message.ShouldNotBeNull();
          _message.Contains("1").ShouldBeTrue();

--- a/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
+++ b/tests/PKSim.Tests/Core/PopulationSimulationEngineSpecs.cs
@@ -154,7 +154,7 @@ namespace PKSim.Core
       }
    }
 
-   public class When_the_population_run_has_multiple_failures_ids_are_listed_in_message : concern_for_PopulationSimulationEngine
+   public class When_the_population_run_has_multiple_failures_indexes_are_listed_in_message : concern_for_PopulationSimulationEngine
    {
       private string _message;
 
@@ -189,7 +189,7 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_list_failing_individual_ids_in_message()
+      public void should_list_failing_individual_indexes_in_message()
       {
          _message.ShouldNotBeNull();
          _message.Contains("1").ShouldBeTrue();


### PR DESCRIPTION
Fixes #3361 

# Description

Improve the message for population results when individuals are failing

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="449" height="167" alt="image" src="https://github.com/user-attachments/assets/97295fce-15fc-4734-8a34-502d5272accf" />

# Questions (if appropriate):