### PR TITLE
Remove SQLite.Interop.dll.dylib from dependency package

### DIFF
--- a/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
+++ b/src/PKSimRDependencyResolution/PKSimRDependencyResolution.csproj
@@ -60,10 +60,8 @@
     <ItemGroup>
       <LinuxFiles Include="$(TargetDir)runtimes/linux-x64/native/SQLite.Interop.dll" />
       <WindowsFiles Include="$(TargetDir)runtimes/win-x64/native/SQLite.Interop.dll" />
-      <MacFiles Include="$(TargetDir)runtimes/osx-x64/native/SQLite.Interop.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(WindowsFiles);" DestinationFolder="$(TargetFolder)" DestinationFiles="@(WindowsFiles-&gt;Replace('runtimes/win-x64/native/SQLite.Interop.dll', 'SQLite.Interop.dll'))" />
     <Copy SourceFiles="@(LinuxFiles);" DestinationFolder="$(TargetFolder)" DestinationFiles="@(LinuxFiles-&gt;Replace('runtimes/linux-x64/native/SQLite.Interop.dll', 'libSQLite.Interop.dll'))" />
-    <Copy SourceFiles="@(MacFiles);" DestinationFolder="$(TargetFolder)" DestinationFiles="@(MacFiles-&gt;Replace('runtimes/osx-x64/native/SQLite.Interop.dll', 'SQLite.Interop.dll.dylib'))" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Removes the macOS Intel (`osx-x64`) SQLite interop library from the R dependency package
- This file only comes in Intel format and macOS packages are no longer built on Intel


Fixes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed macOS-specific SQLite interop artifact handling from the build process; Windows and Linux functionality unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->