### PR TITLE
3417-unnecessary-project-has-changed-save-changes-prompt

### DIFF
--- a/src/PKSim.Presentation/Core/IApplicationIdleScheduler.cs
+++ b/src/PKSim.Presentation/Core/IApplicationIdleScheduler.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace PKSim.Presentation.Core
+{
+   /// <summary>
+   ///    Schedules an action to run once the application message queue is fully drained.
+   ///    Abstraction over <c>Application.Idle</c> so the platform-neutral Presentation layer
+   ///    does not need a WinForms reference.
+   /// </summary>
+   public interface IApplicationIdleScheduler
+   {
+      void ScheduleOnIdle(Action action);
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Charts/SimulationTimeProfileChartPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Charts/SimulationTimeProfileChartPresenter.cs
@@ -35,6 +35,8 @@ namespace PKSim.Presentation.Presenters.Charts
       ISimulationAnalysisPresenter<IndividualSimulation>
 
    {
+      private bool _isInitializing;
+
       public SimulationTimeProfileChartPresenter(ISimulationTimeProfileChartView view, ChartPresenterContext chartPresenterContext,
          IIndividualPKAnalysisPresenter pkAnalysisPresenter, IChartTask chartTask, IObservedDataTask observedDataTask,
          IChartTemplatingTask chartTemplatingTask,
@@ -63,6 +65,9 @@ namespace PKSim.Presentation.Presenters.Charts
 
       protected override void NotifyProjectChanged()
       {
+         if (_isInitializing)
+            return;
+
          base.NotifyProjectChanged();
          if (Simulation != null)
             Simulation.HasChanged = true;
@@ -76,8 +81,16 @@ namespace PKSim.Presentation.Presenters.Charts
 
       public void InitializeAnalysis(ISimulationAnalysis simulationAnalysis, IAnalysable analysable)
       {
-         base.InitializeAnalysis(simulationAnalysis.DowncastTo<SimulationTimeProfileChart>());
-         UpdateAnalysisBasedOn(analysable);
+         try
+         {
+            _isInitializing = true;
+            base.InitializeAnalysis(simulationAnalysis.DowncastTo<SimulationTimeProfileChart>());
+            UpdateAnalysisBasedOn(analysable);
+         }
+         finally
+         {
+            _isInitializing = false;
+         }
       }
 
       public void UpdateAnalysisBasedOn(IAnalysable analysable)

--- a/src/PKSim.Presentation/Services/SimulationTask.cs
+++ b/src/PKSim.Presentation/Services/SimulationTask.cs
@@ -5,6 +5,7 @@ using PKSim.Core;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
+using PKSim.Presentation.Core;
 using PKSim.Presentation.Presenters.Simulations;
 using OSPSuite.Core.Comparison;
 using OSPSuite.Core.Domain;
@@ -62,21 +63,52 @@ namespace PKSim.Presentation.Services
       private readonly IConfigureSimulationTask _configureSimulationTask;
       private readonly IBuildingBlockParametersToSimulationUpdater _blockParametersToSimulationUpdater;
       private readonly ISimulationParametersToBuildingBlockUpdater _simulationParametersToBlockUpdater;
+      private readonly IApplicationIdleScheduler _idleScheduler;
 
       public SimulationTask(
-         IExecutionContext executionContext, 
-         IBuildingBlockTask buildingBlockTask, 
+         IExecutionContext executionContext,
+         IBuildingBlockTask buildingBlockTask,
          IApplicationController applicationController,
-         ISimulationBuildingBlockUpdater simulationBuildingBlockUpdater, 
+         ISimulationBuildingBlockUpdater simulationBuildingBlockUpdater,
          IConfigureSimulationTask configureSimulationTask,
-         IBuildingBlockParametersToSimulationUpdater blockParametersToSimulationUpdater, 
-         ISimulationParametersToBuildingBlockUpdater simulationParametersToBlockUpdater)
+         IBuildingBlockParametersToSimulationUpdater blockParametersToSimulationUpdater,
+         ISimulationParametersToBuildingBlockUpdater simulationParametersToBlockUpdater,
+         IApplicationIdleScheduler idleScheduler)
          : base(executionContext, buildingBlockTask, applicationController, PKSimBuildingBlockType.Simulation)
       {
          _simulationBuildingBlockUpdater = simulationBuildingBlockUpdater;
          _configureSimulationTask = configureSimulationTask;
          _blockParametersToSimulationUpdater = blockParametersToSimulationUpdater;
          _simulationParametersToBlockUpdater = simulationParametersToBlockUpdater;
+         _idleScheduler = idleScheduler;
+      }
+
+      public override void Edit(Simulation simulation)
+      {
+         var projectWasChanged = _executionContext.CurrentProject.HasChanged;
+         base.Edit(simulation);
+         _executionContext.CurrentProject.HasChanged = projectWasChanged;
+
+         // Opening a simulation causes grids in non-visible tabs to fire column-width events
+         // late (when Windows finally paints them), falsely marking the project as changed.
+         // The restore above catches events that fire immediately; this catches the late ones.
+         // Only needed when the project was originally clean.
+         if (!projectWasChanged)
+            scheduleResetProjectChangedFlag();
+      }
+
+      private void scheduleResetProjectChangedFlag()
+      {
+         var project = _executionContext.CurrentProject;
+
+         // ScheduleOnIdle fires when Windows has nothing left to do — all pending events
+         // (including those late-firing grid events) have already been processed by then.
+         // Guard against a project switch that may have happened in the meantime.
+         _idleScheduler.ScheduleOnIdle(() =>
+         {
+            if (ReferenceEquals(_executionContext.CurrentProject, project))
+               project.HasChanged = false;
+         });
       }
 
       public override Simulation AddToProject()

--- a/src/PKSim.UI/ApplicationIdleScheduler.cs
+++ b/src/PKSim.UI/ApplicationIdleScheduler.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Forms;
+using PKSim.Presentation.Core;
+
+namespace PKSim.UI
+{
+   /// <summary>
+   ///    WinForms implementation: schedules an action via <c>Application.Idle</c>, which
+   ///    fires once after the Windows message queue is completely drained — the earliest safe
+   ///    moment to clear flags set by deferred DevExpress grid-paint events.
+   /// </summary>
+   public class ApplicationIdleScheduler : IApplicationIdleScheduler
+   {
+      public void ScheduleOnIdle(Action action)
+      {
+         EventHandler handler = null;
+         handler = (sender, args) =>
+         {
+            Application.Idle -= handler;
+            action();
+         };
+         Application.Idle += handler;
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationTaskSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
@@ -11,6 +12,7 @@ using PKSim.Core.Commands;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
+using PKSim.Presentation.Core;
 using PKSim.Presentation.Presenters.Simulations;
 using PKSim.Presentation.Services;
 
@@ -25,6 +27,7 @@ namespace PKSim.Presentation
       protected IConfigureSimulationTask _configureSimulationTask;
       protected ISimulationResultsImportTask _simulationResultsImportTask;
       protected IApplicationController _applicationController;
+      protected IApplicationIdleScheduler _idleScheduler;
       private ISimulationParametersToBuildingBlockUpdater _simulationParametersToBlockUpdater;
       protected IBuildingBlockParametersToSimulationUpdater _blockParametersToSimulationUpdater;
 
@@ -38,9 +41,10 @@ namespace PKSim.Presentation
          _applicationController = A.Fake<IApplicationController>();
          _simulationParametersToBlockUpdater = A.Fake<ISimulationParametersToBuildingBlockUpdater>();
          _blockParametersToSimulationUpdater = A.Fake<IBuildingBlockParametersToSimulationUpdater>();
+         _idleScheduler = A.Fake<IApplicationIdleScheduler>();
          A.CallTo(() => _applicationController.Start<ICreateSimulationPresenter>()).Returns(_createSimulationPresenter);
          sut = new SimulationTask(_executionContext, _buildingBlockTask, _applicationController, _simulationBuildingBlockUpdater,
-            _configureSimulationTask, _blockParametersToSimulationUpdater, _simulationParametersToBlockUpdater);
+            _configureSimulationTask, _blockParametersToSimulationUpdater, _simulationParametersToBlockUpdater, _idleScheduler);
       }
    }
 
@@ -310,6 +314,170 @@ namespace PKSim.Presentation
       public void should_throw_an_exception()
       {
          The.Action(() => sut.ShowDifferencesBetween(_templateBuildingBlock, _usedBuildingBlock, _simulation)).ShouldThrowAn<PKSimException>();
+      }
+   }
+
+   public class When_editing_an_unchanged_project_simulation_but_chart_initialization_marks_project_as_changed : concern_for_SimulationTask
+   {
+      private IndividualSimulation _simulation;
+      private PKSimProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IndividualSimulation>();
+         _project = new PKSimProject();
+         A.CallTo(() => _executionContext.CurrentProject).Returns(_project);
+
+         // Simulate DevExpress column-settings events firing during base.Edit() and setting HasChanged
+         A.CallTo(() => _buildingBlockTask.Edit(_simulation)).Invokes(_ => _project.HasChanged = true);
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_simulation);
+      }
+
+      [Observation]
+      public void should_restore_project_changed_flag_to_false()
+      {
+         _project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_editing_a_simulation_for_a_project_that_was_already_changed : concern_for_SimulationTask
+   {
+      private IndividualSimulation _simulation;
+      private PKSimProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IndividualSimulation>();
+         _project = new PKSimProject();
+         _project.HasChanged = true;
+         A.CallTo(() => _executionContext.CurrentProject).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_simulation);
+      }
+
+      [Observation]
+      public void project_should_remain_changed()
+      {
+         _project.HasChanged.ShouldBeTrue();
+      }
+   }
+
+   // The following tests use a captured idle action so they can fire it manually
+   // without needing a real Windows message loop.
+
+   internal abstract class concern_for_SimulationTask_with_controllable_idle : ContextSpecification<ISimulationTask>
+   {
+      protected IExecutionContext _executionContext;
+      protected IBuildingBlockTask _buildingBlockTask;
+      protected IApplicationIdleScheduler _idleScheduler;
+      protected PKSimProject _project;
+      protected Action _capturedIdleAction;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _buildingBlockTask = A.Fake<IBuildingBlockTask>();
+         _idleScheduler = A.Fake<IApplicationIdleScheduler>();
+         _project = new PKSimProject();
+
+         A.CallTo(() => _executionContext.CurrentProject).Returns(_project);
+         A.CallTo(() => _idleScheduler.ScheduleOnIdle(A<Action>._))
+            .Invokes(call => _capturedIdleAction = call.GetArgument<Action>(0));
+
+         sut = new SimulationTask(
+            _executionContext,
+            _buildingBlockTask,
+            A.Fake<IApplicationController>(),
+            A.Fake<ISimulationBuildingBlockUpdater>(),
+            A.Fake<IConfigureSimulationTask>(),
+            A.Fake<IBuildingBlockParametersToSimulationUpdater>(),
+            A.Fake<ISimulationParametersToBuildingBlockUpdater>(),
+            _idleScheduler);
+      }
+
+      protected void FireIdleAction() => _capturedIdleAction?.Invoke();
+      protected bool HasPendingIdleAction => _capturedIdleAction != null;
+   }
+
+   internal class When_idle_fires_after_editing_an_unchanged_project : concern_for_SimulationTask_with_controllable_idle
+   {
+      protected override void Because()
+      {
+         sut.Edit(A.Fake<IndividualSimulation>());
+         // Simulate Windows becoming idle: fire the scheduled action.
+         FireIdleAction();
+      }
+
+      [Observation]
+      public void should_have_scheduled_an_idle_reset()
+      {
+         HasPendingIdleAction.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void project_should_not_have_changed_after_idle()
+      {
+         _project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   internal class When_idle_fires_but_the_project_has_been_switched_in_the_meantime : concern_for_SimulationTask_with_controllable_idle
+   {
+      private PKSimProject _newProject;
+
+      protected override void Context()
+      {
+         base.Context();
+         _newProject = new PKSimProject();
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(A.Fake<IndividualSimulation>());
+         // Simulate a project switch before idle fires.
+         A.CallTo(() => _executionContext.CurrentProject).Returns(_newProject);
+         FireIdleAction();
+      }
+
+      [Observation]
+      public void should_not_modify_the_new_project()
+      {
+         _newProject.HasChanged.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void original_project_should_not_be_touched()
+      {
+         _project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   internal class When_editing_an_already_changed_project_no_idle_reset_should_be_scheduled : concern_for_SimulationTask_with_controllable_idle
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _project.HasChanged = true;
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(A.Fake<IndividualSimulation>());
+      }
+
+      [Observation]
+      public void should_not_schedule_an_idle_reset()
+      {
+         HasPendingIdleAction.ShouldBeFalse();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/SimulationTimeProfileChartPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationTimeProfileChartPresenterSpecs.cs
@@ -47,7 +47,7 @@ namespace PKSim.Presentation
       protected IList<ChartEditorLayoutTemplate> _allTemplates;
       protected IChartEditorLayoutTask _chartLayoutTask;
       protected IChartTemplatingTask _chartTemplatingTask;
-      private IProjectRetriever _projectRetriever;
+      protected IProjectRetriever _projectRetriever;
       protected ChartPresenterContext _chartPresenterContext;
       protected IUserSettings _userSettings;
       private ICurveNamer _curveNamer;
@@ -638,6 +638,65 @@ namespace PKSim.Presentation
       public void should_added_them_also_to_the_underlying_simulation()
       {
          _allDataRepositories.Contains(_observedData).ShouldBeTrue();
+      }
+   }
+
+   public class When_column_settings_change_fires_during_chart_initialization : concern_for_SimulationTimeProfileChartPresenter
+   {
+      private PKSimProject _project;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = new PKSimProject();
+         _simulation = new IndividualSimulation {DataRepository = new DataRepository(), Settings = new SimulationSettings()};
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(_project);
+
+         // Simulate DevExpress raising ColumnSettingsChanged during ChartEditorPresenter.Edit()
+         // (which is called by BindChartToEditors inside InitializeAnalysis).
+         A.CallTo(() => _chartEditorPresenter.Edit(A<CurveChart>._))
+            .Invokes(_ => _chartEditorPresenter.ColumnSettingsChanged +=
+               Raise.FreeForm<Action<IReadOnlyCollection<GridColumnSettings>>>.With(new List<GridColumnSettings>()));
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeAnalysis(new SimulationTimeProfileChart(), _simulation);
+      }
+
+      [Observation]
+      public void should_not_mark_the_project_as_changed()
+      {
+         _project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_column_settings_change_fires_after_chart_initialization : concern_for_SimulationTimeProfileChartPresenter
+   {
+      private PKSimProject _project;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = new PKSimProject();
+         _simulation = new IndividualSimulation {DataRepository = new DataRepository(), Settings = new SimulationSettings()};
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(_project);
+         sut.InitializeAnalysis(new SimulationTimeProfileChart(), _simulation);
+      }
+
+      protected override void Because()
+      {
+         // Simulate DevExpress raising ColumnSettingsChanged after initialization is complete.
+         _chartEditorPresenter.ColumnSettingsChanged +=
+            Raise.FreeForm<Action<IReadOnlyCollection<GridColumnSettings>>>.With(new List<GridColumnSettings>());
+      }
+
+      [Observation]
+      public void should_mark_the_project_as_changed()
+      {
+         _project.HasChanged.ShouldBeTrue();
       }
    }
 }


### PR DESCRIPTION
Fixes #3417

# Description

Project has changed issue

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where editing a simulation would incorrectly mark the project as modified due to chart UI updates during initialization. The project state is now preserved correctly when internal components update during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->