### PR TITLE
Fixes #2881 make the user settings layout apply to all instances

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.12" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1667,7 +1667,7 @@ namespace PKSim.Assets
          public static readonly string ModelParameters = "Model Parameters";
          public static readonly string DefaultSpecies = "Species";
          public static readonly string DefaultPopulation = "Population";
-         public static readonly string ParameterLayout = "Parameter layout";
+         public static readonly string ParameterView = "Parameter view";
          public static readonly string ForParameterIdentificationAndSensitivityAnalysis = "For Parameter Identification and Sensitivity Analysis";
          public static readonly string ForOthers = "For all others";
          public static readonly string DefaultLipophilicityName = "Lipophilicity";

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1667,7 +1667,9 @@ namespace PKSim.Assets
          public static readonly string ModelParameters = "Model Parameters";
          public static readonly string DefaultSpecies = "Species";
          public static readonly string DefaultPopulation = "Population";
-         public static readonly string DefaultParameterGroupLayout = "Parameter layout";
+         public static readonly string ParameterLayout = "Parameter layout";
+         public static readonly string ForParameterIdentificationAndSensitivityAnalysis = "For Parameter Identification and Sensitivity Analysis";
+         public static readonly string ForOthers = "For all others";
          public static readonly string DefaultLipophilicityName = "Lipophilicity";
          public static readonly string DefaultFractionUnboundName = "Fraction unbound";
          public static readonly string DefaultSolubilityName = "Solubility";

--- a/src/PKSim.BatchTool/BatchUserSettings.cs
+++ b/src/PKSim.BatchTool/BatchUserSettings.cs
@@ -39,7 +39,7 @@ namespace PKSim.BatchTool
       public DisplayUnitsManager DisplayUnits { get; set; } = new DisplayUnitsManager();
       public Color DisabledColor { get; set; }
       public ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
-      public ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
+      public ParameterGroupingModeIdForParameterAnalyzable DefaultParameterGroupingModeForPIAndSA { get; set; }
       public string LastIgnoredVersion { get; set; }
 
       public IDiagramOptions DiagramOptions { get; set; }

--- a/src/PKSim.BatchTool/BatchUserSettings.cs
+++ b/src/PKSim.BatchTool/BatchUserSettings.cs
@@ -39,6 +39,7 @@ namespace PKSim.BatchTool
       public DisplayUnitsManager DisplayUnits { get; set; } = new DisplayUnitsManager();
       public Color DisabledColor { get; set; }
       public ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
+      public ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
       public string LastIgnoredVersion { get; set; }
 
       public IDiagramOptions DiagramOptions { get; set; }

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -60,8 +60,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -55,9 +55,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.3.12" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
+++ b/src/PKSim.Core/Services/InteractiveSimulationRunner.cs
@@ -8,7 +8,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.SimModel.Services;
 using OSPSuite.Utility;
-using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
@@ -36,7 +35,6 @@ namespace PKSim.Core.Services
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IExecutionContext _executionContext;
       private readonly ConcurrentDictionary<Simulation, CancellationTokenSource> _cancellationTokenSources = new ConcurrentDictionary<Simulation, CancellationTokenSource>();
-      private readonly IEventPublisher _eventPublisher;
       private readonly SimulationRunOptions _simulationRunOptions;
 
       public int ActiveSimulationsCount => _cancellationTokenSources.Count;

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -35,15 +35,15 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.3.12" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UserSettingsXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/UserSettingsXmlSerializer.cs
@@ -34,6 +34,7 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          Map(x => x.ChangedColor);
          Map(x => x.ShouldRestoreWorkspaceLayout);
          Map(x => x.DefaultParameterGroupingMode);
+         Map(x => x.DefaultParameterGroupingModeForPIAndSA);
          Map(x => x.DefaultLipophilicityName);
          Map(x => x.DefaultFractionUnboundName);
          Map(x => x.DefaultSolubilityName);

--- a/src/PKSim.Presentation/IUserSettings.cs
+++ b/src/PKSim.Presentation/IUserSettings.cs
@@ -70,7 +70,7 @@ namespace PKSim.Presentation
       /// <summary>
       ///    Default grouping mode for grouping presenter for Parameter Identification and Sensitivity Analysis
       /// </summary>
-      ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
+      ParameterGroupingModeIdForParameterAnalyzable DefaultParameterGroupingModeForPIAndSA { get; set; }
 
       /// <summary>
       ///    Directory map for the current user

--- a/src/PKSim.Presentation/IUserSettings.cs
+++ b/src/PKSim.Presentation/IUserSettings.cs
@@ -68,6 +68,11 @@ namespace PKSim.Presentation
       ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
 
       /// <summary>
+      ///    Default grouping mode for grouping presenter for Parameter Identification and Sensitivity Analysis
+      /// </summary>
+      ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
+
+      /// <summary>
       ///    Directory map for the current user
       /// </summary>
       DirectoryMapSettings DirectoryMapSettings { get; }

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenter.cs
@@ -10,7 +10,6 @@ using OSPSuite.Presentation.Services;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
-using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.Mappers;
@@ -243,7 +242,6 @@ namespace PKSim.Presentation.Presenters.Parameters
 
             _view.AddNodes(_nodesCache[value]);
             _view.SelectNodeById(_settings.SelectedNodeId);
-            _settings.ParameterGroupingMode = _parameterGroupingMode;
          }
       }
 
@@ -308,7 +306,7 @@ namespace PKSim.Presentation.Presenters.Parameters
       private IGroup parameterGroupFrom(ITreeNode node)
       {
          var parameterGroupNode = node as ITreeNode<IGroup>;
-         return parameterGroupNode == null ? new Group {Name = "not available"} : parameterGroupNode.Tag;
+         return parameterGroupNode == null ? new Group { Name = "not available" } : parameterGroupNode.Tag;
       }
 
       public override bool CanClose => _activePresenter == null || _activePresenter.CanClose;
@@ -316,8 +314,7 @@ namespace PKSim.Presentation.Presenters.Parameters
       public void LoadSettingsForSubject(IWithId subject)
       {
          _settings = _presentationSettingsTask.PresentationSettingsFor<ParameterGroupsPresenterSettings>(this, subject);
-         _settings.DefaultParameterGroupingModeId = _userSettings.DefaultParameterGroupingMode;
-         _parameterGroupingMode = _settings.ParameterGroupingMode;
+         _parameterGroupingMode = ParameterGroupingModes.ById(_userSettings.DefaultParameterGroupingMode);
       }
 
       public string PresentationKey => PresenterConstants.PresenterKeys.ParameterGroupPresenter;

--- a/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
+++ b/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
@@ -1,6 +1,5 @@
 ﻿using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Core;
