### PR TITLE
Fixes #3450 Ensure PKSim.R.API is initialized when using Exchange met…

### DIFF
--- a/src/PKSim.R/Exchange/BuildingBlockCreator.cs
+++ b/src/PKSim.R/Exchange/BuildingBlockCreator.cs
@@ -24,6 +24,7 @@ public static class BuildingBlockCreator
 {
    public static string CreateIndividual(IndividualCharacteristics individualCharacteristics)
    {
+      Api.InitializeOnce();
       var (individualFactory, originDataMapper, serializer, mapper) = Api.ResolveTasks<IIndividualFactory, OriginDataMapper, IPKMLPersistor, IIndividualToIndividualBuildingBlockMapper>();
 
       var originData = originDataMapper.MapToModel(individualCharacteristics, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current)).Result;
@@ -35,6 +36,7 @@ public static class BuildingBlockCreator
 
    public static string CreateExpressionProfile(string category, string moleculeName, string speciesName)
    {
+      Api.InitializeOnce();
       var (serializer, mapper) = Api.ResolveTasks<IPKMLPersistor, IExpressionProfileToExpressionProfileBuildingBlockMapper>();
       ExpressionProfile buildingBlock;
 


### PR DESCRIPTION
Fixes #3450 ensure pksimrapi is initialized when using exchange methods

# Description
When using the MoBi Exchange the API has to be initialized before it can be used.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API initialization sequence to ensure proper startup prior to task resolution in building block creation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->