### PR TITLE
Fixes #3425 Cannot resolve snapshot runner in PKSim.R

### DIFF
--- a/src/PKSim.R/Bootstrap/ApplicationStartup.cs
+++ b/src/PKSim.R/Bootstrap/ApplicationStartup.cs
@@ -73,7 +73,7 @@ namespace PKSim.R.Bootstrap
       private void registerMinimalImplementations(IContainer container)
       {
          container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
-         container.Register<ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
+         container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
          container.Register<IProgressUpdater, NoneProgressUpdater>();
          container.Register<IDisplayUnitRetriever, CLIDisplayUnitRetriever>();
          container.Register<IOntogenyTask, CLIIndividualOntogenyTask>();

--- a/tests/PKSim.R.Tests/APISpecs.cs
+++ b/tests/PKSim.R.Tests/APISpecs.cs
@@ -1,0 +1,86 @@
+﻿using OSPSuite.BDDHelper;
+using System;
+using Castle.MicroKernel.ComponentActivator;
+using NUnit.Framework;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.CLI.Core.RunOptions;
+
+namespace PKSim.R
+{
+   [IntegrationTests]
+   [Category("R")]
+   public class APISpecs : StaticContextSpecification
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         Api.InitializeOnce();
+
+         Environment.CurrentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+      }
+
+      private static Exception getExceptionFromPerforming(Action work)
+      {
+         try
+         {
+            work();
+            return null;
+         }
+         catch (Exception ex)
+         {
+            return ex;
+         }
+      }
+
+      protected static void ActionShouldNotThrowAn<TException>(Action workToPerform) where TException : Exception
+      {
+         Exception exceptionFromPerforming = getExceptionFromPerforming(workToPerform);
+         exceptionFromPerforming.GetType().ShouldNotBeEqualTo(typeof(TException));
+      }
+   }
+
+   public class When_resolving_tasks_after_initialization : APISpecs
+   {
+      [Observation]
+      public void can_get_individual_factory()
+      {
+         Api.GetIndividualFactory().ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void can_get_population_factory()
+      {
+         Api.GetPopulationFactory().ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void can_resolve_snapshot_runner()
+      {
+         ActionShouldNotThrowAn<ComponentActivatorException>(() => Api.RunSnapshot(new SnapshotRunOptions()));
+      }
+
+      [Observation]
+      public void can_resolve_export_runner()
+      {
+         ActionShouldNotThrowAn<ComponentActivatorException>(() => Api.RunExport(new ExportRunOptions()));
+      }
+
+      [Observation]
+      public void can_resolve_json_runner()
+      {
+         ActionShouldNotThrowAn<ComponentActivatorException>(() => Api.RunJson(new JsonRunOptions()));
+      }
+
+      [Observation]
+      public void can_resolve_qualification_runner()
+      {
+         ActionShouldNotThrowAn<ComponentActivatorException>(() => Api.RunQualification(new QualificationRunOptions()));
+      }
+
+      [Observation]
+      public void can_resolve_simulation_export_runner()
+      {
+         ActionShouldNotThrowAn<ComponentActivatorException>(() => Api.RunSimulationExport(new ExportRunOptions()));
+      }
+   }
+}

--- a/tests/PKSim.R.Tests/APISpecs.cs
+++ b/tests/PKSim.R.Tests/APISpecs.cs
@@ -35,7 +35,7 @@ namespace PKSim.R
       protected static void ActionShouldNotThrowAn<TException>(Action workToPerform) where TException : Exception
       {
          Exception exceptionFromPerforming = getExceptionFromPerforming(workToPerform);
-         exceptionFromPerforming.GetType().ShouldNotBeEqualTo(typeof(TException));
+         (exceptionFromPerforming is TException).ShouldBeFalse();
       }
    }
 

--- a/tests/PKSim.R.Tests/APISpecs.cs
+++ b/tests/PKSim.R.Tests/APISpecs.cs
@@ -1,7 +1,7 @@
-﻿using OSPSuite.BDDHelper;
-using System;
+﻿using System;
 using Castle.MicroKernel.ComponentActivator;
 using NUnit.Framework;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using PKSim.CLI.Core.RunOptions;
 


### PR DESCRIPTION
Fixes #3425 Cannot resolve snapshot runner in PKSim.R

# Description
Did not register a newly created interface in OSPSUite.Core

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test suite to validate API initialization and proper resolution of core application components and runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->