-using OSPSuite.Presentation.Presenters;
 
 namespace PKSim.Presentation.Presenters.Parameters
 {
@@ -8,14 +7,6 @@ namespace PKSim.Presentation.Presenters.Parameters
    {
       private const string PARAMETER_GROUPING_MODE_ID_SETTING = "ParameterGroupingModeId";
       private const string SELECTED_NODE_ID = "SelectedNodeId";
-
-      public ParameterGroupingModeId DefaultParameterGroupingModeId { get; set; }
-
-      public virtual ParameterGroupingMode ParameterGroupingMode
-      {
-         get => groupingModeFrom(GetSetting(PARAMETER_GROUPING_MODE_ID_SETTING, DefaultParameterGroupingModeId));
-         set => SetSetting(PARAMETER_GROUPING_MODE_ID_SETTING, value.Id);
-      }
 
       public virtual string SelectedNodeId
       {

--- a/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
+++ b/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
@@ -5,7 +5,6 @@ namespace PKSim.Presentation.Presenters.Parameters
 {
    public class ParameterGroupsPresenterSettings : DefaultPresentationSettings
    {
-      private const string PARAMETER_GROUPING_MODE_ID_SETTING = "ParameterGroupingModeId";
       private const string SELECTED_NODE_ID = "SelectedNodeId";
 
       public virtual string SelectedNodeId

--- a/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
+++ b/src/PKSim.Presentation/Presenters/Parameters/ParameterGroupsPresenterSettings.cs
@@ -1,5 +1,4 @@
-﻿using OSPSuite.Core.Domain;
-using OSPSuite.Presentation.Core;
+﻿using OSPSuite.Presentation.Core;
 
 namespace PKSim.Presentation.Presenters.Parameters
 {
@@ -11,11 +10,6 @@ namespace PKSim.Presentation.Presenters.Parameters
       {
          get => GetSetting<string>(SELECTED_NODE_ID);
          set => SetSetting(SELECTED_NODE_ID, value);
-      }
-
-      private ParameterGroupingMode groupingModeFrom(ParameterGroupingModeId parameterGroupingModeId)
-      {
-         return ParameterGroupingModes.ById(parameterGroupingModeId);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/UserSettingsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/UserSettingsPresenter.cs
@@ -40,8 +40,8 @@ namespace PKSim.Presentation.Presenters
       void SpeciesChanged();
       IEnumerable<string> AllPopulationsFor(string speciesName);
       IEnumerable<string> AllPopulationsDisplayName(string speciesName);
-      IEnumerable<ParameterGroupingModeId> AllParameterGroupingMode();
-      IEnumerable<string> AllParameterGroupingModeDisplay();
+      IReadOnlyList<ParameterGroupingMode> AllParameterGroupingMode();
+      IReadOnlyList<ParameterGroupingModeForParameterAnalyzable> AllParameterGroupingModeForPIAndSA();
 
       /// <summary>
       ///    Resets the layout
@@ -63,8 +63,9 @@ namespace PKSim.Presentation.Presenters
       /// </summary>
       string PopulationIconNameFor(PopulationAnalysisType populationAnalysisType);
 
-      IEnumerable<ViewLayout> AllViewLayouts();
-      IEnumerable<Scalings> AllScalings();
+      IReadOnlyList<ViewLayout> AllViewLayouts();
+      IReadOnlyList<Scalings> AllScalings();
+      
    }
 
    public class UserSettingsPresenter : AbstractSubPresenter<IUserSettingsView, IUserSettingsPresenter>, IUserSettingsPresenter
@@ -148,14 +149,14 @@ namespace PKSim.Presentation.Presenters
          return species.Populations.Select(pop => pop.DisplayName);
       }
 
-      public IEnumerable<ParameterGroupingModeId> AllParameterGroupingMode()
+      public IReadOnlyList<ParameterGroupingModeForParameterAnalyzable> AllParameterGroupingModeForPIAndSA()
       {
-         return ParameterGroupingModes.All().Select(x => x.Id);
+         return ParameterGroupingModesForParameterAnalyzable.All();
       }
 
-      public IEnumerable<string> AllParameterGroupingModeDisplay()
+      public IReadOnlyList<ParameterGroupingMode> AllParameterGroupingMode()
       {
-         return ParameterGroupingModes.All().Select(x => x.DisplayName);
+         return ParameterGroupingModes.All();
       }
 
       public void ResetLayout()
@@ -193,14 +194,14 @@ namespace PKSim.Presentation.Presenters
          return $"{populationAnalysisType}Analysis";
       }
 
-      public IEnumerable<ViewLayout> AllViewLayouts()
+      public IReadOnlyList<ViewLayout> AllViewLayouts()
       {
-         return ViewLayouts.All();
+         return ViewLayouts.All().ToList();
       }
 
-      public IEnumerable<Scalings> AllScalings()
+      public IReadOnlyList<Scalings> AllScalings()
       {
-         return EnumHelper.AllValuesFor<Scalings>();
+         return EnumHelper.AllValuesFor<Scalings>().ToList();
       }
 
       public void SaveSettings()

--- a/src/PKSim.Presentation/Services/ParameterAnalysableParameterSelector.cs
+++ b/src/PKSim.Presentation/Services/ParameterAnalysableParameterSelector.cs
@@ -21,15 +21,6 @@ namespace PKSim.Presentation.Services
                 && !ParameterIsCategorial(parameter);
       }
 
-      public override ParameterGroupingMode DefaultParameterSelectionMode
-      {
-         get
-         {
-            if (_userSettings.DefaultParameterGroupingModeForPIAndSA == ParameterGroupingModeId.Hierarchical)
-               return ParameterGroupingModes.Simple;
-
-            return ParameterGroupingModes.ById(_userSettings.DefaultParameterGroupingModeForPIAndSA);
-         }
-      }
+      public override ParameterGroupingModeForParameterAnalyzable DefaultParameterSelectionMode => ParameterGroupingModesForParameterAnalyzable.ById(_userSettings.DefaultParameterGroupingModeForPIAndSA);
    }
 }

--- a/src/PKSim.Presentation/Services/ParameterAnalysableParameterSelector.cs
+++ b/src/PKSim.Presentation/Services/ParameterAnalysableParameterSelector.cs
@@ -25,10 +25,10 @@ namespace PKSim.Presentation.Services
       {
          get
          {
-            if (_userSettings.DefaultParameterGroupingMode == ParameterGroupingModeId.Hierarchical)
+            if (_userSettings.DefaultParameterGroupingModeForPIAndSA == ParameterGroupingModeId.Hierarchical)
                return ParameterGroupingModes.Simple;
 
-            return ParameterGroupingModes.ById(_userSettings.DefaultParameterGroupingMode);
+            return ParameterGroupingModes.ById(_userSettings.DefaultParameterGroupingModeForPIAndSA);
          }
       }
    }

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -41,9 +41,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
+++ b/src/PKSim.UI.Starter/PKSim.UI.Starter.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.UI" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.UI" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.3.12" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -56,14 +56,14 @@
   <ItemGroup>
      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.UI" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.UI" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.UI/UserSettings.cs
+++ b/src/PKSim.UI/UserSettings.cs
@@ -34,7 +34,7 @@ namespace PKSim.UI
       public Scalings DefaultChartYScaling { get; set; }
       public bool ShouldRestoreWorkspaceLayout { get; set; }
       public ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
-      public ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
+      public ParameterGroupingModeIdForParameterAnalyzable DefaultParameterGroupingModeForPIAndSA { get; set; }
       public string MainViewLayout { get; set; }
       public string RibbonLayout { get; set; }
       public string DefaultChartEditorLayout { get; set; }
@@ -105,7 +105,7 @@ namespace PKSim.UI
          DefaultSpecies = CoreConstants.Species.HUMAN;
          DefaultPopulation = CoreConstants.Population.ICRP;
          DefaultParameterGroupingMode = ParameterGroupingModeId.Simple;
-         DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Simple;
+         DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeIdForParameterAnalyzable.Simple;
          LayoutVersion = CoreConstants.LAYOUT_VERSION;
          AbsTol = CoreConstants.DEFAULT_ABS_TOL;
          RelTol = CoreConstants.DEFAULT_REL_TOL;

--- a/src/PKSim.UI/UserSettings.cs
+++ b/src/PKSim.UI/UserSettings.cs
@@ -34,6 +34,7 @@ namespace PKSim.UI
       public Scalings DefaultChartYScaling { get; set; }
       public bool ShouldRestoreWorkspaceLayout { get; set; }
       public ParameterGroupingModeId DefaultParameterGroupingMode { get; set; }
+      public ParameterGroupingModeId DefaultParameterGroupingModeForPIAndSA { get; set; }
       public string MainViewLayout { get; set; }
       public string RibbonLayout { get; set; }
       public string DefaultChartEditorLayout { get; set; }
@@ -104,6 +105,7 @@ namespace PKSim.UI
          DefaultSpecies = CoreConstants.Species.HUMAN;
          DefaultPopulation = CoreConstants.Population.ICRP;
          DefaultParameterGroupingMode = ParameterGroupingModeId.Simple;
+         DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Simple;
          LayoutVersion = CoreConstants.LAYOUT_VERSION;
          AbsTol = CoreConstants.DEFAULT_ABS_TOL;
          RelTol = CoreConstants.DEFAULT_REL_TOL;

--- a/src/PKSim.UI/Views/UserSettingsView.Designer.cs
+++ b/src/PKSim.UI/Views/UserSettingsView.Designer.cs
@@ -37,7 +37,6 @@ namespace PKSim.UI.Views
          this.tbNumberOfBins = new DevExpress.XtraEditors.TextEdit();
          this.cbPreferredChartYScaling = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.cbPreferredVewLayout = new OSPSuite.UI.Controls.UxComboBoxEdit();
-         this.cbDefaultPopulationAnalysis = new PKSim.UI.Views.Core.UxImageComboBoxEdit();
          this.tbNumberOfProcessors = new DevExpress.XtraEditors.TextEdit();
          this.chkShowUpdateNotification = new OSPSuite.UI.Controls.UxCheckEdit();
          this.colorFormula = new OSPSuite.UI.Controls.UxColorPickEditWithHistory();
@@ -48,7 +47,6 @@ namespace PKSim.UI.Views
          this.tbAbsTol = new DevExpress.XtraEditors.TextEdit();
          this.cbIconSizeContextMenu = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.cbDefaultPopulation = new OSPSuite.UI.Controls.UxComboBoxEdit();
-         this.cbDefaultSpecies = new PKSim.UI.Views.Core.UxImageComboBoxEdit();
          this.chkShouldRestoreWorkspaceLayout = new OSPSuite.UI.Controls.UxCheckEdit();
          this.cbDefaultParameterGroupingMode = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.colorChartDiagramBack = new OSPSuite.UI.Controls.UxColorPickEditWithHistory();
@@ -92,14 +90,19 @@ namespace PKSim.UI.Views
          this.layoutItemFormulaColor = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemColorGroupObservedData = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutGroupDefaults = new DevExpress.XtraLayout.LayoutControlGroup();
-         this.layoutItemDefaultSpecies = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemDefaultPopulation = new DevExpress.XtraLayout.LayoutControlItem();
-         this.layoutItemParameterGroupingMode = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemDefaultLipoName = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemDefaultFuName = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemDefaultSolName = new DevExpress.XtraLayout.LayoutControlItem();
-         this.layoutItemDefaultPopulationAnalysis = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemDefaultChartYScale = new DevExpress.XtraLayout.LayoutControlItem();
+         this.cbDefaultParameterGroupingModePISA = new DevExpress.XtraEditors.ComboBoxEdit();
+         this.layoutItemParameterGroupingMode = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemParameterGroupingModePISA = new DevExpress.XtraLayout.LayoutControlItem();
+         this.cbDefaultPopulationAnalysis = new PKSim.UI.Views.Core.UxImageComboBoxEdit();
+         this.cbDefaultSpecies = new PKSim.UI.Views.Core.UxImageComboBoxEdit();
+         this.layoutItemDefaultSpecies = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemDefaultPopulationAnalysis = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutGroupParameterLayout = new DevExpress.XtraLayout.LayoutControlGroup();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlUserConfig)).BeginInit();
          this.layoutControlUserConfig.SuspendLayout();
