### PR TITLE
Add domain for OverwriteParameterSet feature

### DIFF
--- a/src/PKSim.Core/Model/Compound.cs
+++ b/src/PKSim.Core/Model/Compound.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Core.Model
 {
@@ -21,12 +22,20 @@ namespace PKSim.Core.Model
 
    public class Compound : PKSimBuildingBlock, IWithCalculationMethods
    {
+      private readonly List<OverwriteParameterSet> _overwriteParameterSets = new();
+
       public CalculationMethodCache CalculationMethodCache { get; }
+
+      public IReadOnlyList<OverwriteParameterSet> OverwriteParameterSets => _overwriteParameterSets;
 
       public Compound() : base(PKSimBuildingBlockType.Compound)
       {
          CalculationMethodCache = new CalculationMethodCache();
       }
+
+      public virtual void AddOverwriteParameterSet(OverwriteParameterSet overwriteParameterSet) => _overwriteParameterSets.Add(overwriteParameterSet);
+
+      public virtual void RemoveOverwriteParameterSet(OverwriteParameterSet overwriteParameterSet) => _overwriteParameterSets.Remove(overwriteParameterSet);
 
       public virtual void AddProcess(CompoundProcess process)
       {
@@ -124,6 +133,8 @@ namespace PKSim.Core.Model
          var sourceCompound = sourceObject as Compound;
          if (sourceCompound == null) return;
          CalculationMethodCache.UpdatePropertiesFrom(sourceCompound.CalculationMethodCache, cloneManager);
+         _overwriteParameterSets.Clear();
+         sourceCompound.OverwriteParameterSets.Each(x => AddOverwriteParameterSet(cloneManager.Clone(x)));
       }
    }
 }

--- a/src/PKSim.Core/Model/OverwriteParameterSet.cs
+++ b/src/PKSim.Core/Model/OverwriteParameterSet.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
+
+namespace PKSim.Core.Model
+{
+   public class OverwriteParameterSet : ObjectBase
+   {
+      private readonly ICache<ObjectPath, ParameterValue> _parameterValues = new Cache<ObjectPath, ParameterValue>(pv => pv.Path, x => null);
+
+      public bool IsDefault { get; set; }
+
+      public ExtendedProperties ExtendedProperties { get; } = new();
+
+      public IReadOnlyList<ParameterValue> ParameterValues => _parameterValues.ToList();
+
+      public void Add(ParameterValue parameterValue) => 
+         _parameterValues[parameterValue.Path] = parameterValue;
+
+      public void Remove(ParameterValue parameterValue) =>
+         _parameterValues.Remove(parameterValue.Path);
+
+      public ParameterValue ParameterValueByPath(string parameterPath) =>
+         _parameterValues[parameterPath.ToObjectPath()];
+
+      public override void UpdatePropertiesFrom(IUpdatable source, ICloneManager cloneManager)
+      {
+         base.UpdatePropertiesFrom(source, cloneManager);
+
+         if (!(source is OverwriteParameterSet sourceSet))
+            return;
+
+         IsDefault = sourceSet.IsDefault;
+         ExtendedProperties.UpdateFrom(sourceSet.ExtendedProperties);
+         _parameterValues.Clear();
+         sourceSet.ParameterValues.Each(pv => Add(cloneManager.Clone(pv)));
+      }
+   }
+}

