### PR TITLE
Fixes #3421 Enable PK-Sim ExpressionProfile from MoBi.R

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -868,6 +868,10 @@ namespace PKSim.Assets
 
          public static string EffectiveMolWeightMustBeGreaterThan(double valueInDisplayUnit, string displayUnit) =>
             $"Effective mol weight must be greater than or equal to {valueInDisplayUnit} {displayUnit}";
+
+         public static string InvalidProteinCategory(string category) => $"The category '{category}' is not a valid expression category";
+
+         public static string CouldNotFindValidSpecies(string speciesName) => $"Could not find a valid species named '{speciesName}'";
       }
 
       public static class Information

--- a/src/PKSim.R/Exchange/BuildingBlockCreator.cs
+++ b/src/PKSim.R/Exchange/BuildingBlockCreator.cs
@@ -2,19 +2,25 @@
 using OSPSuite.Core.Snapshots;
 using OSPSuite.Core.Snapshots.Mappers;
 using OSPSuite.R.Domain;
+using PKSim.Assets;
 using PKSim.Core.Mappers;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
 using PKSim.Core.Snapshots.Mappers;
+using System;
+using static PKSim.Assets.PKSimConstants.UI;
 
 namespace PKSim.R.Exchange;
 
 /// <summary>
-/// The class is intended to allow MoBi to dynamically load and call the method and receive a serialized individual building block
-/// We exchange data between PK-Sim and MoBi domains only through serializing and deserializing due to differences in the dimension systems.
-/// The systems are different in the sense that they each rely on dimensions being singular in the app, but by exchanging objects, that will not be the case.
-/// You will have two Mass dimension objects for example.
+///    The class is intended to allow MoBi to dynamically load and call the method and receive a serialized 
+///    building blocks. We exchange data between PK-Sim and MoBi domains only through serializing and deserializing
+///    due to differences in the dimension systems. The systems are different in the sense that they each rely on
+///    dimensions being singular in the app, but by exchanging objects, that will not be the case.
+///    You will have two Mass dimension objects for example.
 /// </summary>
-public class BuildingBlockCreator
+public static class BuildingBlockCreator
 {
    public static string CreateIndividual(IndividualCharacteristics individualCharacteristics)
    {
@@ -26,4 +32,45 @@ public class BuildingBlockCreator
 
       return serializer.Serialize(mapper.MapFrom(buildingBlock));
    }
+
+   public static string CreateExpressionProfile(ExpressionProfileCharacteristics expressionProfileCharacteristics)
+   {
+      var (serializer, mapper) = Api.ResolveTasks<IPKMLPersistor, IExpressionProfileToExpressionProfileBuildingBlockMapper>();
+      ExpressionProfile buildingBlock;
+
+      var category = expressionProfileCharacteristics.Category;
+      if (string.Equals(category, TransportProtein))
+         buildingBlock = createExpressionProfile<IndividualTransporter>(expressionProfileCharacteristics);
+      else if (string.Equals(category, ProteinBindingPartner))
+         buildingBlock = createExpressionProfile<IndividualOtherProtein>(expressionProfileCharacteristics);
+      else if (string.Equals(category, MetabolizingEnzyme))
+         buildingBlock = createExpressionProfile<IndividualEnzyme>(expressionProfileCharacteristics);
+      else
+         throw new ArgumentException(PKSimConstants.Error.InvalidProteinCategory(category));
+
+      return serializer.Serialize(mapper.MapFrom(buildingBlock));
+   }
+
+   private static ExpressionProfile createExpressionProfile<T>(ExpressionProfileCharacteristics expressionProfileCharacteristics) where T : IndividualMolecule
+   {
+      var (expressionProfileFactory, moleculeParameterTask, speciesRepository) = Api.ResolveTasks<IExpressionProfileFactory, IMoleculeParameterTask, ISpeciesRepository>();
+
+      var species = speciesRepository.FindByName(expressionProfileCharacteristics.Species);
+      if (species == null)
+         throw new ArgumentException(PKSimConstants.Error.CouldNotFindValidSpecies(expressionProfileCharacteristics.Species));
+
+      var expressionProfile = expressionProfileFactory.Create<T>(species, expressionProfileCharacteristics.MoleculeName);
+      expressionProfile.Category = expressionProfileCharacteristics.Category;
+
+      moleculeParameterTask.SetDefaultFor(expressionProfile);
+
+      return expressionProfile;
+   }
+}
+
+public class ExpressionProfileCharacteristics
+{
+   public string Category { get; set; }
+   public string Species { get; set; }
+   public string MoleculeName { get; set; }
 }

