### PR TITLE
Fixes #1312 Allow Import/Export of BuildingBlocks to snapshot in "standard" mode

### DIFF
--- a/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockContextMenu.cs
@@ -6,7 +6,6 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Utility.Container;
 using PKSim.Assets;
 using PKSim.Core.Model;
-using PKSim.Core.Services;
 using PKSim.Presentation.UICommands;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
@@ -16,7 +15,6 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       protected BuildingBlockContextMenu(TBuildingBlock buildingBlock, IContainer container)
          : base(buildingBlock, container)
       {
-         
       }
 
       protected virtual IEnumerable<IMenuBarItem> AllStandardMenuItemsFor<TCommand>(TBuildingBlock buildingBlock) where TCommand : IEditBuildingBlockUICommand<TBuildingBlock>
@@ -47,8 +45,6 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          yield return ParameterValueDebugMenuFor(buildingBlock)
             .AsGroupStarter();
 
-         yield return ExportSnapshotMenuFor(buildingBlock);
-
          yield return ExportMarkdownMenuFor(buildingBlock);
       }
 
@@ -56,6 +52,8 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       {
          yield return SaveAsUserTemplateMenuFor(buildingBlock)
             .AsGroupStarter();
+
+         yield return ExportSnapshotMenuFor(buildingBlock);
 
          yield return SaveAsSystemTemplateMenuFor(buildingBlock);
 
@@ -108,14 +106,14 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       protected IMenuBarItem SaveAsUserTemplateMenuFor(TBuildingBlock buildingBlock)
       {
          return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.SaveAsTemplate)
-            .WithCommandFor<SaveBuildingBlockAsTemplateCommand<TBuildingBlock>, IReadOnlyList<TBuildingBlock>>(new[] {buildingBlock,}, _container)
+            .WithCommandFor<SaveBuildingBlockAsTemplateCommand<TBuildingBlock>, IReadOnlyList<TBuildingBlock>>(new[] { buildingBlock, }, _container)
             .WithIcon(ApplicationIcons.SaveAsTemplate);
       }
 
       protected IMenuBarItem SaveAsSystemTemplateMenuFor(TBuildingBlock buildingBlock)
       {
          return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.SaveAsSystemTemplate)
-            .WithCommandFor<SaveBuildingBlockAsSystemTemplateCommand<TBuildingBlock>, IReadOnlyList<TBuildingBlock>>(new[] {buildingBlock,}, _container)
+            .WithCommandFor<SaveBuildingBlockAsSystemTemplateCommand<TBuildingBlock>, IReadOnlyList<TBuildingBlock>>(new[] { buildingBlock, }, _container)
             .WithIcon(ApplicationIcons.SaveAsTemplate)
             .ForDeveloper();
       }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileContextMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
@@ -22,25 +23,16 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       {
          var allMenuItems = new List<IMenuBarItem>();
          allMenuItems.AddRange(EditContextMenusFor<EditExpressionProfileCommand>(expressionProfile));
-         allMenuItems.AddRange(extendedExportMenus(expressionProfile));
+         allMenuItems.AddRange(ExportContextMenusFor(expressionProfile));
          allMenuItems.AddRange(DeleteContextMenusFor(expressionProfile));
          allMenuItems.AddRange(DebugContextMenusFor(expressionProfile));
          return allMenuItems;
       }
 
-      private IEnumerable<IMenuBarItem> extendedExportMenus(ExpressionProfile expressionProfile)
-      {
-         yield return SaveAsUserTemplateMenuFor(expressionProfile)
-            .AsGroupStarter();
+      protected override IEnumerable<IMenuBarItem> ExportContextMenusFor(ExpressionProfile expressionProfile) =>
+         base.ExportContextMenusFor(expressionProfile).Concat(new[] { exportToPkml(expressionProfile) });
 
-         yield return SaveAsSystemTemplateMenuFor(expressionProfile);
-
-         yield return AddToJournalMenuFor(expressionProfile);
-
-         yield return ExportToPkml(expressionProfile);
-      }
-
-      private IMenuBarItem ExportToPkml(ExpressionProfile expressionProfile)
+      private IMenuBarItem exportToPkml(ExpressionProfile expressionProfile)
       {
          return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.ExportToPKML)
             .WithCommandFor<ExportExpressionProfileToPKMLCommand, ExpressionProfile>(expressionProfile, _container)
@@ -57,9 +49,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          _container = container;
       }
 
-      public override IContextMenu CreateFor(ExpressionProfile expressionProfile, IPresenterWithContextMenu<ITreeNode> presenter)
-      {
-         return new ExpressionProfileContextMenu(expressionProfile, _container);
-      }
+      public override IContextMenu CreateFor(ExpressionProfile expressionProfile, IPresenterWithContextMenu<ITreeNode> presenter) =>
+         new ExpressionProfileContextMenu(expressionProfile, _container);
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/GenericMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/GenericMenu.cs
@@ -1,14 +1,13 @@
-﻿using PKSim.Assets;
-using OSPSuite.Presentation.MenuAndBars;
-using PKSim.Presentation.UICommands;
+﻿using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.UICommands;
-using OSPSuite.Assets;
+using PKSim.Assets;
 using PKSim.Core.Model;