--- a/src/PKSim.Core/Model/OverwriteParameterSetSelections.cs
+++ b/src/PKSim.Core/Model/OverwriteParameterSetSelections.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
+
+namespace PKSim.Core.Model
+{
+   /// <summary>
+   ///    Stores which <see cref="OverwriteParameterSet"/> is selected per compound in a simulation configuration.
+   /// </summary>
+   public class OverwriteParameterSetSelections
+   {
+      private readonly ICache<string, OverwriteParameterSetSelection> _selections = new Cache<string, OverwriteParameterSetSelection>(s => s.CompoundName, x => null);
+
+      public IReadOnlyList<OverwriteParameterSetSelection> Selections => _selections.ToList();
+
+      public void SetSelectionForCompound(string compoundName, OverwriteParameterSet overwriteParameterSet)
+      {
+         if (_selections.Contains(compoundName))
+            _selections[compoundName].OverwriteParameterSet = overwriteParameterSet;
+         else
+            _selections.Add(new OverwriteParameterSetSelection { CompoundName = compoundName, OverwriteParameterSet = overwriteParameterSet });
+      }
+
+      public void SetSelectionForCompound(OverwriteParameterSetSelection selection)
+      {
+         if (_selections.Contains(selection.CompoundName))
+            _selections[selection.CompoundName].OverwriteParameterSet = selection.OverwriteParameterSet;
+         else
+            _selections.Add(selection);
+      }
+
+      public void RemoveSelectionForCompound(string compoundName) =>
+         _selections.Remove(compoundName);
+
+      public OverwriteParameterSet SelectedSetFor(string compoundName) =>
+         _selections[compoundName]?.OverwriteParameterSet;
+
+      public OverwriteParameterSetSelections Clone()
+      {
+         var clone = new OverwriteParameterSetSelections();
+         _selections.Each(s => clone._selections.Add(s.Clone()));
+         return clone;
+      }
+   }
+
+   public class OverwriteParameterSetSelection
+   {
+      public string CompoundName { get; init; }
+
+      public OverwriteParameterSet OverwriteParameterSet { get; set; }
+
+      public OverwriteParameterSetSelection Clone() =>
+         new()
+         {
+            CompoundName = CompoundName,
+            OverwriteParameterSet = OverwriteParameterSet
+         };
+   }
+}

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -6,6 +6,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Visitor;
@@ -406,6 +407,7 @@ namespace PKSim.Core.Model
             return;
 
          Properties = sourceSimulation.Properties.Clone(cloneManager);
+         OverwriteParameterSetSelections = sourceSimulation.OverwriteParameterSetSelections.Clone();
          sourceSimulation.UsedBuildingBlocks.Each(bb => AddUsedBuildingBlock(bb.Clone(cloneManager)));
          Model = cloneManager.Clone(sourceSimulation.Model);
 
@@ -486,6 +488,26 @@ namespace PKSim.Core.Model
       public virtual double? EndTime
       {
          get { return OutputSchema?.Intervals.Select(x => x.EndTime.Value).Max(); }
+      }
+
+      public virtual OverwriteParameterSetSelections OverwriteParameterSetSelections { get; protected set; } = new();
+
+      /// <summary>
+      ///    Adds a selection of <paramref name="overwriteParameterSet"/> for the compound with <paramref name="compoundName"/>.
+      ///    Only compounds used as building blocks in the simulation are accepted.
+      ///    Compounds created by the simulation (e.g. unnamed metabolites) are ignored.
+      /// </summary>
+      public virtual void AddOverwriteParameterSetSelection(string compoundName, OverwriteParameterSet overwriteParameterSet)
+      {
+         if (!CompoundNames.Contains(compoundName))
+            return;
+
+         OverwriteParameterSetSelections.SetSelectionForCompound(compoundName, overwriteParameterSet);
+      }
+
+      public virtual void RemoveOverwriteParameterSetSelection(string compoundName)
+      {
+         OverwriteParameterSetSelections.RemoveSelectionForCompound(compoundName);
       }
 
       /// <summary>
@@ -651,6 +673,20 @@ namespace PKSim.Core.Model
       public virtual IReadOnlyList<Protocol> Protocols => AllBuildingBlocks<Protocol>().ToList();
 
       public virtual IReadOnlyList<string> CompoundNames => Compounds.AllNames().ToList();