@@ -108,7 +111,6 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.tbNumberOfBins.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbPreferredChartYScaling.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbPreferredVewLayout.Properties)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulationAnalysis.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.tbNumberOfProcessors.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.chkShowUpdateNotification.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorFormula.Properties)).BeginInit();
@@ -119,7 +121,6 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.tbAbsTol.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbIconSizeContextMenu.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulation.Properties)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultSpecies.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.chkShouldRestoreWorkspaceLayout.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbDefaultParameterGroupingMode.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorChartDiagramBack.Properties)).BeginInit();
@@ -163,14 +164,19 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaColor)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemColorGroupObservedData)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutGroupDefaults)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSpecies)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulation)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingMode)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultLipoName)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultFuName)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSolName)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulationAnalysis)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultChartYScale)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultParameterGroupingModePISA.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingMode)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingModePISA)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulationAnalysis.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultSpecies.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSpecies)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulationAnalysis)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutGroupParameterLayout)).BeginInit();
          this.SuspendLayout();
          // 
          // layoutControlUserConfig
@@ -206,9 +212,11 @@ namespace PKSim.UI.Views
          this.layoutControlUserConfig.Controls.Add(this.cbActiveSkin);
          this.layoutControlUserConfig.Controls.Add(this.chkAllowsScientificNotation);
          this.layoutControlUserConfig.Controls.Add(this.chckColorGroupObservedData);
+         this.layoutControlUserConfig.Controls.Add(this.cbDefaultParameterGroupingModePISA);
          this.layoutControlUserConfig.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControlUserConfig.Location = new System.Drawing.Point(0, 0);
          this.layoutControlUserConfig.Name = "layoutControlUserConfig";
+         this.layoutControlUserConfig.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1315, 438, 1546, 803);
          this.layoutControlUserConfig.OptionsView.UseSkinIndents = false;
          this.layoutControlUserConfig.Root = this.layoutControlGroup;
          this.layoutControlUserConfig.Size = new System.Drawing.Size(640, 623);
@@ -217,73 +225,63 @@ namespace PKSim.UI.Views
          // 
          // cbTemplateReferenceBehavior
          // 
-         this.cbTemplateReferenceBehavior.Location = new System.Drawing.Point(206, 397);
+         this.cbTemplateReferenceBehavior.Location = new System.Drawing.Point(218, 685);
          this.cbTemplateReferenceBehavior.Name = "cbTemplateReferenceBehavior";
          this.cbTemplateReferenceBehavior.Properties.AllowMouseWheel = false;
          this.cbTemplateReferenceBehavior.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbTemplateReferenceBehavior.Size = new System.Drawing.Size(398, 20);
+         this.cbTemplateReferenceBehavior.Size = new System.Drawing.Size(386, 20);
          this.cbTemplateReferenceBehavior.StyleController = this.layoutControlUserConfig;
          this.cbTemplateReferenceBehavior.TabIndex = 38;
          // 
          // tbNumberOfIndividualsPerBin
          // 
-         this.tbNumberOfIndividualsPerBin.Location = new System.Drawing.Point(206, -251);
+         this.tbNumberOfIndividualsPerBin.Location = new System.Drawing.Point(218, -20);
          this.tbNumberOfIndividualsPerBin.Name = "tbNumberOfIndividualsPerBin";
-         this.tbNumberOfIndividualsPerBin.Size = new System.Drawing.Size(398, 20);
+         this.tbNumberOfIndividualsPerBin.Size = new System.Drawing.Size(386, 20);
          this.tbNumberOfIndividualsPerBin.StyleController = this.layoutControlUserConfig;
          this.tbNumberOfIndividualsPerBin.TabIndex = 35;
          // 
          // tbNumberOfBins
          // 
-         this.tbNumberOfBins.Location = new System.Drawing.Point(206, -281);
+         this.tbNumberOfBins.Location = new System.Drawing.Point(218, -50);
          this.tbNumberOfBins.Name = "tbNumberOfBins";
-         this.tbNumberOfBins.Size = new System.Drawing.Size(398, 20);
+         this.tbNumberOfBins.Size = new System.Drawing.Size(386, 20);
          this.tbNumberOfBins.StyleController = this.layoutControlUserConfig;
          this.tbNumberOfBins.TabIndex = 34;
          // 
          // cbPreferredChartYScaling
          // 
-         this.cbPreferredChartYScaling.Location = new System.Drawing.Point(206, 193);
+         this.cbPreferredChartYScaling.Location = new System.Drawing.Point(218, 244);
          this.cbPreferredChartYScaling.Name = "cbPreferredChartYScaling";
          this.cbPreferredChartYScaling.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbPreferredChartYScaling.Size = new System.Drawing.Size(398, 20);
+         this.cbPreferredChartYScaling.Size = new System.Drawing.Size(386, 20);
          this.cbPreferredChartYScaling.StyleController = this.layoutControlUserConfig;
          this.cbPreferredChartYScaling.TabIndex = 33;
          // 
          // cbPreferredVewLayout
          // 
-         this.cbPreferredVewLayout.Location = new System.Drawing.Point(206, -134);
+         this.cbPreferredVewLayout.Location = new System.Drawing.Point(218, 97);
          this.cbPreferredVewLayout.Name = "cbPreferredVewLayout";
          this.cbPreferredVewLayout.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbPreferredVewLayout.Size = new System.Drawing.Size(398, 20);
+         this.cbPreferredVewLayout.Size = new System.Drawing.Size(386, 20);
          this.cbPreferredVewLayout.StyleController = this.layoutControlUserConfig;
          this.cbPreferredVewLayout.TabIndex = 32;
          // 
-         // cbDefaultPopulationAnalysis
-         // 
-         this.cbDefaultPopulationAnalysis.Location = new System.Drawing.Point(206, 163);
-         this.cbDefaultPopulationAnalysis.Name = "cbDefaultPopulationAnalysis";
-         this.cbDefaultPopulationAnalysis.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultPopulationAnalysis.Size = new System.Drawing.Size(398, 20);
-         this.cbDefaultPopulationAnalysis.StyleController = this.layoutControlUserConfig;
-         this.cbDefaultPopulationAnalysis.TabIndex = 31;
-         // 
          // tbNumberOfProcessors
          // 
-         this.tbNumberOfProcessors.Location = new System.Drawing.Point(206, -311);
+         this.tbNumberOfProcessors.Location = new System.Drawing.Point(218, -80);
          this.tbNumberOfProcessors.Name = "tbNumberOfProcessors";
-         this.tbNumberOfProcessors.Size = new System.Drawing.Size(398, 20);
+         this.tbNumberOfProcessors.Size = new System.Drawing.Size(386, 20);
          this.tbNumberOfProcessors.StyleController = this.layoutControlUserConfig;
          this.tbNumberOfProcessors.TabIndex = 29;
          // 
          // chkShowUpdateNotification
          // 
          this.chkShowUpdateNotification.AllowClicksOutsideControlArea = false;
-         this.chkShowUpdateNotification.Location = new System.Drawing.Point(19, -74);
+         this.chkShowUpdateNotification.Location = new System.Drawing.Point(19, 157);
          this.chkShowUpdateNotification.Name = "chkShowUpdateNotification";
          this.chkShowUpdateNotification.Properties.Caption = "chkShowUpdateNotification";
          this.chkShowUpdateNotification.Size = new System.Drawing.Size(585, 20);
@@ -293,98 +291,88 @@ namespace PKSim.UI.Views
          // colorFormula
          // 
          this.colorFormula.EditValue = System.Drawing.Color.Empty;
-         this.colorFormula.Location = new System.Drawing.Point(206, 454);
+         this.colorFormula.Location = new System.Drawing.Point(218, 742);
          this.colorFormula.Name = "colorFormula";
          this.colorFormula.Properties.AutomaticColor = System.Drawing.Color.Black;
          this.colorFormula.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.colorFormula.Size = new System.Drawing.Size(398, 20);
+         this.colorFormula.Size = new System.Drawing.Size(386, 20);
          this.colorFormula.StyleController = this.layoutControlUserConfig;
          this.colorFormula.TabIndex = 26;
          // 
          // cbDefaultSolName
          // 
-         this.cbDefaultSolName.Location = new System.Drawing.Point(206, 133);
+         this.cbDefaultSolName.Location = new System.Drawing.Point(218, 274);
          this.cbDefaultSolName.Name = "cbDefaultSolName";
          this.cbDefaultSolName.Properties.AllowRemoveMRUItems = false;
          this.cbDefaultSolName.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultSolName.Size = new System.Drawing.Size(398, 20);