--- a/src/PKSim.R/Exchange/BuildingBlockCreator.cs
+++ b/src/PKSim.R/Exchange/BuildingBlockCreator.cs
@@ -33,44 +33,36 @@ public static class BuildingBlockCreator
       return serializer.Serialize(mapper.MapFrom(buildingBlock));
    }
 
-   public static string CreateExpressionProfile(ExpressionProfileCharacteristics expressionProfileCharacteristics)
+   public static string CreateExpressionProfile(string category, string moleculeName, string speciesName)
    {
       var (serializer, mapper) = Api.ResolveTasks<IPKMLPersistor, IExpressionProfileToExpressionProfileBuildingBlockMapper>();
       ExpressionProfile buildingBlock;
 
-      var category = expressionProfileCharacteristics.Category;
       if (string.Equals(category, TransportProtein))
-         buildingBlock = createExpressionProfile<IndividualTransporter>(expressionProfileCharacteristics);
+         buildingBlock = createExpressionProfile<IndividualTransporter>(category, moleculeName, speciesName);
       else if (string.Equals(category, ProteinBindingPartner))
-         buildingBlock = createExpressionProfile<IndividualOtherProtein>(expressionProfileCharacteristics);
+         buildingBlock = createExpressionProfile<IndividualOtherProtein>(category, moleculeName, speciesName);
       else if (string.Equals(category, MetabolizingEnzyme))
-         buildingBlock = createExpressionProfile<IndividualEnzyme>(expressionProfileCharacteristics);
+         buildingBlock = createExpressionProfile<IndividualEnzyme>(category, moleculeName, speciesName);
       else
          throw new ArgumentException(PKSimConstants.Error.InvalidProteinCategory(category));
 
       return serializer.Serialize(mapper.MapFrom(buildingBlock));
    }
 
-   private static ExpressionProfile createExpressionProfile<T>(ExpressionProfileCharacteristics expressionProfileCharacteristics) where T : IndividualMolecule
+   private static ExpressionProfile createExpressionProfile<T>(string category, string moleculeName, string speciesName) where T : IndividualMolecule
    {
       var (expressionProfileFactory, moleculeParameterTask, speciesRepository) = Api.ResolveTasks<IExpressionProfileFactory, IMoleculeParameterTask, ISpeciesRepository>();
 
-      var species = speciesRepository.FindByName(expressionProfileCharacteristics.Species);
+      var species = speciesRepository.FindByName(speciesName);
       if (species == null)
-         throw new ArgumentException(PKSimConstants.Error.CouldNotFindValidSpecies(expressionProfileCharacteristics.Species));
+         throw new ArgumentException(PKSimConstants.Error.CouldNotFindValidSpecies(speciesName));
 
-      var expressionProfile = expressionProfileFactory.Create<T>(species, expressionProfileCharacteristics.MoleculeName);
-      expressionProfile.Category = expressionProfileCharacteristics.Category;
+      var expressionProfile = expressionProfileFactory.Create<T>(species, moleculeName);
+      expressionProfile.Category = category;
 
       moleculeParameterTask.SetDefaultFor(expressionProfile);
 
       return expressionProfile;
    }
-}
-
-public class ExpressionProfileCharacteristics
-{
-   public string Category { get; set; }
-   public string Species { get; set; }
-   public string MoleculeName { get; set; }
 }

--- a/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
@@ -1,46 +1,168 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Snapshots;
 using OSPSuite.R.Domain;
+using PKSim.Assets;
 using PKSim.Core;
 using PKSim.R.Exchange;
+using static PKSim.Assets.PKSimConstants.UI;
 