+
+      /// <summary>
+      ///    Returns the name of the building block compound whose name appears as an element in <paramref name="parameterPath"/>,
+      ///    or <c>null</c> if no building block compound matches.
+      ///    Compounds created by the simulation but not used as building blocks (e.g. unnamed metabolites) are not matched.
+      /// </summary>
+      public virtual string CompoundNameForParameterPath(string parameterPath)
+      {
+         if (string.IsNullOrEmpty(parameterPath))
+            return null;
+
+         var pathElements = parameterPath.ToPathArray();
+         return CompoundNames.FirstOrDefault(name => pathElements.Contains(name));
+      }
 
       /// <summary>
       ///    Returns the compound properties used in the simulation configuration

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/CompoundXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/CompoundXmlSerializer.cs
@@ -8,6 +8,7 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
       {
          base.PerformMapping();
          Map(x => x.CalculationMethodCache);
+         MapEnumerable(x => x.OverwriteParameterSets, x => x.AddOverwriteParameterSet);
       }
    }
 }

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetSelectionXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetSelectionXmlSerializer.cs
@@ -1,0 +1,13 @@
+using PKSim.Core.Model;
+
+namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+{
+   public class OverwriteParameterSetSelectionXmlSerializer : BaseXmlSerializer<OverwriteParameterSetSelection>
+   {
+      public override void PerformMapping()
+      {
+         Map(x => x.CompoundName);
+         MapReference(x => x.OverwriteParameterSet);
+      }
+   }
+}

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetSelectionsXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetSelectionsXmlSerializer.cs
@@ -1,0 +1,12 @@
+using PKSim.Core.Model;
+
+namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+{
+   public class OverwriteParameterSetSelectionsXmlSerializer : BaseXmlSerializer<OverwriteParameterSetSelections>
+   {
+      public override void PerformMapping()
+      {
+         MapEnumerable(x => x.Selections, x => x.SetSelectionForCompound);
+      }
+   }
+}

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/OverwriteParameterSetXmlSerializer.cs
@@ -1,0 +1,16 @@
+using OSPSuite.Core.Serialization.Xml;
+using PKSim.Core.Model;
+
+namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+{
+   public class OverwriteParameterSetXmlSerializer : ObjectBaseXmlSerializer<OverwriteParameterSet>, IPKSimXmlSerializer
+   {
+      public override void PerformMapping()
+      {
+         base.PerformMapping();
+         Map(x => x.IsDefault);
+         MapEnumerable(x => x.ExtendedProperties, x => x.ExtendedProperties.Add);
+         MapEnumerable(x => x.ParameterValues, x => x.Add);
+      }
+   }
+}

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/SimulationXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/SimulationXmlSerializer.cs
@@ -20,6 +20,7 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          MapEnumerable(x => x.Reactions, x => x.AddReactions);
          MapEnumerable(x => x.UsedBuildingBlocks, x => x.AddUsedBuildingBlock);
          MapEnumerable(x => x.UsedObservedData, x => x.AddUsedObservedData);
+         Map(x => x.OverwriteParameterSetSelections);
 
          //Do not save charts that will be saved separately
       }

--- a/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
+++ b/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
@@ -633,4 +633,152 @@ namespace PKSim.Core
    {
 
    }