+using PKSim.Presentation.UICommands;
 using IContainer = OSPSuite.Utility.Container.IContainer;
-using System.ComponentModel;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
@@ -21,13 +20,11 @@ namespace PKSim.Presentation.Presenters.ContextMenus
             .WithCommandFor<EditDescriptionUICommand, IObjectBase>(objectBase, container);
       }
 
-    
       public static IMenuBarItem ExportSnapshotMenuFor<T>(T objectToExport, IContainer container) where T : class, IObjectBase
       {
-         return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.AsDeveloperOnly("Save Snapshot"))
+         return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.ExportSnapshot)
             .WithCommandFor<ExportSnapshotUICommand<T>, T>(objectToExport, container)
-            .WithIcon(ApplicationIcons.SnapshotExport)
-            .ForDeveloper();        
+            .WithIcon(ApplicationIcons.SnapshotExport);
       }
 
       public static IMenuBarItem ExportMarkdownMenuFor<T>(T objectToExport, IContainer container) where T : class, IObjectBase
@@ -35,15 +32,14 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.AsDeveloperOnly("Save Markdown"))
             .WithCommandFor<ExportMarkdownUICommand<T>, T>(objectToExport, container)
 //            .WithIcon(ApplicationIcons.SnapshotExport)
-            .ForDeveloper();        
-      }
-    
-      public static IMenuBarItem LoadBuildingBlockFromSnapshot<T>(IContainer container) where T:class, IPKSimBuildingBlock
-      {
-         return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.AsDeveloperOnly("Load from Snapshot"))
-            .WithCommand<LoadBuildingBlockFromSnapshotUICommand<T>>(container)
-            .WithIcon(ApplicationIcons.SnapshotImport)
             .ForDeveloper();
+      }
+
+      public static IMenuBarItem LoadBuildingBlockFromSnapshot<T>(IContainer container) where T : class, IPKSimBuildingBlock
+      {
+         return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.LoadFromSnapshot)
+            .WithCommand<LoadBuildingBlockFromSnapshotUICommand<T>>(container)
+            .WithIcon(ApplicationIcons.SnapshotImport);
       }
 
       public static IMenuBarItem EditMenuFor<TCommand, T>(T objectToEdit, IContainer container) where T : class where TCommand : IObjectUICommand<T>

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ObservedDataFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ObservedDataFolderContextMenu.cs
@@ -1,21 +1,20 @@
 using System.Linq;
-using PKSim.Assets;
+using OSPSuite.Assets;
+using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Nodes;
+using OSPSuite.Presentation.Repositories;
+using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Presenters.Main;
 using PKSim.Presentation.UICommands;
-using OSPSuite.Presentation.Core;
-using OSPSuite.Presentation.Presenters;
-using OSPSuite.Presentation.Presenters.ContextMenus;
-using OSPSuite.Presentation.Presenters.Nodes;
-using OSPSuite.Presentation.Repositories;
-using OSPSuite.Assets;
-using System;
-using OSPSuite.Utility.Container;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
@@ -38,14 +37,14 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          foreach (var compound in allCompounds)
          {
             addObservedDataFor.AddItem(CreateMenuButton.WithCaption(compound.Name)
-               .WithCommandFor<AddObservedDataForCompoundUICommand, Compound>(compound, container));  
+               .WithCommandFor<AddObservedDataForCompoundUICommand, Compound>(compound, container));
          }
 
          _view.AddMenuItem(repository[MenuBarItemIds.AddObservedData]);
          if (allCompounds.Any())
             _view.AddMenuItem(addObservedDataFor);
 
-         if ( treeNode.HasChildren) 
+         if (treeNode.HasChildren)
             _view.AddMenuItem(ObservedDataClassificationCommonContextMenuItems.ColorGroupObservedData(userSettings));
 
 
@@ -54,11 +53,10 @@ namespace PKSim.Presentation.Presenters.ContextMenus
             .WithIcon(ApplicationIcons.LoadFromTemplate)
             .AsGroupStarter());
 
-         _view.AddMenuItem(CreateMenuButton.WithCaption(PKSimConstants.MenuNames.AsDeveloperOnly("Load from Snapshot"))
+         _view.AddMenuItem(CreateMenuButton.WithCaption(PKSimConstants.MenuNames.LoadFromSnapshot)
             .WithCommand<LoadObservedDataFromSnapshotUICommand>(container)
-            .WithIcon(ApplicationIcons.SnapshotImport)
-            .ForDeveloper());
-           
+            .WithIcon(ApplicationIcons.SnapshotImport));
+
 
          if (treeNode.AllLeafNodes.OfType<ObservedDataNode>().Any())
             _view.AddMenuItem(ObservedDataClassificationCommonContextMenuItems.EditMultipleMetaData(treeNode, container).AsGroupStarter());


### PR DESCRIPTION
Fixes #1312 

# Description
Removed Developer only status from building block snapshot save and load

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):