+         this.cbDefaultSolName.Size = new System.Drawing.Size(386, 20);
          this.cbDefaultSolName.StyleController = this.layoutControlUserConfig;
          this.cbDefaultSolName.TabIndex = 25;
          // 
          // cbDefaultFuName
          // 
-         this.cbDefaultFuName.Location = new System.Drawing.Point(206, 103);
+         this.cbDefaultFuName.Location = new System.Drawing.Point(218, 304);
          this.cbDefaultFuName.Name = "cbDefaultFuName";
          this.cbDefaultFuName.Properties.AllowRemoveMRUItems = false;
          this.cbDefaultFuName.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultFuName.Size = new System.Drawing.Size(398, 20);
+         this.cbDefaultFuName.Size = new System.Drawing.Size(386, 20);
          this.cbDefaultFuName.StyleController = this.layoutControlUserConfig;
          this.cbDefaultFuName.TabIndex = 24;
          // 
          // cbDefaultLipoName
          // 
-         this.cbDefaultLipoName.Location = new System.Drawing.Point(206, 73);
+         this.cbDefaultLipoName.Location = new System.Drawing.Point(218, 334);
          this.cbDefaultLipoName.Name = "cbDefaultLipoName";
          this.cbDefaultLipoName.Properties.AllowRemoveMRUItems = false;
          this.cbDefaultLipoName.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultLipoName.Size = new System.Drawing.Size(398, 20);
+         this.cbDefaultLipoName.Size = new System.Drawing.Size(386, 20);
          this.cbDefaultLipoName.StyleController = this.layoutControlUserConfig;
          this.cbDefaultLipoName.TabIndex = 23;
          // 
          // tbRelTol
          // 
-         this.tbRelTol.Location = new System.Drawing.Point(206, -341);
+         this.tbRelTol.Location = new System.Drawing.Point(218, -110);
          this.tbRelTol.Name = "tbRelTol";
-         this.tbRelTol.Size = new System.Drawing.Size(398, 20);
+         this.tbRelTol.Size = new System.Drawing.Size(386, 20);
          this.tbRelTol.StyleController = this.layoutControlUserConfig;
          this.tbRelTol.TabIndex = 22;
          // 
          // tbAbsTol
          // 
-         this.tbAbsTol.Location = new System.Drawing.Point(206, -371);
+         this.tbAbsTol.Location = new System.Drawing.Point(218, -140);
          this.tbAbsTol.Name = "tbAbsTol";
-         this.tbAbsTol.Size = new System.Drawing.Size(398, 20);
+         this.tbAbsTol.Size = new System.Drawing.Size(386, 20);
          this.tbAbsTol.StyleController = this.layoutControlUserConfig;
          this.tbAbsTol.TabIndex = 21;
          // 
          // cbIconSizeContextMenu
          // 
-         this.cbIconSizeContextMenu.Location = new System.Drawing.Point(206, 310);
+         this.cbIconSizeContextMenu.Location = new System.Drawing.Point(218, 598);
          this.cbIconSizeContextMenu.Name = "cbIconSizeContextMenu";
          this.cbIconSizeContextMenu.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbIconSizeContextMenu.Size = new System.Drawing.Size(398, 20);
+         this.cbIconSizeContextMenu.Size = new System.Drawing.Size(386, 20);
          this.cbIconSizeContextMenu.StyleController = this.layoutControlUserConfig;
          this.cbIconSizeContextMenu.TabIndex = 20;
          // 
          // cbDefaultPopulation
          // 
-         this.cbDefaultPopulation.Location = new System.Drawing.Point(206, 13);
+         this.cbDefaultPopulation.Location = new System.Drawing.Point(218, 364);
          this.cbDefaultPopulation.Name = "cbDefaultPopulation";
          this.cbDefaultPopulation.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultPopulation.Size = new System.Drawing.Size(398, 20);
+         this.cbDefaultPopulation.Size = new System.Drawing.Size(386, 20);
          this.cbDefaultPopulation.StyleController = this.layoutControlUserConfig;
          this.cbDefaultPopulation.TabIndex = 18;
-         // 
-         // cbDefaultSpecies
-         // 
-         this.cbDefaultSpecies.Location = new System.Drawing.Point(206, -17);
-         this.cbDefaultSpecies.Name = "cbDefaultSpecies";
-         this.cbDefaultSpecies.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultSpecies.Size = new System.Drawing.Size(398, 20);
-         this.cbDefaultSpecies.StyleController = this.layoutControlUserConfig;
-         this.cbDefaultSpecies.TabIndex = 17;
          // 
          // chkShouldRestoreWorkspaceLayout
          // 
          this.chkShouldRestoreWorkspaceLayout.AllowClicksOutsideControlArea = false;
-         this.chkShouldRestoreWorkspaceLayout.Location = new System.Drawing.Point(19, -104);
+         this.chkShouldRestoreWorkspaceLayout.Location = new System.Drawing.Point(19, 127);
          this.chkShouldRestoreWorkspaceLayout.Name = "chkShouldRestoreWorkspaceLayout";
          this.chkShouldRestoreWorkspaceLayout.Properties.Caption = "chkShouldRestoreWorkspaceLayout";
          this.chkShouldRestoreWorkspaceLayout.Size = new System.Drawing.Size(585, 20);
@@ -393,111 +381,111 @@ namespace PKSim.UI.Views
          // 
          // cbDefaultParameterGroupingMode
          // 
-         this.cbDefaultParameterGroupingMode.Location = new System.Drawing.Point(206, 43);
+         this.cbDefaultParameterGroupingMode.Location = new System.Drawing.Point(218, 481);
          this.cbDefaultParameterGroupingMode.Name = "cbDefaultParameterGroupingMode";
          this.cbDefaultParameterGroupingMode.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbDefaultParameterGroupingMode.Size = new System.Drawing.Size(398, 20);
+         this.cbDefaultParameterGroupingMode.Size = new System.Drawing.Size(386, 20);
          this.cbDefaultParameterGroupingMode.StyleController = this.layoutControlUserConfig;
          this.cbDefaultParameterGroupingMode.TabIndex = 19;
          // 
          // colorChartDiagramBack
          // 
          this.colorChartDiagramBack.EditValue = System.Drawing.Color.Empty;
-         this.colorChartDiagramBack.Location = new System.Drawing.Point(206, 544);
+         this.colorChartDiagramBack.Location = new System.Drawing.Point(218, 832);
          this.colorChartDiagramBack.Name = "colorChartDiagramBack";
          this.colorChartDiagramBack.Properties.AutomaticColor = System.Drawing.Color.Black;
          this.colorChartDiagramBack.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.colorChartDiagramBack.Size = new System.Drawing.Size(398, 20);
+         this.colorChartDiagramBack.Size = new System.Drawing.Size(386, 20);
          this.colorChartDiagramBack.StyleController = this.layoutControlUserConfig;
          this.colorChartDiagramBack.TabIndex = 13;
          // 
          // colorChartBack
          // 
          this.colorChartBack.EditValue = System.Drawing.Color.Empty;
-         this.colorChartBack.Location = new System.Drawing.Point(206, 514);
+         this.colorChartBack.Location = new System.Drawing.Point(218, 802);
          this.colorChartBack.Name = "colorChartBack";
          this.colorChartBack.Properties.AutomaticColor = System.Drawing.Color.Black;
          this.colorChartBack.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.colorChartBack.Size = new System.Drawing.Size(398, 20);
+         this.colorChartBack.Size = new System.Drawing.Size(386, 20);
          this.colorChartBack.StyleController = this.layoutControlUserConfig;
          this.colorChartBack.TabIndex = 12;
          // 
          // tbTemplateDatabase
          // 
-         this.tbTemplateDatabase.Location = new System.Drawing.Point(206, 367);
+         this.tbTemplateDatabase.Location = new System.Drawing.Point(218, 655);
          this.tbTemplateDatabase.Name = "tbTemplateDatabase";
          this.tbTemplateDatabase.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(),
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.SpinRight)});
-         this.tbTemplateDatabase.Size = new System.Drawing.Size(398, 20);
+         this.tbTemplateDatabase.Size = new System.Drawing.Size(386, 20);
          this.tbTemplateDatabase.StyleController = this.layoutControlUserConfig;
          this.tbTemplateDatabase.TabIndex = 10;
          // 
          // cbIconSizeTab
          // 
-         this.cbIconSizeTab.Location = new System.Drawing.Point(206, 280);
+         this.cbIconSizeTab.Location = new System.Drawing.Point(218, 568);
          this.cbIconSizeTab.Name = "cbIconSizeTab";
          this.cbIconSizeTab.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbIconSizeTab.Size = new System.Drawing.Size(398, 20);
+         this.cbIconSizeTab.Size = new System.Drawing.Size(386, 20);
          this.cbIconSizeTab.StyleController = this.layoutControlUserConfig;
          this.cbIconSizeTab.TabIndex = 9;
          // 
          // cbIconSizeTreeView
          // 
-         this.cbIconSizeTreeView.Location = new System.Drawing.Point(206, 250);
+         this.cbIconSizeTreeView.Location = new System.Drawing.Point(218, 538);
          this.cbIconSizeTreeView.Name = "cbIconSizeTreeView";
          this.cbIconSizeTreeView.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbIconSizeTreeView.Size = new System.Drawing.Size(398, 20);
