### PR TITLE
Fixes #3394 Add registration for OSPSuite.Core.ICoreUserSettings in P…

### DIFF
--- a/src/PKSim.R/Bootstrap/ApplicationStartup.cs
+++ b/src/PKSim.R/Bootstrap/ApplicationStartup.cs
@@ -70,7 +70,7 @@ namespace PKSim.R.Bootstrap
       private void registerMinimalImplementations(IContainer container)
       {
          container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
-         container.Register<ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
+         container.Register<OSPSuite.Core.ICoreUserSettings, ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
          container.Register<IProgressUpdater, NoneProgressUpdater>();
          container.Register<IOntogenyTask, CLIIndividualOntogenyTask>();
       }

--- a/tests/PKSim.R.Tests/ContextForStaticIntegration.cs
+++ b/tests/PKSim.R.Tests/ContextForStaticIntegration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using NUnit.Framework;
+using OSPSuite.BDDHelper;
+
+namespace PKSim.R;
+
+[IntegrationTests]
+[Category("R")]
+public abstract class ContextForStaticIntegration : StaticContextSpecification
+{
+   public override void GlobalContext()
+   {
+      base.GlobalContext();
+      Api.InitializeOnce();
+
+      Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+   }
+}

--- a/tests/PKSim.R.Tests/Data/Atazanavir-Model_1Sim.json
+++ b/tests/PKSim.R.Tests/Data/Atazanavir-Model_1Sim.json
@@ -1,0 +1,98 @@
+{
+  "Version": 76,
+  "Individuals": [
+    {
+      "Name": "Acosta2007",
+      "Seed": 8908561,
+      "OriginData": {
+        "CalculationMethods": [
+          "SurfaceAreaPlsInt_VAR1",
+          "Body surface area - Mosteller"
+        ],
+        "Species": "Human",
+        "Population": "WhiteAmerican_NHANES_1997",
+        "Gender": "MALE",
+        "Age": {
+          "Value": 34.0,
+          "Unit": "year(s)"
+        },
+        "Weight": {
+          "Value": 78.0,
+          "Unit": "kg"
+        }
+      },
+      "Molecules": [
+        {
+          "Name": "CYP3A4",
+          "Type": "Enzyme",
+          "MembraneLocation": "Apical",
+          "TissueLocation": "Intracellular",
+          "IntracellularVascularEndoLocation": "Endosomal",
+          "Expression": [
+            {
+              "Name": "Brain",
+              "Value": 0.0041682898325
+            },
+            {
+              "Name": "Gonads",
+              "Value": 0.00078691079081
+            },
+            {
+              "Name": "Kidney",
+              "Value": 0.0053603428126
+            },
+            {
+              "Name": "Periportal",
+              "Value": 1.0
+            },
+            {
+              "Name": "Pericentral",
+              "Value": 1.0
+            },
+            {
+              "Name": "Lung",
+              "Value": 0.00042695753798
+            },
+            {
+              "Name": "SmallIntestine",
+              "Value": 0.0727697702
+            },
+            {
+              "Name": "Duodenum",
+              "Value": 0.0727697702
+            },
+            {
+              "Name": "UpperJejunum",
+              "Value": 0.0727697702
+            },
+            {
+              "Name": "LowerJejunum",
+              "Value": 0.0727697702
+            },
+            {
+              "Name": "UpperIleum",
+              "Value": 0.0727697702
+            },
+            {
+              "Name": "LowerIleum",
+              "Value": 0.0727697702
+            }
+          ],
+          "Ontogeny": {
+            "Name": "CYP3A4"
+          },
+          "Parameters": [
+            {
+              "Name": "t1/2 (liver)",
+              "Value": 22.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/PKSim.R.Tests/DomainHelperForSpecs.cs
+++ b/tests/PKSim.R.Tests/DomainHelperForSpecs.cs
@@ -5,7 +5,6 @@ namespace PKSim.R;
 
 internal static class DomainHelperForSpecs
 {
-   // Borrowing test data from PKSim.Tests
    private static readonly string _pathToData = "..\\..\\..\\Data\\";
 
    public static string DataFilePathFor(string fileNameWithExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _pathToData, fileNameWithExtension);

--- a/tests/PKSim.R.Tests/DomainHelperForSpecs.cs
+++ b/tests/PKSim.R.Tests/DomainHelperForSpecs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.IO;
+
+namespace PKSim.R;
+
+internal static class DomainHelperForSpecs
+{
+   // Borrowing test data from PKSim.Tests
+   private static readonly string _pathToData = "..\\..\\..\\Data\\";
+
+   public static string DataFilePathFor(string fileNameWithExtension) => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _pathToData, fileNameWithExtension);
+}

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Data\" />
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/RunSnapshotSpecs.cs
+++ b/tests/PKSim.R.Tests/RunSnapshotSpecs.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.CLI.Core.RunOptions;
+using OSPSuite.CLI.Core.Services;
+using OSPSuite.Utility;
+using System.IO;
+
+namespace PKSim.R;
+
+internal class RunSnapshotSpecs : ContextForStaticIntegration
+{
+   private readonly string _inputFolder = @"C:\Input\";
+   private readonly string _outputFolder = @"C:\Output\";
+
+   protected override void Context()
+   {
+      base.Context();
+      var runOptions = new SnapshotRunOptions
+      {
+         InputFolder = _inputFolder,
+         OutputFolder = _outputFolder,
+         ExportMode = SnapshotExportMode.Project
+      };
+
+      DirectoryHelper.CreateDirectory(_inputFolder);
+      FileHelper.Copy(DomainHelperForSpecs.DataFilePathFor("Atazanavir-Model_1Sim.json"), Path.Join(_inputFolder, "Atazanavir-Model_1Sim.json"));
+
+      Api.RunSnapshot(runOptions);
+   }
+
+   [Observation]
+   public void the_output_folder_contains_one_pksim5_file()
+   {
+      Directory.Exists(_outputFolder).ShouldBeTrue();
+      File.Exists(Path.Join(_outputFolder, "Atazanavir-Model_1Sim.pksim5"));
+   }
+
+   public override void Cleanup()
+   {
+      base.Cleanup();
+      DirectoryHelper.DeleteDirectory(_outputFolder, true);
+      DirectoryHelper.DeleteDirectory(_inputFolder, true);
+   }
+}

--- a/tests/PKSim.R.Tests/RunSnapshotSpecs.cs
+++ b/tests/PKSim.R.Tests/RunSnapshotSpecs.cs
@@ -33,7 +33,7 @@ internal class RunSnapshotSpecs : ContextForStaticIntegration
    public void the_output_folder_contains_one_pksim5_file()
    {
       Directory.Exists(_outputFolder).ShouldBeTrue();
-      File.Exists(Path.Join(_outputFolder, "Atazanavir-Model_1Sim.pksim5"));
+      File.Exists(Path.Join(_outputFolder, "Atazanavir-Model_1Sim.pksim5")).ShouldBeTrue();
    }
 
    public override void Cleanup()


### PR DESCRIPTION
Fixes #3394

# Description
Adding registration for `OSPSuite.Core.ICoreUserSettings` as required

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test infrastructure for R with new test context, helpers, and specs validating snapshot export and cleanup.

* **Chores**
  * Added sample simulation data and a Data project folder for test fixtures.

* **Refactor**
  * Adjusted startup service registration to align internal wiring (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->