-namespace PKSim.R
+namespace PKSim.R;
+
+internal class CreateExchangeIndividual : ContextForStaticIntegration
 {
-   internal class CreateExchangeIndividual : ContextForStaticIntegration
+   private IndividualCharacteristics _individualCharacteristics;
+   private string _result;
+
+   protected override void Context()
    {
-      private IndividualCharacteristics _individualCharacteristics;
+      base.Context();
+      _individualCharacteristics = new IndividualCharacteristics
+      {
+         Species = CoreConstants.Species.HUMAN,
+         Population = CoreConstants.Population.ICRP,
+         Age = new Parameter
+         {
+            Value = 30,
+            Unit = "year(s)",
+         },
+         Weight = new Parameter
+         {
+            Value = 75,
+            Unit = "kg",
+         },
+         Height = new Parameter
+         {
+            Value = 175,
+            Unit = "cm",
+         },
+         Gender = CoreConstants.Gender.MALE
+      };
+   }
+
+   protected override void Because()
+   {
+      _result = BuildingBlockCreator.CreateIndividual(_individualCharacteristics);
+   }
+
+   [Observation]
+   public void an_exchangeable_string_is_created()
+   {
+      _result.ShouldNotBeNull();
+   }
+}
+
+internal class CreateExchangeMetabolizingEnzyme : ContextForStaticIntegration
+{
+   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
+   private string _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
+      {
+         Species = CoreConstants.Species.HUMAN,
+         Category = MetabolizingEnzyme,
+         MoleculeName = "CYP3A4"
+      };
+   }
+
+   protected override void Because()
+   {
+      _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+   }
+
+   [Observation]
+   public void an_exchangeable_string_is_created()
+   {
+      _result.ShouldNotBeNull();
+   }
+}
+
+internal class CreateExchangeExpressionProfileWithInvalidSpecies : ContextForStaticIntegration
+{
+   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
+   private const string _invalidSpecies = "InvalidSpecies";
+
+   protected override void Context()
+   {
+      base.Context();
+      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
+      {
+         Species = _invalidSpecies,
+         Category = MetabolizingEnzyme,
+         MoleculeName = "CYP3A4"
+      };
+   }
+
+   [Observation]
+   public void should_throw_an_argument_exception_with_species_not_found_message()
+   {
+      var message = string.Empty;
+      The.Action(() =>
+      {
+         try
+         {
+            BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+         }
+         catch (Exception e)
+         {
+            message = e.Message;
+            throw;
+         }
+      }).ShouldThrowAn<ArgumentException>();
+      message.ShouldBeEqualTo(PKSimConstants.Error.CouldNotFindValidSpecies(_invalidSpecies));
+   }
+}
+
+internal class CreateExchangeTransportProtein : ContextForStaticIntegration
+{
+   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
+   private string _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
+      {
+         Species = CoreConstants.Species.HUMAN,
+         Category = TransportProtein,
+         MoleculeName = "CYP3A4"
+      };
+   }
+
+   protected override void Because()
+   {
+      _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+   }
+
+   [Observation]
+   public void an_exchangeable_string_is_created()
+   {
+      _result.ShouldNotBeNull();
+   }
+
+   internal class CreateExchangeProteinBindingPartner : ContextForStaticIntegration
+   {
+      private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
       private string _result;
 
       protected override void Context()
       {
          base.Context();
-         _individualCharacteristics = new IndividualCharacteristics
+         _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
          {
             Species = CoreConstants.Species.HUMAN,
-            Population = CoreConstants.Population.ICRP,
-            Age = new Parameter
-            {
-               Value = 30,
-               Unit = "year(s)",
-            },
-            Weight = new Parameter
-            {
-               Value = 75,
-               Unit = "kg",
-            },
-            Height = new Parameter
-            {
-               Value = 175,
-               Unit = "cm",
-            },
-            Gender = CoreConstants.Gender.MALE
+            Category = ProteinBindingPartner,
+            MoleculeName = "CYP3A4"
          };
       }
 
       protected override void Because()
       {
-         _result = BuildingBlockCreator.CreateIndividual(_individualCharacteristics);
+         _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
       }
 
       [Observation]

--- a/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
@@ -55,23 +55,11 @@ internal class CreateExchangeIndividual : ContextForStaticIntegration
 
 internal class CreateExchangeMetabolizingEnzyme : ContextForStaticIntegration
 {
-   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
    private string _result;
-
-   protected override void Context()
-   {
-      base.Context();
-      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
-      {
-         Species = CoreConstants.Species.HUMAN,
-         Category = MetabolizingEnzyme,
-         MoleculeName = "CYP3A4"
-      };
-   }
 
    protected override void Because()
    {
-      _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+      _result = BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", CoreConstants.Species.HUMAN);
    }
 
    [Observation]
@@ -83,20 +71,6 @@ internal class CreateExchangeMetabolizingEnzyme : ContextForStaticIntegration
 
 internal class CreateExchangeExpressionProfileWithInvalidSpecies : ContextForStaticIntegration
 {
-   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
-   private const string _invalidSpecies = "InvalidSpecies";
-
-   protected override void Context()
-   {
-      base.Context();
-      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
-      {
-         Species = _invalidSpecies,
-         Category = MetabolizingEnzyme,
-         MoleculeName = "CYP3A4"
-      };
-   }
-
    [Observation]
    public void should_throw_an_argument_exception_with_species_not_found_message()
    {
@@ -105,7 +79,7 @@ internal class CreateExchangeExpressionProfileWithInvalidSpecies : ContextForSta
       {
          try
          {
-            BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+            BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", "InvalidSpecies");
          }
          catch (Exception e)
          {
@@ -113,29 +87,17 @@ internal class CreateExchangeExpressionProfileWithInvalidSpecies : ContextForSta
             throw;
          }
       }).ShouldThrowAn<ArgumentException>();
-      message.ShouldBeEqualTo(PKSimConstants.Error.CouldNotFindValidSpecies(_invalidSpecies));
+      message.ShouldBeEqualTo(PKSimConstants.Error.CouldNotFindValidSpecies("InvalidSpecies"));
    }
 }
 
 internal class CreateExchangeTransportProtein : ContextForStaticIntegration
 {
-   private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
    private string _result;
-
-   protected override void Context()
-   {
-      base.Context();
-      _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
-      {
-         Species = CoreConstants.Species.HUMAN,
-         Category = TransportProtein,
-         MoleculeName = "CYP3A4"
-      };
-   }
 
    protected override void Because()
    {
-      _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+      _result = BuildingBlockCreator.CreateExpressionProfile(TransportProtein, "CYP3A4", CoreConstants.Species.HUMAN);
    }
 
    [Observation]
@@ -146,23 +108,11 @@ internal class CreateExchangeTransportProtein : ContextForStaticIntegration
 
    internal class CreateExchangeProteinBindingPartner : ContextForStaticIntegration
    {
-      private ExpressionProfileCharacteristics _expressionProfileCharacteristics;
       private string _result;
-
-      protected override void Context()
-      {
-         base.Context();
-         _expressionProfileCharacteristics = new ExpressionProfileCharacteristics
-         {
-            Species = CoreConstants.Species.HUMAN,
-            Category = ProteinBindingPartner,
-            MoleculeName = "CYP3A4"
-         };
-      }
 
       protected override void Because()
       {
-         _result = BuildingBlockCreator.CreateExpressionProfile(_expressionProfileCharacteristics);
+         _result = BuildingBlockCreator.CreateExpressionProfile(ProteinBindingPartner, "CYP3A4", CoreConstants.Species.HUMAN);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #3421 Enable PK-Sim ExpressionProfile from MoBi.R

# Description
Allow MoBi to call into PK-Sim to create an Expression profile. First is to create the default profile without the database query.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create and exchange expression profiles by specifying a category, molecule name, and species. The system automatically validates the species to ensure validity and provides clear error messaging.

* **Chores**
  * Enhanced error messages for improved user feedback when invalid categories or unrecognized species are encountered.
  * Expanded test coverage to ensure robust building block creation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->