+         this.cbIconSizeTreeView.Size = new System.Drawing.Size(386, 20);
          this.cbIconSizeTreeView.StyleController = this.layoutControlUserConfig;
          this.cbIconSizeTreeView.TabIndex = 8;
          // 
          // tbMRUListItemCount
          // 
-         this.tbMRUListItemCount.Location = new System.Drawing.Point(206, -164);
+         this.tbMRUListItemCount.Location = new System.Drawing.Point(218, 67);
          this.tbMRUListItemCount.Name = "tbMRUListItemCount";
-         this.tbMRUListItemCount.Size = new System.Drawing.Size(398, 20);
+         this.tbMRUListItemCount.Size = new System.Drawing.Size(386, 20);
          this.tbMRUListItemCount.StyleController = this.layoutControlUserConfig;
          this.tbMRUListItemCount.TabIndex = 7;
          // 
          // colorChanged
          // 
          this.colorChanged.EditValue = System.Drawing.Color.Empty;
-         this.colorChanged.Location = new System.Drawing.Point(206, 484);
+         this.colorChanged.Location = new System.Drawing.Point(218, 772);
          this.colorChanged.Name = "colorChanged";
          this.colorChanged.Properties.AutomaticColor = System.Drawing.Color.Black;
          this.colorChanged.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.colorChanged.Size = new System.Drawing.Size(398, 20);
+         this.colorChanged.Size = new System.Drawing.Size(386, 20);
          this.colorChanged.StyleController = this.layoutControlUserConfig;
          this.colorChanged.TabIndex = 11;
          // 
          // tbDecimalPlace
          // 
-         this.tbDecimalPlace.Location = new System.Drawing.Point(206, -401);
+         this.tbDecimalPlace.Location = new System.Drawing.Point(218, -170);
          this.tbDecimalPlace.Name = "tbDecimalPlace";
-         this.tbDecimalPlace.Size = new System.Drawing.Size(398, 20);
+         this.tbDecimalPlace.Size = new System.Drawing.Size(386, 20);
          this.tbDecimalPlace.StyleController = this.layoutControlUserConfig;
          this.tbDecimalPlace.TabIndex = 6;
          // 
          // cbActiveSkin
          // 
-         this.cbActiveSkin.Location = new System.Drawing.Point(206, -194);
+         this.cbActiveSkin.Location = new System.Drawing.Point(218, 37);
          this.cbActiveSkin.Name = "cbActiveSkin";
          this.cbActiveSkin.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbActiveSkin.Size = new System.Drawing.Size(398, 20);
+         this.cbActiveSkin.Size = new System.Drawing.Size(386, 20);
          this.cbActiveSkin.StyleController = this.layoutControlUserConfig;
          this.cbActiveSkin.TabIndex = 5;
          // 
          // chkAllowsScientificNotation
          // 
          this.chkAllowsScientificNotation.AllowClicksOutsideControlArea = false;
-         this.chkAllowsScientificNotation.Location = new System.Drawing.Point(19, -431);
+         this.chkAllowsScientificNotation.Location = new System.Drawing.Point(19, -200);
          this.chkAllowsScientificNotation.Name = "chkAllowsScientificNotation";
          this.chkAllowsScientificNotation.Properties.Caption = "chkAllowsScientificNotation";
          this.chkAllowsScientificNotation.Size = new System.Drawing.Size(585, 20);
@@ -506,7 +494,7 @@ namespace PKSim.UI.Views
          // 
          // chckColorGroupObservedData
          // 
-         this.chckColorGroupObservedData.Location = new System.Drawing.Point(19, 574);
+         this.chckColorGroupObservedData.Location = new System.Drawing.Point(19, 862);
          this.chckColorGroupObservedData.Name = "chckColorGroupObservedData";
          this.chckColorGroupObservedData.Properties.Caption = "chckColorGroupObservedData";
          this.chckColorGroupObservedData.Size = new System.Drawing.Size(585, 20);
@@ -523,11 +511,12 @@ namespace PKSim.UI.Views
             this.layoutGroupIconSizes,
             this.layoutGroupTemplateDatabase,
             this.layoutGroupColors,
-            this.layoutGroupDefaults});
-         this.layoutControlGroup.Name = "layoutControlGroup";
+            this.layoutGroupDefaults,
+            this.layoutGroupParameterLayout});
+         this.layoutControlGroup.Name = "Root";
          this.layoutControlGroup.OptionsItemText.TextToControlDistance = 5;
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(10, 10, 10, 10);
-         this.layoutControlGroup.Size = new System.Drawing.Size(623, 1094);
+         this.layoutControlGroup.Size = new System.Drawing.Size(623, 1151);
          this.layoutControlGroup.TextVisible = false;
          // 
          // layoutGroupNumericalProperties
@@ -563,7 +552,7 @@ namespace PKSim.UI.Views
          this.layoutItemDecimalPlace.Location = new System.Drawing.Point(0, 30);
          this.layoutItemDecimalPlace.Name = "layoutItemDecimalPlace";
          this.layoutItemDecimalPlace.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDecimalPlace.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDecimalPlace.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemAbsTol
          // 
@@ -572,7 +561,7 @@ namespace PKSim.UI.Views
          this.layoutItemAbsTol.Location = new System.Drawing.Point(0, 60);
          this.layoutItemAbsTol.Name = "layoutItemAbsTol";
          this.layoutItemAbsTol.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemAbsTol.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemAbsTol.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemRelTol
          // 
@@ -581,7 +570,7 @@ namespace PKSim.UI.Views
          this.layoutItemRelTol.Location = new System.Drawing.Point(0, 90);
          this.layoutItemRelTol.Name = "layoutItemRelTol";
          this.layoutItemRelTol.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemRelTol.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemRelTol.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemNumberOfProcessors
          // 
@@ -590,7 +579,7 @@ namespace PKSim.UI.Views
          this.layoutItemNumberOfProcessors.Location = new System.Drawing.Point(0, 120);
          this.layoutItemNumberOfProcessors.Name = "layoutItemNumberOfProcessors";
          this.layoutItemNumberOfProcessors.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemNumberOfProcessors.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemNumberOfProcessors.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemNumberOfBins
          // 
@@ -598,7 +587,7 @@ namespace PKSim.UI.Views
          this.layoutItemNumberOfBins.Location = new System.Drawing.Point(0, 150);
          this.layoutItemNumberOfBins.Name = "layoutItemNumberOfBins";
          this.layoutItemNumberOfBins.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemNumberOfBins.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemNumberOfBins.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemNumberOfIndividualsPerBin
          // 
@@ -606,7 +595,7 @@ namespace PKSim.UI.Views
          this.layoutItemNumberOfIndividualsPerBin.Location = new System.Drawing.Point(0, 180);
          this.layoutItemNumberOfIndividualsPerBin.Name = "layoutItemNumberOfIndividualsPerBin";
          this.layoutItemNumberOfIndividualsPerBin.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemNumberOfIndividualsPerBin.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemNumberOfIndividualsPerBin.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutGroupUIProperties
          // 
@@ -629,7 +618,7 @@ namespace PKSim.UI.Views
          this.layoutItemActiveSkin.Location = new System.Drawing.Point(0, 0);
          this.layoutItemActiveSkin.Name = "layoutItemActiveSkin";
          this.layoutItemActiveSkin.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemActiveSkin.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemActiveSkin.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemMRUListItemCount
          // 
@@ -638,7 +627,7 @@ namespace PKSim.UI.Views
          this.layoutItemMRUListItemCount.Location = new System.Drawing.Point(0, 30);
          this.layoutItemMRUListItemCount.Name = "layoutItemMRUListItemCount";
          this.layoutItemMRUListItemCount.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemMRUListItemCount.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemMRUListItemCount.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutControlItem1
          // 
@@ -667,13 +656,13 @@ namespace PKSim.UI.Views
          this.layoutItemPreferredViewLayout.Location = new System.Drawing.Point(0, 60);
          this.layoutItemPreferredViewLayout.Name = "layoutItemPreferredViewLayout";
          this.layoutItemPreferredViewLayout.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemPreferredViewLayout.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemPreferredViewLayout.TextSize = new System.Drawing.Size(194, 13);
          // 
          // emptySpaceItem1
          // 
          this.emptySpaceItem1.AllowHotTrack = false;
          this.emptySpaceItem1.CustomizationFormText = "emptySpaceItem1";
-         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 1062);
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 1119);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
          this.emptySpaceItem1.Size = new System.Drawing.Size(601, 10);
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
@@ -685,7 +674,7 @@ namespace PKSim.UI.Views
             this.layoutItemIconSizeTreeView,
             this.layoutItemIconSizeTab,
             this.layoutItemIconSizeContextMenu});
-         this.layoutGroupIconSizes.Location = new System.Drawing.Point(0, 681);
+         this.layoutGroupIconSizes.Location = new System.Drawing.Point(0, 738);
          this.layoutGroupIconSizes.Name = "layoutGroupIconSizes";
          this.layoutGroupIconSizes.OptionsItemText.TextToControlDistance = 5;
          this.layoutGroupIconSizes.Size = new System.Drawing.Size(601, 117);