+
+   public abstract class concern_for_IndividualSimulation_compound_path_matching : concern_for_IndividualSimulation
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var compound = new Compound().WithName("Aspirin");
+         sut.AddUsedBuildingBlock(new UsedBuildingBlock("compoundTemplate", PKSimBuildingBlockType.Compound) {BuildingBlock = compound});
+      }
+   }
+
+   public class When_matching_a_parameter_path_that_contains_a_building_block_compound_name : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_the_compound_name()
+      {
+         sut.CompoundNameForParameterPath("Organism|Aspirin|Lipophilicity").ShouldBeEqualTo("Aspirin");
+      }
+   }
+
+   public class When_matching_a_parameter_path_that_does_not_contain_a_building_block_compound_name : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_null()
+      {
+         sut.CompoundNameForParameterPath("Organism|Liver|Volume").ShouldBeNull();
+      }
+   }
+
+   public class When_matching_a_parameter_path_for_an_unnamed_metabolite : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_null_since_unnamed_metabolites_are_not_building_block_compounds()
+      {
+         sut.CompoundNameForParameterPath("Organism|Metabolite|SomeParam").ShouldBeNull();
+      }
+   }
+
+   public class When_matching_a_parameter_path_where_compound_name_is_a_substring_but_not_a_path_element : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_null()
+      {
+         sut.CompoundNameForParameterPath("Organism|AspirinDerivative|SomeParam").ShouldBeNull();
+      }
+   }
+
+   public class When_matching_a_null_or_empty_parameter_path : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_null_for_null_path()
+      {
+         sut.CompoundNameForParameterPath(null).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_return_null_for_empty_path()
+      {
+         sut.CompoundNameForParameterPath(string.Empty).ShouldBeNull();
+      }
+   }
+
+   public abstract class concern_for_IndividualSimulation_with_compound : concern_for_IndividualSimulation
+   {
+      protected Compound _compound;
+      protected OverwriteParameterSet _renalImpairmentSet;
+      protected OverwriteParameterSet _hepaticImpairmentSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         _compound = new Compound().WithName("Aspirin");
+         _renalImpairmentSet = new OverwriteParameterSet { Name = "RenalImpairment" };
+         _hepaticImpairmentSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+         sut.AddUsedBuildingBlock(new UsedBuildingBlock("compoundTemplate", PKSimBuildingBlockType.Compound) {BuildingBlock = _compound});
+      }
+   }
+
+   public class When_adding_an_overwrite_parameter_set_selection_for_a_building_block_compound : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Because()
+      {
+         sut.AddOverwriteParameterSetSelection(_compound.Name, _renalImpairmentSet);
+      }
+
+      [Observation]
+      public void should_store_the_selection()
+      {
+         sut.OverwriteParameterSetSelections.Selections.Count.ShouldBeEqualTo(1);
+         sut.OverwriteParameterSetSelections.Selections[0].CompoundName.ShouldBeEqualTo(_compound.Name);
+         sut.OverwriteParameterSetSelections.Selections[0].OverwriteParameterSet.ShouldBeEqualTo(_renalImpairmentSet);
+      }
+   }
+
+   public class When_adding_an_overwrite_parameter_set_selection_for_a_compound_not_used_as_building_block : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Because()
+      {
+         sut.AddOverwriteParameterSetSelection("Metabolite", _renalImpairmentSet);
+      }
+
+      [Observation]
+      public void should_not_store_the_selection()
+      {
+         sut.OverwriteParameterSetSelections.Selections.ShouldBeEmpty();
+      }
+   }
+
+   public class When_removing_an_overwrite_parameter_set_selection : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.AddOverwriteParameterSetSelection(_compound.Name, _renalImpairmentSet);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveOverwriteParameterSetSelection(_compound.Name);
+      }
+
+      [Observation]
+      public void should_no_longer_contain_the_selection()
+      {
+         sut.OverwriteParameterSetSelections.Selections.ShouldBeEmpty();
+      }
+   }
+
+   public class When_updating_an_overwrite_parameter_set_selection_for_an_existing_compound : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.AddOverwriteParameterSetSelection(_compound.Name, _renalImpairmentSet);
+      }
+
+      protected override void Because()
+      {
+         sut.AddOverwriteParameterSetSelection(_compound.Name, _hepaticImpairmentSet);
+      }
+
+      [Observation]
+      public void should_update_the_selection_without_adding_a_duplicate()
+      {
+         sut.OverwriteParameterSetSelections.Selections.Count.ShouldBeEqualTo(1);
+         sut.OverwriteParameterSetSelections.Selections[0].OverwriteParameterSet.ShouldBeEqualTo(_hepaticImpairmentSet);
+      }
+   }
 }

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionsSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionsSpecs.cs
@@ -1,0 +1,134 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_OverwriteParameterSetSelections : ContextSpecification<OverwriteParameterSetSelections>
+   {
+      protected OverwriteParameterSet _renalImpairmentSet;
+      protected OverwriteParameterSet _hepaticImpairmentSet;
+
+      protected override void Context()
+      {
+         sut = new OverwriteParameterSetSelections();
+         _renalImpairmentSet = new OverwriteParameterSet { Name = "RenalImpairment" };
+         _hepaticImpairmentSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+      }
+   }
+
+   public class When_setting_a_selection_for_a_compound : concern_for_OverwriteParameterSetSelections
+   {
+      protected override void Because()
+      {
+         sut.SetSelectionForCompound("Aspirin", _renalImpairmentSet);
+      }
+
+      [Observation]
+      public void should_store_the_selection()
+      {
+         sut.SelectedSetFor("Aspirin").ShouldBeEqualTo(_renalImpairmentSet);
+      }
+
+      [Observation]
+      public void should_have_one_selection()
+      {
+         sut.Selections.Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_updating_a_selection_for_an_existing_compound : concern_for_OverwriteParameterSetSelections
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.SetSelectionForCompound("Aspirin", _renalImpairmentSet);
+      }
+
+      protected override void Because()
+      {
+         sut.SetSelectionForCompound("Aspirin", _hepaticImpairmentSet);
+      }
+
+      [Observation]
+      public void should_update_the_selection()
+      {
+         sut.SelectedSetFor("Aspirin").ShouldBeEqualTo(_hepaticImpairmentSet);
+      }
+
+      [Observation]
+      public void should_not_add_a_duplicate_entry()
+      {
+         sut.Selections.Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_querying_a_selection_for_an_unknown_compound : concern_for_OverwriteParameterSetSelections
+   {
+      [Observation]
+      public void should_return_null()
+      {
+         sut.SelectedSetFor("Unknown").ShouldBeNull();
+      }
+   }
+
+   public class When_removing_a_selection : concern_for_OverwriteParameterSetSelections
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.SetSelectionForCompound("Aspirin", _renalImpairmentSet);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveSelectionForCompound("Aspirin");
+      }
+
+      [Observation]
+      public void should_no_longer_have_the_selection()
+      {
+         sut.SelectedSetFor("Aspirin").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_have_no_selections()
+      {
+         sut.Selections.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_cloning_selections : concern_for_OverwriteParameterSetSelections
+   {
+      private OverwriteParameterSetSelections _clone;
+      private OverwriteParameterSet _caffeineSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         _caffeineSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+         sut.SetSelectionForCompound("Aspirin", _renalImpairmentSet);
+         sut.SetSelectionForCompound("Caffeine", _caffeineSet);
+      }
+
+      protected override void Because()
+      {
+         _clone = sut.Clone();
+      }
+
+      [Observation]
+      public void should_clone_all_selections()
+      {
+         _clone.Selections.Count.ShouldBeEqualTo(2);
+         _clone.SelectedSetFor("Aspirin").ShouldBeEqualTo(_renalImpairmentSet);
+         _clone.SelectedSetFor("Caffeine").ShouldBeEqualTo(_caffeineSet);
+      }
+
+      [Observation]
+      public void should_create_independent_copy()
+      {
+         _clone.SetSelectionForCompound("Aspirin", _hepaticImpairmentSet);
+         sut.SelectedSetFor("Aspirin").ShouldBeEqualTo(_renalImpairmentSet);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetSpecs.cs
@@ -1,0 +1,141 @@
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_OverwriteParameterSet : ContextSpecification<OverwriteParameterSet>
+   {
+      protected override void Context()
+      {
+         sut = new OverwriteParameterSet { Name = "TestSet", IsDefault = false };
+      }
+   }
+
+   public class When_adding_a_parameter_value : concern_for_OverwriteParameterSet
+   {
+      protected override void Because()
+      {
+         sut.Add(new ParameterValue { Path = "Path|To|Param".ToObjectPath(), Value = 1.0 });
+      }
+
+      [Observation]
+      public void should_contain_the_parameter_value()
+      {
+         sut.ParameterValues.Count.ShouldBeEqualTo(1);
+         sut.ParameterValues[0].Path.PathAsString.ShouldBeEqualTo("Path|To|Param");
+      }
+   }
+
+   public class When_retrieving_a_parameter_value_by_path : concern_for_OverwriteParameterSet
+   {
+      private ParameterValue _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.Add(new ParameterValue { Path = "Path|To|Param".ToObjectPath(), Value = 1.0 });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.ParameterValueByPath("Path|To|Param");
+      }
+
+      [Observation]
+      public void should_return_the_matching_parameter_value()
+      {
+         _result.ShouldNotBeNull();
+         _result.Value.ShouldBeEqualTo(1.0);
+      }
+   }
+
+   public class When_retrieving_a_parameter_value_by_nonexistent_path : concern_for_OverwriteParameterSet
+   {
+      private ParameterValue _result;
+
+      protected override void Because()
+      {
+         _result = sut.ParameterValueByPath("NonExistent");
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _result.ShouldBeNull();
+      }
+   }
+
+   public class When_removing_a_parameter_value : concern_for_OverwriteParameterSet
+   {
+      private ParameterValue _parameterValue;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValue = new ParameterValue { Path = "Path|To|Param".ToObjectPath(), Value = 1.0 };
+         sut.Add(_parameterValue);
+      }
+
+      protected override void Because()
+      {
+         sut.Remove(_parameterValue);
+      }
+
+      [Observation]
+      public void should_no_longer_contain_the_parameter_value()
+      {
+         sut.ParameterValues.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_updating_properties_from_another_overwrite_parameter_set : concern_for_OverwriteParameterSet
+   {
+      private OverwriteParameterSet _source;
+      private ICloneManager _cloneManager;
+      private ParameterValue _sourceParameterValue;
+      private ParameterValue _clonedParameterValue;
+
+      protected override void Context()
+      {
+         base.Context();
+         _cloneManager = A.Fake<ICloneManager>();
+         _source = new OverwriteParameterSet { Name = "SourceSet", IsDefault = true };
+         _sourceParameterValue = new ParameterValue { Path = "Path|To|Param".ToObjectPath(), Value = 1.0 };
+         _source.Add(_sourceParameterValue);
+         _source.ExtendedProperties.Add(new ExtendedProperty<string> { Name = "Species", Value = "Human" });
+         _clonedParameterValue = new ParameterValue { Path = "Path|To|Param".ToObjectPath(), Value = 1.0 };
+         A.CallTo(() => _cloneManager.Clone(_sourceParameterValue)).Returns(_clonedParameterValue);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdatePropertiesFrom(_source, _cloneManager);
+      }
+
+      [Observation]
+      public void should_update_basic_properties()
+      {
+         sut.Name.ShouldBeEqualTo("SourceSet");
+         sut.IsDefault.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_clone_parameter_values_using_clone_manager()
+      {
+         sut.ParameterValues.Count.ShouldBeEqualTo(1);
+         sut.ParameterValues[0].ShouldBeEqualTo(_clonedParameterValue);
+      }
+
+      [Observation]
+      public void should_update_extended_properties()
+      {
+         sut.ExtendedProperties["Species"].ValueAsObject.ShouldBeEqualTo("Human");
+      }
+   }
+}


### PR DESCRIPTION
Implements OverwriteParameterSet domain objects


Closes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing parameter set overrides in simulations, allowing users to select and configure alternative parameter sets for compounds within their simulation configurations.
  * Introduced capability to add, remove, and track parameter value overrides per compound.

* **Tests**
  * Added comprehensive test coverage for parameter set selection behavior and override management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->