### PR TITLE
#3014 multiple dose application naming

### DIFF
--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -149,7 +149,7 @@ namespace PKSim.Core.Services
          eventGroup.SourceCriteria.Add(new MatchTagCondition(CoreConstants.Tags.EVENTS));
 
          var schemaItems = _schemaItemsMapper.MapFrom(protocol).ToList();
-         var width = System.Math.Max(3, schemaItems.Count.ToString().Length);
+         var width = schemaItems.Count.ToString().Length;
 
          schemaItems.Each((schemaItem, index) =>
          {

--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -148,10 +148,13 @@ namespace PKSim.Core.Services
 
          eventGroup.SourceCriteria.Add(new MatchTagCondition(CoreConstants.Tags.EVENTS));
 
-         _schemaItemsMapper.MapFrom(protocol).Each((schemaItem, index) =>
+         var schemaItems = _schemaItemsMapper.MapFrom(protocol).ToList();
+         var width = System.Math.Max(3, schemaItems.Count.ToString().Length);
+
+         schemaItems.Each((schemaItem, index) =>
          {
-            //+1 to start at 1 for the nomenclature
-            var applicationName = $"{CoreConstants.APPLICATION_NAME_TEMPLATE}{index + 1}";
+            var number = (index + 1).ToString($"D{width}");
+            var applicationName = $"{CoreConstants.APPLICATION_NAME_TEMPLATE}{number}";
             addApplication(eventGroup, schemaItem, applicationName, compoundProperties, protocol);
          });
 


### PR DESCRIPTION
Fixes #3014

# Description

When creating multiple dose application and exporting it to MoBi, the index in the naming does not have the same amount of numbers, leading to confusing order.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="485" height="777" alt="image" src="https://github.com/user-attachments/assets/0ce640d9-9af2-4c28-88ce-f1d303212090" />


# Questions (if appropriate):