@@ -697,7 +686,7 @@ namespace PKSim.UI.Views
          this.layoutItemIconSizeTreeView.Location = new System.Drawing.Point(0, 0);
          this.layoutItemIconSizeTreeView.Name = "layoutItemIconSizeTreeView";
          this.layoutItemIconSizeTreeView.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemIconSizeTreeView.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemIconSizeTreeView.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemIconSizeTab
          // 
@@ -706,7 +695,7 @@ namespace PKSim.UI.Views
          this.layoutItemIconSizeTab.Location = new System.Drawing.Point(0, 30);
          this.layoutItemIconSizeTab.Name = "layoutItemIconSizeTab";
          this.layoutItemIconSizeTab.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemIconSizeTab.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemIconSizeTab.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemIconSizeContextMenu
          // 
@@ -715,7 +704,7 @@ namespace PKSim.UI.Views
          this.layoutItemIconSizeContextMenu.Location = new System.Drawing.Point(0, 60);
          this.layoutItemIconSizeContextMenu.Name = "layoutItemIconSizeContextMenu";
          this.layoutItemIconSizeContextMenu.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemIconSizeContextMenu.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemIconSizeContextMenu.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutGroupTemplateDatabase
          // 
@@ -723,7 +712,7 @@ namespace PKSim.UI.Views
          this.layoutGroupTemplateDatabase.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemTemplateDatabase,
             this.layoutItemTemplateRefBehavior});
-         this.layoutGroupTemplateDatabase.Location = new System.Drawing.Point(0, 798);
+         this.layoutGroupTemplateDatabase.Location = new System.Drawing.Point(0, 855);
          this.layoutGroupTemplateDatabase.Name = "layoutGroupTemplateDatabase";
          this.layoutGroupTemplateDatabase.OptionsItemText.TextToControlDistance = 5;
          this.layoutGroupTemplateDatabase.Size = new System.Drawing.Size(601, 87);
@@ -735,7 +724,7 @@ namespace PKSim.UI.Views
          this.layoutItemTemplateDatabase.Location = new System.Drawing.Point(0, 0);
          this.layoutItemTemplateDatabase.Name = "layoutItemTemplateDatabase";
          this.layoutItemTemplateDatabase.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemTemplateDatabase.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemTemplateDatabase.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemTemplateRefBehavior
          // 
@@ -743,7 +732,7 @@ namespace PKSim.UI.Views
          this.layoutItemTemplateRefBehavior.Location = new System.Drawing.Point(0, 30);
          this.layoutItemTemplateRefBehavior.Name = "layoutItemTemplateRefBehavior";
          this.layoutItemTemplateRefBehavior.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemTemplateRefBehavior.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemTemplateRefBehavior.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutGroupColors
          // 
@@ -754,7 +743,7 @@ namespace PKSim.UI.Views
             this.layoutItemChartDiagramBackColor,
             this.layoutItemFormulaColor,
             this.layoutItemColorGroupObservedData});
-         this.layoutGroupColors.Location = new System.Drawing.Point(0, 885);
+         this.layoutGroupColors.Location = new System.Drawing.Point(0, 942);
          this.layoutGroupColors.Name = "layoutGroupColor";
          this.layoutGroupColors.OptionsItemText.TextToControlDistance = 5;
          this.layoutGroupColors.Size = new System.Drawing.Size(601, 177);
@@ -767,7 +756,7 @@ namespace PKSim.UI.Views
          this.layoutItemChangedColor.Location = new System.Drawing.Point(0, 30);
          this.layoutItemChangedColor.Name = "layoutItemChangedColor";
          this.layoutItemChangedColor.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemChangedColor.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemChangedColor.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemChartBackColor
          // 
@@ -777,7 +766,7 @@ namespace PKSim.UI.Views
          this.layoutItemChartBackColor.Name = "layoutItemPlotBackColor";
          this.layoutItemChartBackColor.Size = new System.Drawing.Size(595, 30);
          this.layoutItemChartBackColor.Text = "layoutItemChartBackColor";
-         this.layoutItemChartBackColor.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemChartBackColor.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemChartDiagramBackColor
          // 
@@ -787,7 +776,7 @@ namespace PKSim.UI.Views
          this.layoutItemChartDiagramBackColor.Name = "layoutItemPlotDiagramBackColor";
          this.layoutItemChartDiagramBackColor.Size = new System.Drawing.Size(595, 30);
          this.layoutItemChartDiagramBackColor.Text = "layoutItemChartDiagramBackColor";
-         this.layoutItemChartDiagramBackColor.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemChartDiagramBackColor.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemFormulaColor
          // 
@@ -796,7 +785,7 @@ namespace PKSim.UI.Views
          this.layoutItemFormulaColor.Location = new System.Drawing.Point(0, 0);
          this.layoutItemFormulaColor.Name = "layoutItemFormulaColor";
          this.layoutItemFormulaColor.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemFormulaColor.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemFormulaColor.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemColorGroupObservedData
          // 
@@ -813,7 +802,6 @@ namespace PKSim.UI.Views
          this.layoutGroupDefaults.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemDefaultSpecies,
             this.layoutItemDefaultPopulation,
-            this.layoutItemParameterGroupingMode,
             this.layoutItemDefaultLipoName,
             this.layoutItemDefaultFuName,
             this.layoutItemDefaultSolName,
@@ -822,80 +810,127 @@ namespace PKSim.UI.Views
          this.layoutGroupDefaults.Location = new System.Drawing.Point(0, 414);
          this.layoutGroupDefaults.Name = "layoutGroupDefaults";
          this.layoutGroupDefaults.OptionsItemText.TextToControlDistance = 5;
-         this.layoutGroupDefaults.Size = new System.Drawing.Size(601, 267);
-         // 
-         // layoutItemDefaultSpecies
-         // 
-         this.layoutItemDefaultSpecies.Control = this.cbDefaultSpecies;
-         this.layoutItemDefaultSpecies.CustomizationFormText = "layoutItemDefaultSpecies";
-         this.layoutItemDefaultSpecies.Location = new System.Drawing.Point(0, 0);
-         this.layoutItemDefaultSpecies.Name = "layoutItemDefaultSpecies";
-         this.layoutItemDefaultSpecies.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultSpecies.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutGroupDefaults.Size = new System.Drawing.Size(601, 237);
          // 
          // layoutItemDefaultPopulation
          // 
          this.layoutItemDefaultPopulation.Control = this.cbDefaultPopulation;
          this.layoutItemDefaultPopulation.CustomizationFormText = "layoutItemDefaultPopulation";
-         this.layoutItemDefaultPopulation.Location = new System.Drawing.Point(0, 30);
+         this.layoutItemDefaultPopulation.Location = new System.Drawing.Point(0, 150);
          this.layoutItemDefaultPopulation.Name = "layoutItemDefaultPopulation";
          this.layoutItemDefaultPopulation.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultPopulation.TextSize = new System.Drawing.Size(182, 13);
-         // 
-         // layoutItemParameterGroupingMode
-         // 
-         this.layoutItemParameterGroupingMode.Control = this.cbDefaultParameterGroupingMode;
-         this.layoutItemParameterGroupingMode.CustomizationFormText = "layoutItemParameterGroupingMode";
-         this.layoutItemParameterGroupingMode.Location = new System.Drawing.Point(0, 60);
-         this.layoutItemParameterGroupingMode.Name = "layoutItemParameterGroupingMode";
-         this.layoutItemParameterGroupingMode.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemParameterGroupingMode.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDefaultPopulation.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemDefaultLipoName
          // 
          this.layoutItemDefaultLipoName.Control = this.cbDefaultLipoName;
          this.layoutItemDefaultLipoName.CustomizationFormText = "layoutItemDefaultLipo";
-         this.layoutItemDefaultLipoName.Location = new System.Drawing.Point(0, 90);
+         this.layoutItemDefaultLipoName.Location = new System.Drawing.Point(0, 120);
          this.layoutItemDefaultLipoName.Name = "layoutItemDefaultLipo";
          this.layoutItemDefaultLipoName.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultLipoName.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDefaultLipoName.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemDefaultFuName
          // 
          this.layoutItemDefaultFuName.Control = this.cbDefaultFuName;
          this.layoutItemDefaultFuName.CustomizationFormText = "layoutItemDefaultFuName";
-         this.layoutItemDefaultFuName.Location = new System.Drawing.Point(0, 120);
+         this.layoutItemDefaultFuName.Location = new System.Drawing.Point(0, 90);
          this.layoutItemDefaultFuName.Name = "layoutItemDefaultFuName";
          this.layoutItemDefaultFuName.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultFuName.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDefaultFuName.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemDefaultSolName
          // 
          this.layoutItemDefaultSolName.Control = this.cbDefaultSolName;
          this.layoutItemDefaultSolName.CustomizationFormText = "layoutItemDefaultSolName";
-         this.layoutItemDefaultSolName.Location = new System.Drawing.Point(0, 150);
+         this.layoutItemDefaultSolName.Location = new System.Drawing.Point(0, 60);
          this.layoutItemDefaultSolName.Name = "layoutItemDefaultSolName";
          this.layoutItemDefaultSolName.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultSolName.TextSize = new System.Drawing.Size(182, 13);
