### PR TITLE
Fixes #3363 data folder not accessible for coverage

### DIFF
--- a/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
+++ b/tests/PKSim.Tests/CLI/JsonSimulationRunnerSpecs.cs
@@ -22,7 +22,7 @@ namespace PKSim.CLI
       {
          _runOptions = new JsonRunOptions
          {
-            InputFolder = DomainHelperForSpecs.PATH_TO_DATA,
+            InputFolder = DomainHelperForSpecs.DataFolder,
             OutputFolder = "c:/tests/temp"
          };
          _snapshotTask = A.Fake<ISnapshotTask>();

--- a/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
+++ b/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
@@ -26,48 +26,26 @@ namespace PKSim.Core
       private static Dimension _fractionDimension;
 
       private static readonly string PATH_TO_SRC = "..\\..\\..\\..\\..\\src\\";
-      public static readonly string PATH_TO_DATA = "..\\..\\..\\Data\\";
+      private static readonly string PATH_TO_DATA = "..\\..\\..\\Data\\";
       private static readonly string PATH_TO_TEMPLATES = "..\\..\\..\\Templates\\";
 
-      public static string FilePathFor(string fileNameWithExtension)
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileNameWithExtension);
-      }
+      public static string DataFolder => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA);
 
-      public static string DataFilePathFor(string fileNameWithExtension)
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, fileNameWithExtension);
-      }
+      public static string FilePathFor(string fileNameWithExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileNameWithExtension);
 
-      public static string PopulationFilePathFor(string fileNameWithoutExtension)
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "PopulationFiles", fileNameWithoutExtension + ".csv");
-      }
+      public static string DataFilePathFor(string fileNameWithExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, fileNameWithExtension);
 
-      public static string SimulationResultsFilePathFor(string fileNameWithoutExtension)
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "SimulationResultsFiles", fileNameWithoutExtension + ".csv");
-      }
+      public static string PopulationFilePathFor(string fileNameWithoutExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "PopulationFiles", fileNameWithoutExtension + ".csv");
 
-      public static string PKAnalysesFilePathFor(string fileNameWithoutExtension)
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "PKAnalysesFiles", fileNameWithoutExtension + ".csv");
-      }
+      public static string SimulationResultsFilePathFor(string fileNameWithoutExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "SimulationResultsFiles", fileNameWithoutExtension + ".csv");
 
-      public static string TEXTemplateFolder()
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_TEMPLATES, "StandardTemplate");
-      }
+      public static string PKAnalysesFilePathFor(string fileNameWithoutExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_DATA, "PKAnalysesFiles", fileNameWithoutExtension + ".csv");
 
-      public static string UserTemplateDatabasePath()
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_SRC, "Db\\TemplateDB", "PKSimTemplateDBUser.template");
-      }
+      public static string TEXTemplateFolder() => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_TEMPLATES, "StandardTemplate");
 
-      public static string SystemTemplateDatabasePath()
-      {
-         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_SRC, "Db\\TemplateDB", "PKSimTemplateDBSystem.mdb");
-      }
+      public static string UserTemplateDatabasePath() => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_SRC, "Db\\TemplateDB", "PKSimTemplateDBUser.template");
+
+      public static string SystemTemplateDatabasePath() => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, PATH_TO_SRC, "Db\\TemplateDB", "PKSimTemplateDBSystem.mdb");
 
       public static ExpressionProfile CreateExpressionProfile<TMolecule>(string speciesName = "Species", string moleculeName = "CYP3A4", string category = "Healthy") where TMolecule : IndividualMolecule, new()
       {
@@ -326,15 +304,9 @@ namespace PKSim.Core
          return ind;
       }
 
-      private static QuantityValues createValuesArray(int i, int numberOfPoints)
-      {
-         return createArray("Path " + i, LengthDimensionForSpecs(), numberOfPoints);
-      }
+      private static QuantityValues createValuesArray(int i, int numberOfPoints) => createArray("Path " + i, LengthDimensionForSpecs(), numberOfPoints);
 
-      private static QuantityValues createTimeArray(int numberOfPoints)
-      {
-         return createArray("Time", TimeDimensionForSpecs(), numberOfPoints);
-      }
+      private static QuantityValues createTimeArray(int numberOfPoints) => createArray("Time", TimeDimensionForSpecs(), numberOfPoints);
 
       private static QuantityValues createArray(string path, IDimension dimension, int numberOfPoints)
       {


### PR DESCRIPTION
Fixes #3363

# Description
A data folder was not accessible using relative path during coverage tests

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):