### PR TITLE
Fixes #3467 Fix spurious warnings in qualification CLI mode

### DIFF
--- a/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -132,7 +132,7 @@ namespace PKSim.Core.Snapshots.Mappers
             await runParallelSimulations(allSimulationsWithSnapshots, snapshotContext);
          }
 
-         await addAnalysesToSimulations(snapshotContext, allSimulationsWithSnapshots);
+         await addAnalysesToSimulations(snapshotContext, allSimulationsWithSnapshots, projectContext.RunSimulations);
 
          //Map all classifications once project is loaded
          await updateProjectClassifications(projectSnapshot, snapshotContext);
@@ -140,9 +140,9 @@ namespace PKSim.Core.Snapshots.Mappers
          return project;
       }
 
-      private async Task addAnalysesToSimulations(SnapshotContext snapshotContext, IReadOnlyList<(ModelSimulation simulation, Simulation snapshotSimulation)> allSimulations)
+      private async Task addAnalysesToSimulations(SnapshotContext snapshotContext, IReadOnlyList<(ModelSimulation simulation, Simulation snapshotSimulation)> allSimulations, bool runSimulations)
       {
-         var simulationContext = new SimulationContext(true, snapshotContext)
+         var simulationContext = new SimulationContext(runSimulations, snapshotContext)
          {
             NumberOfSimulationsToLoad = allSimulations.Count,
             NumberOfSimulationsLoaded = 1

--- a/tests/PKSim.Tests/Core/ProjectMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/ProjectMapperSpecs.cs
@@ -313,7 +313,7 @@ namespace PKSim.Core
 
    public class When_converting_a_project_snapshot_to_project : concern_for_ProjectMapper
    {
-      private PKSimProject _newProject;
+      protected PKSimProject _newProject;
       private Simulation _corruptedSimulationSnapshot;
       private CreationMetaData _creationMetaData;
       private ISnapshotMapper _defaultMapper;
@@ -534,6 +534,30 @@ namespace PKSim.Core
       }
    }
 
+
+   public class When_loading_a_project_snapshot_without_running_simulations : When_converting_a_project_snapshot_to_project
+   {
+      protected override async Task Because()
+      {
+         _newProject = await sut.MapToModel(_snapshot, new ProjectContext(new PKSimProject(), runSimulations: false));
+      }
+
+      [Observation]
+      public void should_not_run_any_simulations()
+      {
+         A.CallTo(() => _simulationRunner.RunSimulation(A<ModelSimulation>._, A<PKSim.Core.Services.SimulationRunOptions>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_log_warnings_about_missing_quantities()
+      {
+         // Fixes #3467: when simulations are not run, CurveMapper must not warn about
+         // missing data columns since no results are expected
+         A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Warning, A<string>._))
+            .MustNotHaveHappened();
+      }
+   }
 
    public class ExpressionProfileEqualityComparer : GenericEqualityComparer<ExpressionProfile>
    {


### PR DESCRIPTION
## Summary

- Fixes the `Could not find quantity with path` warnings that appear in V13 qualification CLI mode but not in V12.2
- Root cause: the `#3232` refactoring (parallel simulation execution) moved chart/analysis mapping from `SimulationMapper` to `ProjectMapper` but **hardcoded `Run=true`** in the `SimulationContext` passed to `addAnalysesToSimulations`. The qualification CLI defaults `--run` to `false`, so simulations are not executed and no `DataRepository` results exist. However, because `Run` was hardcoded to `true`, the `CurveMapper` believed simulations had been run and emitted warnings for every curve whose data column was (expectedly) missing. In V12.2, the `SimulationContext.Run` flag matched the actual `projectContext.RunSimulations` value, so these warnings were correctly suppressed.
- Fix: pass `projectContext.RunSimulations` through to `addAnalysesToSimulations` instead of hardcoding `true`

## Test plan

- [x] Added test `When_loading_a_project_snapshot_without_running_simulations` verifying that `RunSimulation=false` is propagated to chart mappers when `runSimulations: false`
- [ ] Run `PKSim.CLI.exe qualification -i config.json` (without `-r`) and confirm no spurious warnings appear
- [ ] Run `PKSim.CLI.exe qualification -i config.json -r` and confirm normal behavior (simulations run, no false warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project snapshot loading now properly respects simulation execution settings. When loading a project without running simulations, the system skips unnecessary simulation executions and analysis calculations, improving load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->