-         // 
-         // layoutItemDefaultPopulationAnalysis
-         // 
-         this.layoutItemDefaultPopulationAnalysis.Control = this.cbDefaultPopulationAnalysis;
-         this.layoutItemDefaultPopulationAnalysis.CustomizationFormText = "layoutItemDefaultPopulationAnalysis";
-         this.layoutItemDefaultPopulationAnalysis.Location = new System.Drawing.Point(0, 180);
-         this.layoutItemDefaultPopulationAnalysis.Name = "layoutItemDefaultPopulationAnalysis";
-         this.layoutItemDefaultPopulationAnalysis.Size = new System.Drawing.Size(595, 30);
-         this.layoutItemDefaultPopulationAnalysis.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDefaultSolName.TextSize = new System.Drawing.Size(194, 13);
          // 
          // layoutItemDefaultChartYScale
          // 
          this.layoutItemDefaultChartYScale.Control = this.cbPreferredChartYScaling;
          this.layoutItemDefaultChartYScale.CustomizationFormText = "layoutItemDefaultChartScale";
-         this.layoutItemDefaultChartYScale.Location = new System.Drawing.Point(0, 210);
+         this.layoutItemDefaultChartYScale.Location = new System.Drawing.Point(0, 30);
          this.layoutItemDefaultChartYScale.Name = "layoutItemDefaultChartYScale";
          this.layoutItemDefaultChartYScale.Size = new System.Drawing.Size(595, 30);
          this.layoutItemDefaultChartYScale.Text = "layoutItemDefaultChartScale";
-         this.layoutItemDefaultChartYScale.TextSize = new System.Drawing.Size(182, 13);
+         this.layoutItemDefaultChartYScale.TextSize = new System.Drawing.Size(194, 13);
+         // 
+         // cbDefaultParameterGroupingModePISA
+         // 
+         this.cbDefaultParameterGroupingModePISA.Location = new System.Drawing.Point(218, 451);
+         this.cbDefaultParameterGroupingModePISA.Name = "cbDefaultParameterGroupingModePISA";
+         this.cbDefaultParameterGroupingModePISA.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cbDefaultParameterGroupingModePISA.Size = new System.Drawing.Size(386, 20);
+         this.cbDefaultParameterGroupingModePISA.StyleController = this.layoutControlUserConfig;
+         this.cbDefaultParameterGroupingModePISA.TabIndex = 39;
+         // 
+         // layoutItemParameterGroupingMode
+         // 
+         this.layoutItemParameterGroupingMode.Control = this.cbDefaultParameterGroupingMode;
+         this.layoutItemParameterGroupingMode.CustomizationFormText = "layoutItemParameterGroupingMode";
+         this.layoutItemParameterGroupingMode.Location = new System.Drawing.Point(0, 30);
+         this.layoutItemParameterGroupingMode.Name = "layoutItemParameterGroupingMode";
+         this.layoutItemParameterGroupingMode.Size = new System.Drawing.Size(595, 30);
+         this.layoutItemParameterGroupingMode.TextSize = new System.Drawing.Size(194, 13);
+         // 
+         // layoutItemParameterGroupingModePISA
+         // 
+         this.layoutItemParameterGroupingModePISA.Control = this.cbDefaultParameterGroupingModePISA;
+         this.layoutItemParameterGroupingModePISA.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemParameterGroupingModePISA.Name = "layoutItemParameterGroupingModePISA";
+         this.layoutItemParameterGroupingModePISA.Size = new System.Drawing.Size(595, 30);
+         this.layoutItemParameterGroupingModePISA.TextSize = new System.Drawing.Size(194, 13);
+         // 
+         // cbDefaultPopulationAnalysis
+         // 
+         this.cbDefaultPopulationAnalysis.Location = new System.Drawing.Point(218, 214);
+         this.cbDefaultPopulationAnalysis.Name = "cbDefaultPopulationAnalysis";
+         this.cbDefaultPopulationAnalysis.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cbDefaultPopulationAnalysis.Size = new System.Drawing.Size(386, 20);
+         this.cbDefaultPopulationAnalysis.StyleController = this.layoutControlUserConfig;
+         this.cbDefaultPopulationAnalysis.TabIndex = 31;
+         // 
+         // cbDefaultSpecies
+         // 
+         this.cbDefaultSpecies.Location = new System.Drawing.Point(218, 394);
+         this.cbDefaultSpecies.Name = "cbDefaultSpecies";
+         this.cbDefaultSpecies.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cbDefaultSpecies.Size = new System.Drawing.Size(386, 20);
+         this.cbDefaultSpecies.StyleController = this.layoutControlUserConfig;
+         this.cbDefaultSpecies.TabIndex = 17;
+         // 
+         // layoutItemDefaultSpecies
+         // 
+         this.layoutItemDefaultSpecies.Control = this.cbDefaultSpecies;
+         this.layoutItemDefaultSpecies.CustomizationFormText = "layoutItemDefaultSpecies";
+         this.layoutItemDefaultSpecies.Location = new System.Drawing.Point(0, 180);
+         this.layoutItemDefaultSpecies.Name = "layoutItemDefaultSpecies";
+         this.layoutItemDefaultSpecies.Size = new System.Drawing.Size(595, 30);
+         this.layoutItemDefaultSpecies.TextSize = new System.Drawing.Size(194, 13);
+         // 
+         // layoutItemDefaultPopulationAnalysis
+         // 
+         this.layoutItemDefaultPopulationAnalysis.Control = this.cbDefaultPopulationAnalysis;
+         this.layoutItemDefaultPopulationAnalysis.CustomizationFormText = "layoutItemDefaultPopulationAnalysis";
+         this.layoutItemDefaultPopulationAnalysis.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemDefaultPopulationAnalysis.Name = "layoutItemDefaultPopulationAnalysis";
+         this.layoutItemDefaultPopulationAnalysis.Size = new System.Drawing.Size(595, 30);
+         this.layoutItemDefaultPopulationAnalysis.TextSize = new System.Drawing.Size(194, 13);
+         // 
+         // layoutGroupParameterLayout
+         // 
+         this.layoutGroupParameterLayout.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemParameterGroupingMode,
+            this.layoutItemParameterGroupingModePISA});
+         this.layoutGroupParameterLayout.Location = new System.Drawing.Point(0, 651);
+         this.layoutGroupParameterLayout.Name = "layoutGroupParameterLayout";
+         this.layoutGroupParameterLayout.Size = new System.Drawing.Size(601, 87);
          // 
          // UserSettingsView
          // 
@@ -913,7 +948,6 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.tbNumberOfBins.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbPreferredChartYScaling.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbPreferredVewLayout.Properties)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulationAnalysis.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.tbNumberOfProcessors.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.chkShowUpdateNotification.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorFormula.Properties)).EndInit();
@@ -924,7 +958,6 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.tbAbsTol.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbIconSizeContextMenu.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulation.Properties)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultSpecies.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.chkShouldRestoreWorkspaceLayout.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cbDefaultParameterGroupingMode.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.colorChartDiagramBack.Properties)).EndInit();
@@ -968,14 +1001,19 @@ namespace PKSim.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaColor)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemColorGroupObservedData)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutGroupDefaults)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSpecies)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulation)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingMode)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultLipoName)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultFuName)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSolName)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulationAnalysis)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultChartYScale)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultParameterGroupingModePISA.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingMode)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemParameterGroupingModePISA)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultPopulationAnalysis.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbDefaultSpecies.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultSpecies)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDefaultPopulationAnalysis)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutGroupParameterLayout)).EndInit();
          this.ResumeLayout(false);
 
         }
@@ -1018,7 +1056,6 @@ namespace PKSim.UI.Views
         private DevExpress.XtraLayout.LayoutControlItem layoutItemDefaultSpecies;
         private DevExpress.XtraLayout.LayoutControlItem layoutItemDefaultPopulation;
         private OSPSuite.UI.Controls.UxComboBoxEdit cbDefaultParameterGroupingMode;
-        private DevExpress.XtraLayout.LayoutControlItem layoutItemParameterGroupingMode;
         private OSPSuite.UI.Controls.UxComboBoxEdit cbIconSizeContextMenu;
         private DevExpress.XtraLayout.LayoutControlItem layoutItemIconSizeContextMenu;
         private DevExpress.XtraEditors.TextEdit tbRelTol;
@@ -1051,5 +1088,9 @@ namespace PKSim.UI.Views
       private DevExpress.XtraLayout.LayoutControlItem layoutItemColorGroupObservedData;
       private UxComboBoxEdit cbTemplateReferenceBehavior;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemTemplateRefBehavior;
+      private DevExpress.XtraEditors.ComboBoxEdit cbDefaultParameterGroupingModePISA;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemParameterGroupingMode;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemParameterGroupingModePISA;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutGroupParameterLayout;
    }
 }

--- a/src/PKSim.UI/Views/UserSettingsView.Designer.cs
+++ b/src/PKSim.UI/Views/UserSettingsView.Designer.cs
@@ -216,7 +216,6 @@ namespace PKSim.UI.Views
          this.layoutControlUserConfig.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControlUserConfig.Location = new System.Drawing.Point(0, 0);
          this.layoutControlUserConfig.Name = "layoutControlUserConfig";
-         this.layoutControlUserConfig.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1315, 438, 1546, 803);
          this.layoutControlUserConfig.OptionsView.UseSkinIndents = false;
          this.layoutControlUserConfig.Root = this.layoutControlGroup;
          this.layoutControlUserConfig.Size = new System.Drawing.Size(640, 623);

--- a/src/PKSim.UI/Views/UserSettingsView.cs
+++ b/src/PKSim.UI/Views/UserSettingsView.cs
@@ -94,6 +94,11 @@ namespace PKSim.UI.Views
             .WithValues(x => _presenter.AllParameterGroupingMode())
             .AndDisplays(x => _presenter.AllParameterGroupingModeDisplay());
 
+         _screenBinder.Bind(x => x.DefaultParameterGroupingModeForPIAndSA)
+            .To(cbDefaultParameterGroupingModePISA)
+            .WithValues(x => _presenter.AllParameterGroupingMode())
+            .AndDisplays(x => _presenter.AllParameterGroupingModeDisplay());
+
          _screenBinder.Bind(x => x.AbsTol).To(tbAbsTol);
          _screenBinder.Bind(x => x.RelTol).To(tbRelTol);
          _screenBinder.Bind(x => x.NumberOfBins).To(tbNumberOfBins);
@@ -186,7 +191,9 @@ namespace PKSim.UI.Views
          layoutItemChangedColor.Text = PKSimConstants.UI.ChangedColor.FormatForLabel();
          layoutItemDefaultSpecies.Text = PKSimConstants.UI.DefaultSpecies.FormatForLabel();
          layoutItemDefaultPopulation.Text = PKSimConstants.UI.DefaultPopulation.FormatForLabel();
-         layoutItemParameterGroupingMode.Text = PKSimConstants.UI.DefaultParameterGroupLayout.FormatForLabel();
+         layoutItemParameterGroupingMode.Text = PKSimConstants.UI.ForOthers.FormatForLabel();
+         layoutItemParameterGroupingModePISA.Text = PKSimConstants.UI.ForParameterIdentificationAndSensitivityAnalysis.FormatForLabel();
+         layoutGroupParameterLayout.Text = PKSimConstants.UI.ParameterLayout;
          layoutItemDefaultLipoName.Text = PKSimConstants.UI.DefaultLipophilicityName.FormatForLabel();
          layoutItemDefaultFuName.Text = PKSimConstants.UI.DefaultFractionUnboundName.FormatForLabel();
          layoutItemDefaultSolName.Text = PKSimConstants.UI.DefaultSolubilityName.FormatForLabel();

--- a/src/PKSim.UI/Views/UserSettingsView.cs
+++ b/src/PKSim.UI/Views/UserSettingsView.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
 using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Extensions;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
@@ -91,13 +93,13 @@ namespace PKSim.UI.Views
 
          _screenBinder.Bind(x => x.DefaultParameterGroupingMode)
             .To(cbDefaultParameterGroupingMode)
-            .WithValues(x => _presenter.AllParameterGroupingMode())
-            .AndDisplays(x => _presenter.AllParameterGroupingModeDisplay());
+            .WithValues(x => allModes().Select(mode => mode.Id))
+            .AndDisplays(x => allModes().Select(mode => mode.DisplayName));
 
          _screenBinder.Bind(x => x.DefaultParameterGroupingModeForPIAndSA)
             .To(cbDefaultParameterGroupingModePISA)
-            .WithValues(x => _presenter.AllParameterGroupingMode())
-            .AndDisplays(x => _presenter.AllParameterGroupingModeDisplay());
+            .WithValues(x => allModesForPIAndSA().Select(mode => mode.Id))
+            .AndDisplays(x => allModesForPIAndSA().Select(mode => mode.DisplayName));
 
          _screenBinder.Bind(x => x.AbsTol).To(tbAbsTol);
          _screenBinder.Bind(x => x.RelTol).To(tbRelTol);
@@ -140,6 +142,16 @@ namespace PKSim.UI.Views
          _screenBinder.Changed += NotifyViewChanged;
 
          tbTemplateDatabase.ButtonClick += (o, e) => OnEvent(() => templateDatabaseButtonClick(o, e));
+      }
+
+      private IReadOnlyList<ParameterGroupingModeForParameterAnalyzable> allModesForPIAndSA()
+      {
+         return _presenter.AllParameterGroupingModeForPIAndSA();
+      }
+
+      private IReadOnlyList<ParameterGroupingMode> allModes()
+      {
+         return _presenter.AllParameterGroupingMode();
       }
 
       private void templateDatabaseButtonClick(object sender, ButtonPressedEventArgs e)
@@ -193,7 +205,7 @@ namespace PKSim.UI.Views
          layoutItemDefaultPopulation.Text = PKSimConstants.UI.DefaultPopulation.FormatForLabel();
          layoutItemParameterGroupingMode.Text = PKSimConstants.UI.ForOthers.FormatForLabel();
          layoutItemParameterGroupingModePISA.Text = PKSimConstants.UI.ForParameterIdentificationAndSensitivityAnalysis.FormatForLabel();
-         layoutGroupParameterLayout.Text = PKSimConstants.UI.ParameterLayout;
+         layoutGroupParameterLayout.Text = PKSimConstants.UI.ParameterView;
          layoutItemDefaultLipoName.Text = PKSimConstants.UI.DefaultLipophilicityName.FormatForLabel();
          layoutItemDefaultFuName.Text = PKSimConstants.UI.DefaultFractionUnboundName.FormatForLabel();
          layoutItemDefaultSolName.Text = PKSimConstants.UI.DefaultSolubilityName.FormatForLabel();

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -72,14 +72,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.3.1" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.3.12" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.FuncParser.Ubuntu22" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.FuncParser.MacOS.Arm64" Version="4.0.0.73" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.R" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.R" Version="12.3.12" />
     <PackageReference Include="OSPSuite.SimModel.Ubuntu22" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel.MacOS.Arm64" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES.Ubuntu22" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
@@ -76,18 +76,11 @@ namespace PKSim.Core
       [Observation]
       public void should_return_the_grouping_mode_from_the_user_settings_for_simple_or_advanced()
       {
-         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Advanced;
-         sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Advanced);
+         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeIdForParameterAnalyzable.Advanced;
+         sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModesForParameterAnalyzable.Advanced);
 
-         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Simple;
-         sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Simple);
-      }
-
-      [Observation]
-      public void should_return_simple_if_the_default_selection_is_hierarchical()
-      {
-         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Hierarchical;
-         sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Simple);
+         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeIdForParameterAnalyzable.Simple;
+         sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModesForParameterAnalyzable.Simple);
       }
    }
 }

--- a/tests/PKSim.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
@@ -76,17 +76,17 @@ namespace PKSim.Core
       [Observation]
       public void should_return_the_grouping_mode_from_the_user_settings_for_simple_or_advanced()
       {
-         _userSettings.DefaultParameterGroupingMode = ParameterGroupingModeId.Advanced;
+         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Advanced;
          sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Advanced);
 
-         _userSettings.DefaultParameterGroupingMode = ParameterGroupingModeId.Simple;
+         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Simple;
          sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Simple);
       }
 
       [Observation]
       public void should_return_simple_if_the_default_selection_is_hierarchical()
       {
-         _userSettings.DefaultParameterGroupingMode = ParameterGroupingModeId.Hierarchical;
+         _userSettings.DefaultParameterGroupingModeForPIAndSA = ParameterGroupingModeId.Hierarchical;
          sut.DefaultParameterSelectionMode.ShouldBeEqualTo(ParameterGroupingModes.Simple);
       }
    }

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+    <PackageReference Include="OSPSuite.Core" Version="12.3.12" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/Presentation/ParameterGroupsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ParameterGroupsPresenterSpecs.cs
@@ -82,7 +82,7 @@ namespace PKSim.Presentation
       protected void CreateSutForSettings(ParameterGroupingModeId parameterGroupingModeId)
       {
          A.CallTo(() => _userSettings.DefaultParameterGroupingMode).Returns(parameterGroupingModeId);
-         var settings = new ParameterGroupsPresenterSettings {DefaultParameterGroupingModeId = parameterGroupingModeId};
+         var settings = new ParameterGroupsPresenterSettings();
 
          A.CallTo(_presenterSettingsTask).WithReturnType<ParameterGroupsPresenterSettings>().Returns(settings);
 

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -24,11 +24,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="12.3.1" />
+		<PackageReference Include="OSPSuite.Assets" Version="12.3.12" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="12.3.1" />
+		<PackageReference Include="OSPSuite.Core" Version="12.3.12" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" />
-		<PackageReference Include="OSPSuite.UI" Version="12.3.1" />
+		<PackageReference Include="OSPSuite.UI" Version="12.3.12" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
Fixes #2881

# Description
Add a new user setting for parameter layout grouping for PI and SA. Remove subject-cached settings for parameter layout

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="677" height="485" alt="image" src="https://github.com/user-attachments/assets/ba61345b-cd7e-48f5-8b5f-ee1a5cf27ece" />

# Questions (if appropriate):