### PR TITLE
Fixes #3428 Add snapshot save/load for OverwriteParameterSet

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -831,6 +831,8 @@ namespace PKSim.Assets
 
          public static string SimulationTemplateBuildingBlockNotFoundInProject(string buildingBlockName, string buildingBlockType) => $"{buildingBlockType} '{buildingBlockName} not found in project.";
 
+         public static string OverWriteParameterSetNotFoundInCompound(string overWriteParameterSetName, string comnpoundName)=> $"Overwrite parameter set '{overWriteParameterSetName}' not found in compound '{comnpoundName}'";
+
          public static string ProcessNotFoundInCompound(string processName, string compound) => $"Process '{processName}' was not found in compound '{compound}'";
 
          public static string OnlyPKSimSimulationCanBeExportedToSnapshot(string simulationName, string origin) => $"Snapshot export is not supported for {origin} simulation '{simulationName}'.";

--- a/src/PKSim.Core/Snapshots/Compound.cs
+++ b/src/PKSim.Core/Snapshots/Compound.cs
@@ -30,6 +30,7 @@ namespace PKSim.Core.Snapshots
       public PkaType[] PkaTypes { get; set; }
       public CompoundProcess[] Processes { get; set; }
       public CalculationMethodCache CalculationMethods { get; set; }
+      public OverwriteParameterSet[] OverwriteParameterSets { get; set; }
       public PKSimBuildingBlockType BuildingBlockType { get; } = PKSimBuildingBlockType.Compound;
    }
 }

--- a/src/PKSim.Core/Snapshots/Mappers/CompoundMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/CompoundMapper.cs
@@ -19,6 +19,7 @@ public class CompoundMapper : ParameterContainerSnapshotMapperBase<ModelCompound
    private readonly CalculationMethodCacheMapper _calculationMethodCacheMapper;
    private readonly CompoundProcessMapper _processMapper;
    private readonly ValueOriginMapper _valueOriginMapper;
+   private readonly OverwriteParameterSetMapper _overwriteParameterSetMapper;
    private readonly ICompoundFactory _compoundFactory;
 
    public CompoundMapper(
@@ -27,12 +28,14 @@ public class CompoundMapper : ParameterContainerSnapshotMapperBase<ModelCompound
       CalculationMethodCacheMapper calculationMethodCacheMapper,
       CompoundProcessMapper processMapper,
       ValueOriginMapper valueOriginMapper,
+      OverwriteParameterSetMapper overwriteParameterSetMapper,
       ICompoundFactory compoundFactory) : base(parameterMapper)
    {
       _alternativeMapper = alternativeMapper;
       _calculationMethodCacheMapper = calculationMethodCacheMapper;
       _processMapper = processMapper;
       _valueOriginMapper = valueOriginMapper;
+      _overwriteParameterSetMapper = overwriteParameterSetMapper;
       _compoundFactory = compoundFactory;
    }
 
@@ -47,6 +50,7 @@ public class CompoundMapper : ParameterContainerSnapshotMapperBase<ModelCompound
       snapshot.Permeability = await mapAlternatives(compound, COMPOUND_PERMEABILITY);
       snapshot.PkaTypes = await mapPkaTypes(compound);
       snapshot.Processes = await mapProcesses(compound);
+      snapshot.OverwriteParameterSets = await _overwriteParameterSetMapper.MapToSnapshots(compound.OverwriteParameterSets);
       snapshot.IsSmallMolecule = compound.IsSmallMolecule;
       snapshot.PlasmaProteinBindingPartner = SnapshotValueFor(compound.PlasmaProteinBindingPartner, PlasmaProteinBindingPartner.Unknown);
       return snapshot;
@@ -67,6 +71,7 @@ public class CompoundMapper : ParameterContainerSnapshotMapperBase<ModelCompound
       updatePkaTypes(compound, snapshot);
 
       await updateProcesses(snapshot, compound, snapshotContext);
+      await updateOverwriteParameterSets(snapshot, compound, snapshotContext);
       await UpdateParametersFromSnapshot(snapshot, compound, snapshotContext);
 
       synchronizeMolWeightValueOrigins(compound);
@@ -84,6 +89,12 @@ public class CompoundMapper : ParameterContainerSnapshotMapperBase<ModelCompound
    {
       var processes = await _processMapper.MapToModels(snapshot.Processes, snapshotContext);
       processes?.Each(compound.AddProcess);
+   }
+
+   private async Task updateOverwriteParameterSets(SnapshotCompound snapshot, ModelCompound compound, SnapshotContext snapshotContext)
+   {
+      var overwriteParameterSets = await _overwriteParameterSetMapper.MapToModels(snapshot.OverwriteParameterSets, snapshotContext);
+      overwriteParameterSets?.Each(compound.AddOverwriteParameterSet);
    }
 
    private async Task updateAlternatives(ModelCompound compound, Alternative[] snapshotAlternatives, string alternativeGroupName, SnapshotContext snapshotContext)

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetMapper.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using OSPSuite.Core.Snapshots.Mappers;
+using OSPSuite.Utility.Extensions;
+using static OSPSuite.Core.Extensions.SnapshotMapperBaseExtensions;
+using ModelOverwriteParameterSet = PKSim.Core.Model.OverwriteParameterSet;
+using SnapshotOverwriteParameterSet = PKSim.Core.Snapshots.OverwriteParameterSet;
+
+namespace PKSim.Core.Snapshots.Mappers;
+
+public class OverwriteParameterSetMapper : SnapshotMapperBase<ModelOverwriteParameterSet, SnapshotOverwriteParameterSet>
+{
+   private readonly ParameterValueMapper _parameterValueMapper;
+   private readonly ExtendedPropertyMapper _extendedPropertyMapper;
+
+   public OverwriteParameterSetMapper(ParameterValueMapper parameterValueMapper, ExtendedPropertyMapper extendedPropertyMapper)
+   {
+      _parameterValueMapper = parameterValueMapper;
+      _extendedPropertyMapper = extendedPropertyMapper;
+   }
+
+   public override async Task<SnapshotOverwriteParameterSet> MapToSnapshot(ModelOverwriteParameterSet model)
+   {
+      var snapshot = await SnapshotFrom(model, x =>
+      {
+         x.Name = model.Name;
+         x.IsDefault = SnapshotValueFor(model.IsDefault, false);
+      });
+
+      snapshot.ExtendedProperties = await _extendedPropertyMapper.MapToSnapshots(model.ExtendedProperties.All);
+      snapshot.ParameterValues = await _parameterValueMapper.MapToSnapshots(model.ParameterValues);
+
+      return snapshot;
+   }
+
+   public override async Task<ModelOverwriteParameterSet> MapToModel(SnapshotOverwriteParameterSet snapshot, SnapshotContext snapshotContext)
+   {
+      var overwriteParameterSet = new ModelOverwriteParameterSet
+      {
+         Name = snapshot.Name,
+         IsDefault = ModelValueFor(snapshot.IsDefault, false)
+      };
+
+      var extendedProperties = await _extendedPropertyMapper.MapToModels(snapshot.ExtendedProperties, snapshotContext);
+      extendedProperties?.Each(overwriteParameterSet.ExtendedProperties.Add);
+
+      var parameterValues = await _parameterValueMapper.MapToModels(snapshot.ParameterValues, snapshotContext);
+      parameterValues?.Each(overwriteParameterSet.Add);
+
+      return overwriteParameterSet;
+   }
+}

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
@@ -41,7 +41,10 @@ public class OverwriteParameterSetSelectionMapper : SnapshotMapperBase<ModelOver
 
       var overwriteParameterSet = compound.OverwriteParameterSets.FirstOrDefault(x => x.IsNamed(snapshot.OverwriteParameterSetName));
       if (overwriteParameterSet == null)
+      {
+         _logger.AddWarning(PKSimConstants.Error.OverWriteParameterSetNotFoundInCompound(snapshot.OverwriteParameterSetName, snapshot.CompoundName));
          return Task.FromResult<ModelOverwriteParameterSetSelection>(null);
+      }
 
       var selection = new ModelOverwriteParameterSetSelection
       {

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
@@ -20,9 +20,9 @@ public class OverwriteParameterSetSelectionMapper : SnapshotMapperBase<ModelOver
       _logger = logger;
    }
 
-   public override async Task<SnapshotOverwriteParameterSetSelection> MapToSnapshot(ModelOverwriteParameterSetSelection selection, PKSimProject project)
+   public override Task<SnapshotOverwriteParameterSetSelection> MapToSnapshot(ModelOverwriteParameterSetSelection selection, PKSimProject project)
    {
-      return await SnapshotFrom(selection, snapshot =>
+      return SnapshotFrom(selection, snapshot =>
       {
          snapshot.CompoundName = selection.CompoundName;
          snapshot.OverwriteParameterSetName = selection.OverwriteParameterSet?.Name;

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using System.Threading.Tasks;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+using OSPSuite.Core.Snapshots.Mappers;
+using PKSim.Assets;
+using PKSim.Core.Model;
+using ModelCompound = PKSim.Core.Model.Compound;
+using ModelOverwriteParameterSetSelection = PKSim.Core.Model.OverwriteParameterSetSelection;
+using SnapshotOverwriteParameterSetSelection = PKSim.Core.Snapshots.OverwriteParameterSetSelection;
+
+namespace PKSim.Core.Snapshots.Mappers;
+
+public class OverwriteParameterSetSelectionMapper : SnapshotMapperBase<ModelOverwriteParameterSetSelection, SnapshotOverwriteParameterSetSelection, SnapshotContext, PKSimProject>
+{
+   private readonly IOSPSuiteLogger _logger;
+
+   public OverwriteParameterSetSelectionMapper(IOSPSuiteLogger logger)
+   {
+      _logger = logger;
+   }
+
+   public override async Task<SnapshotOverwriteParameterSetSelection> MapToSnapshot(ModelOverwriteParameterSetSelection selection, PKSimProject project)
+   {
+      return await SnapshotFrom(selection, snapshot =>
+      {
+         snapshot.CompoundName = selection.CompoundName;
+         snapshot.OverwriteParameterSetName = selection.OverwriteParameterSet?.Name;
+      });
+   }
+
+   public override Task<ModelOverwriteParameterSetSelection> MapToModel(SnapshotOverwriteParameterSetSelection snapshot, SnapshotContext snapshotContext)
+   {
+      var project = snapshotContext.PKSimProject();
+      var compound = project.BuildingBlockByName<ModelCompound>(snapshot.CompoundName);
+      if (compound == null)
+      {
+         _logger.AddWarning(PKSimConstants.Error.SimulationTemplateBuildingBlockNotFoundInProject(snapshot.CompoundName, nameof(ModelCompound)));
+         return Task.FromResult<ModelOverwriteParameterSetSelection>(null);
+      }
+
+      var overwriteParameterSet = compound.OverwriteParameterSets.FirstOrDefault(x => x.IsNamed(snapshot.OverwriteParameterSetName));
+      if (overwriteParameterSet == null)
+         return Task.FromResult<ModelOverwriteParameterSetSelection>(null);
+
+      var selection = new ModelOverwriteParameterSetSelection
+      {
+         CompoundName = snapshot.CompoundName,
+         OverwriteParameterSet = overwriteParameterSet
+      };
+
+      return Task.FromResult(selection);
+   }
+}

--- a/src/PKSim.Core/Snapshots/Mappers/ParameterRangeMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ParameterRangeMapper.cs
@@ -17,7 +17,7 @@ namespace PKSim.Core.Snapshots.Mappers
 
    public class ParameterRangeMapper : SnapshotMapperBase<ModelParameterRange, SnapshotParameterRange, ParameterRangeSnapshotContext>
    {
-      public override async Task<SnapshotParameterRange> MapToSnapshot(ModelParameterRange parameterRange)
+      public override Task<SnapshotParameterRange> MapToSnapshot(ModelParameterRange parameterRange)
       {
          if (parameterRange == null)
             return null;
@@ -26,7 +26,7 @@ namespace PKSim.Core.Snapshots.Mappers
          if (parameterRange.MaxValueInDisplayUnit == null && parameterRange.MaxValueInDisplayUnit == null)
             return null;
 
-         return await SnapshotFrom(parameterRange, snapshot =>
+         return SnapshotFrom(parameterRange, snapshot =>
          {
             snapshot.Min = parameterRange.MinValueInDisplayUnit;
             snapshot.Max = parameterRange.MaxValueInDisplayUnit;

--- a/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
@@ -8,11 +8,11 @@ namespace PKSim.Core.Snapshots.Mappers;
 
 public class ParameterValueMapper : SnapshotMapperBase<ModelParameterValue, SnapshotParameterValue>
 {
-   public override async Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
+   public override Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
    {
       // We will only use path and value because in an OverWriteParameterSet we only care about parameters whose values
       // are overridden in the simulation. You can only override a parameter in a simulation with a value.
-      return await SnapshotFrom(parameterValue, snapshot =>
+      return SnapshotFrom(parameterValue, snapshot =>
       {
          snapshot.Path = parameterValue.Path.ToString();
          snapshot.Value = parameterValue.Value.Value;

--- a/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Snapshots.Mappers;
+using ModelParameterValue = OSPSuite.Core.Domain.Builder.ParameterValue;
+using SnapshotParameterValue = PKSim.Core.Snapshots.ParameterValue;
+
+namespace PKSim.Core.Snapshots.Mappers;
+
+public class ParameterValueMapper : SnapshotMapperBase<ModelParameterValue, SnapshotParameterValue>
+{
+   public override async Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
+   {
+      // We will only use path and value for this application
+      return await SnapshotFrom(parameterValue, snapshot =>
+      {
+         snapshot.Path = parameterValue.Path.ToString();
+         snapshot.Value = parameterValue.Value.GetValueOrDefault();
+      });
+   }
+
+   public override Task<ModelParameterValue> MapToModel(SnapshotParameterValue snapshot, SnapshotContext snapshotContext)
+   {
+      var parameterValue = new ModelParameterValue
+      {
+         Path = snapshot.Path.ToObjectPath(),
+         Value = snapshot.Value
+      };
+
+      return Task.FromResult(parameterValue);
+   }
+}

--- a/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
@@ -10,11 +10,12 @@ public class ParameterValueMapper : SnapshotMapperBase<ModelParameterValue, Snap
 {
    public override async Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
    {
-      // We will only use path and value for this application
+      // We will only use path and value because in an OverWriteParameterSet we only care about parameters whose values
+      // are overridden in the simulation. You can only override a parameter in a simulation with a value.
       return await SnapshotFrom(parameterValue, snapshot =>
       {
          snapshot.Path = parameterValue.Path.ToString();
-         snapshot.Value = parameterValue.Value.GetValueOrDefault();
+         snapshot.Value = parameterValue.Value.Value;
       });
    }
 

--- a/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -217,30 +217,30 @@ namespace PKSim.Core.Snapshots.Mappers
       private Task<OSPSuite.Core.Domain.QualificationPlan[]> allQualificationPlansFrom(QualificationPlan[] qualificationPlans, SnapshotContext snapshotContext)
          => _qualificationPlanMapper.MapToModels(qualificationPlans, snapshotContext);
 
-      private async Task<SimulationComparison[]> mapSimulationComparisonsToSnapshots(IReadOnlyCollection<ISimulationComparison> allSimulationComparisons)
+      private Task<SimulationComparison[]> mapSimulationComparisonsToSnapshots(IReadOnlyCollection<ISimulationComparison> allSimulationComparisons)
       {
          if (!allSimulationComparisons.Any())
             return null;
 
          allSimulationComparisons.Each(load);
-         return await _simulationComparisonMapper.MapToSnapshots(allSimulationComparisons);
+         return _simulationComparisonMapper.MapToSnapshots(allSimulationComparisons);
       }
 
-      private async Task<Simulation[]> mapSimulationsToSnapshots(IReadOnlyCollection<ModelSimulation> allSimulations, ModelProject project)
+      private Task<Simulation[]> mapSimulationsToSnapshots(IReadOnlyCollection<ModelSimulation> allSimulations, ModelProject project)
       {
          allSimulations.Each(loadSimulation);
-         return await _simulationMapper.MapToSnapshots(allSimulations, project);
+         return _simulationMapper.MapToSnapshots(allSimulations, project);
       }
 
-      private async Task<QualificationPlan[]> mapQualificationPlansToSnapshots(IReadOnlyCollection<OSPSuite.Core.Domain.QualificationPlan> allQualificationPlans)
+      private Task<QualificationPlan[]> mapQualificationPlansToSnapshots(IReadOnlyCollection<OSPSuite.Core.Domain.QualificationPlan> allQualificationPlans)
       {
-         return await _qualificationPlanMapper.MapToSnapshots(allQualificationPlans);
+         return _qualificationPlanMapper.MapToSnapshots(allQualificationPlans);
       }
 
-      protected override async Task<ParameterIdentification[]> MapParameterIdentificationToSnapshots(IReadOnlyCollection<ModelParameterIdentification> allParameterIdentifications)
+      protected override Task<ParameterIdentification[]> MapParameterIdentificationToSnapshots(IReadOnlyCollection<ModelParameterIdentification> allParameterIdentifications)
       {
          allParameterIdentifications.Each(load);
-         return await base.MapParameterIdentificationToSnapshots(allParameterIdentifications);
+         return base.MapParameterIdentificationToSnapshots(allParameterIdentifications);
       }
 
       private void load(ILazyLoadable lazyLoadable) => _lazyLoadTask.Load(lazyLoadable);

--- a/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
@@ -44,6 +44,7 @@ namespace PKSim.Core.Snapshots.Mappers
       private readonly IContainerTask _containerTask;
       private readonly IEntityPathResolver _entityPathResolver;
       private readonly IChartTask _chartTask;
+      private readonly OverwriteParameterSetSelectionMapper _overwriteParameterSetSelectionMapper;
 
       public SimulationMapper(
          SolverSettingsMapper solverSettingsMapper,
@@ -58,6 +59,7 @@ namespace PKSim.Core.Snapshots.Mappers
          PopulationAnalysisChartMapper populationAnalysisChartMapper,
          ProcessMappingMapper processMappingMapper,
          OutputMappingMapper outputMappingMapper,
+         OverwriteParameterSetSelectionMapper overwriteParameterSetSelectionMapper,
          ISimulationFactory simulationFactory,
          IExecutionContext executionContext,
          ISimulationModelCreator simulationModelCreator,
@@ -81,6 +83,7 @@ namespace PKSim.Core.Snapshots.Mappers
          _populationAnalysisChartMapper = populationAnalysisChartMapper;
          _processMappingMapper = processMappingMapper;
          _outputMappingMapper = outputMappingMapper;
+         _overwriteParameterSetSelectionMapper = overwriteParameterSetSelectionMapper;
          _simulationFactory = simulationFactory;
          _executionContext = executionContext;
          _simulationModelCreator = simulationModelCreator;
@@ -118,7 +121,14 @@ namespace PKSim.Core.Snapshots.Mappers
          snapshot.PopulationAnalyses = await _populationAnalysisChartMapper.MapToSnapshots(simulation.AnalysesOfType<ModelPopulationAnalysisChart>());
          snapshot.HasResults = simulation.HasResults;
          snapshot.AlteredBuildingBlocks = alteredBuildingBlocksIn(simulation);
+         snapshot.OverwriteParameterSetSelections = await _overwriteParameterSetSelectionMapper.MapToSnapshots(simulation.OverwriteParameterSetSelections.Selections, project);
          return snapshot;
+      }
+
+      private async Task updateOverwriteParameterSetSelections(ModelSimulation simulation, OverwriteParameterSetSelection[] snapshotSelections, SnapshotContext snapshotContext)
+      {
+         var selections = await _overwriteParameterSetSelectionMapper.MapToModels(snapshotSelections, snapshotContext);
+         selections?.Each(selection => simulation.AddOverwriteParameterSetSelection(selection.CompoundName, selection.OverwriteParameterSet));
       }
 
       private AlteredBuildingBlock[] alteredBuildingBlocksIn(ModelSimulation simulation)
@@ -287,6 +297,7 @@ namespace PKSim.Core.Snapshots.Mappers
          updateUsedObservedData(simulation, snapshot.ObservedData, project);
 
          updateAlteredBuildingBlock(simulation, snapshot.AlteredBuildingBlocks);
+         await updateOverwriteParameterSetSelections(simulation, snapshot.OverwriteParameterSetSelections, snapshotContext);
 
          _simulationParameterOriginIdUpdater.UpdateSimulationId(simulation);
          _chartTask.UpdateObservedDataInChartsFor(simulation, snapshotContext.Project);

--- a/src/PKSim.Core/Snapshots/OverwriteParameterSet.cs
+++ b/src/PKSim.Core/Snapshots/OverwriteParameterSet.cs
@@ -1,0 +1,11 @@
+using OSPSuite.Core.Snapshots;
+
+namespace PKSim.Core.Snapshots
+{
+   public class OverwriteParameterSet : SnapshotBase
+   {
+      public bool? IsDefault { get; set; }
+      public ExtendedProperty[] ExtendedProperties { get; set; }
+      public ParameterValue[] ParameterValues { get; set; }
+   }
+}

--- a/src/PKSim.Core/Snapshots/OverwriteParameterSetSelection.cs
+++ b/src/PKSim.Core/Snapshots/OverwriteParameterSetSelection.cs
@@ -1,0 +1,8 @@
+namespace PKSim.Core.Snapshots
+{
+   public class OverwriteParameterSetSelection
+   {
+      public string CompoundName { get; set; }
+      public string OverwriteParameterSetName { get; set; }
+   }
+}

--- a/src/PKSim.Core/Snapshots/OverwriteParameterSetSelection.cs
+++ b/src/PKSim.Core/Snapshots/OverwriteParameterSetSelection.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PKSim.Core.Snapshots
 {
    public class OverwriteParameterSetSelection
    {
+      [Required]
       public string CompoundName { get; set; }
+
+      [Required]
       public string OverwriteParameterSetName { get; set; }
    }
 }

--- a/src/PKSim.Core/Snapshots/ParameterValue.cs
+++ b/src/PKSim.Core/Snapshots/ParameterValue.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PKSim.Core.Snapshots;
 
 public class ParameterValue
 {
+   [Required]
    public string Path { get; set; }
+
+   [Required]
    public double Value { get; set; }
 }

--- a/src/PKSim.Core/Snapshots/ParameterValue.cs
+++ b/src/PKSim.Core/Snapshots/ParameterValue.cs
@@ -1,0 +1,7 @@
+namespace PKSim.Core.Snapshots;
+
+public class ParameterValue
+{
+   public string Path { get; set; }
+   public double Value { get; set; }
+}

--- a/src/PKSim.Core/Snapshots/Simulation.cs
+++ b/src/PKSim.Core/Snapshots/Simulation.cs
@@ -39,6 +39,7 @@ namespace PKSim.Core.Snapshots
       public PopulationAnalysisChart[] PopulationAnalyses { get; set; }
 
       public CompoundProcessSelection[] Interactions { get; set; }
+      public OverwriteParameterSetSelection[] OverwriteParameterSetSelections { get; set; }
 
       public IReadOnlyList<OSPSuite.Core.Snapshots.Chart> Analyses
       {

--- a/tests/PKSim.Tests/Core/CompoundMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/CompoundMapperSpecs.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using OSPSuite.Core.Snapshots;
 using CalculationMethodCache = OSPSuite.Core.Snapshots.CalculationMethodCache;
-using CalculationMethodCacheMapper = PKSim.Core.Snapshots.Mappers.CalculationMethodCacheMapper;
 using Compound = PKSim.Core.Snapshots.Compound;
 using CompoundProcess = PKSim.Core.Snapshots.CompoundProcess;
 using ValueOrigin = OSPSuite.Core.Snapshots.ValueOrigin;
@@ -37,9 +36,10 @@ namespace PKSim.Core
       private ParameterAlternativeGroup _compoundIntestinalPermeabilityAlternativeGroup;
       private ParameterAlternative _calculatedAlternative;
       protected ValueOriginMapper _valueOriginMapper;
+      protected OverwriteParameterSetMapper _overwriteParameterSetMapper;
       protected ValueOrigin _snapshotValueOrigin;
       protected OSPSuite.Core.Domain.ValueOrigin _pkaValueOrigin;
-      private IParameter _molweightParameter;
+      private IParameter _molWeightParameter;
       private IParameter _halogenFParameter;
 
       protected override Task Context()
@@ -50,7 +50,8 @@ namespace PKSim.Core
          _processMapper = A.Fake<CompoundProcessMapper>();
          _compoundFactory = A.Fake<ICompoundFactory>();
          _valueOriginMapper = A.Fake<ValueOriginMapper>();
-         sut = new CompoundMapper(_parameterMapper, _alternativeMapper, _calculationMethodCacheMapper, _processMapper, _valueOriginMapper, _compoundFactory);
+         _overwriteParameterSetMapper = A.Fake<OverwriteParameterSetMapper>();
+         sut = new CompoundMapper(_parameterMapper, _alternativeMapper, _calculationMethodCacheMapper, _processMapper, _valueOriginMapper, _overwriteParameterSetMapper, _compoundFactory);
 
          _compound = new Model.Compound
          {
@@ -94,13 +95,13 @@ namespace PKSim.Core
          A.CallTo(() => _processMapper.MapToSnapshot(_partialProcess)).Returns(_snapshotProcess1);
          A.CallTo(() => _processMapper.MapToSnapshot(_systemicProcess)).Returns(_snapshotProcess2);
 
-         _molweightParameter = DomainHelperForSpecs.ConstantParameterWithValue(400).WithName(Constants.Parameters.MOL_WEIGHT);
-         _molweightParameter.ValueOrigin.Method = ValueOriginDeterminationMethods.InVivo;
+         _molWeightParameter = DomainHelperForSpecs.ConstantParameterWithValue(400).WithName(Constants.Parameters.MOL_WEIGHT);
+         _molWeightParameter.ValueOrigin.Method = ValueOriginDeterminationMethods.InVivo;
 
          //Do not update F value origin to ensure that it's being synchronized when mapping from snapshot
          _halogenFParameter = DomainHelperForSpecs.ConstantParameterWithValue(5).WithName(Constants.Parameters.F);
 
-         _compound.Add(_molweightParameter);
+         _compound.Add(_molWeightParameter);
          _compound.Add(_halogenFParameter);
          return _completed;
       }
@@ -131,6 +132,19 @@ namespace PKSim.Core
 
    public class When_mapping_a_compound_to_snapshot : concern_for_CompoundMapper
    {
+      private Model.OverwriteParameterSet _overwriteParameterSet;
+      private Snapshots.OverwriteParameterSet _snapshotOverwriteParameterSet;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _overwriteParameterSet = new Model.OverwriteParameterSet { Name = "MySet" };
+         _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+         _snapshotOverwriteParameterSet = new Snapshots.OverwriteParameterSet { Name = "MySet" };
+         A.CallTo(() => _overwriteParameterSetMapper.MapToSnapshot(_overwriteParameterSet)).Returns(_snapshotOverwriteParameterSet);
+      }
+
       protected override async Task Because()
       {
          _snapshot = await sut.MapToSnapshot(_compound);
@@ -175,6 +189,12 @@ namespace PKSim.Core
          _snapshot.Solubility.Length.ShouldBeEqualTo(1);
          _snapshot.IntestinalPermeability.Length.ShouldBeEqualTo(1);
          _snapshot.Permeability.Length.ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_save_the_overwrite_parameter_sets()
+      {
+         _snapshot.OverwriteParameterSets.ShouldOnlyContain(_snapshotOverwriteParameterSet);
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
@@ -1,0 +1,193 @@
+using System.Linq;
+using System.Threading.Tasks;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Snapshots;
+using OSPSuite.Core.Snapshots.Mappers;
+using PKSim.Core.Model;
+using ModelOverwriteParameterSet = PKSim.Core.Model.OverwriteParameterSet;
+using ModelParameterValue = OSPSuite.Core.Domain.Builder.ParameterValue;
+using OverwriteParameterSetMapper = PKSim.Core.Snapshots.Mappers.OverwriteParameterSetMapper;
+using ParameterValueMapper = PKSim.Core.Snapshots.Mappers.ParameterValueMapper;
+using SnapshotOverwriteParameterSet = PKSim.Core.Snapshots.OverwriteParameterSet;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_OverwriteParameterSetMapper : ContextSpecificationAsync<OverwriteParameterSetMapper>
+   {
+      protected ModelOverwriteParameterSet _modelOverwriteParameterSet;
+      protected SnapshotOverwriteParameterSet _snapshot;
+      protected ParameterValueMapper _parameterValueMapper;
+      protected ExtendedPropertyMapper _extendedPropertyMapper;
+
+      protected override Task Context()
+      {
+         _parameterValueMapper = new ParameterValueMapper();
+         _extendedPropertyMapper = new ExtendedPropertyMapper();
+         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper);
+
+         _modelOverwriteParameterSet = new ModelOverwriteParameterSet
+         {
+            Name = "MyParameterSet",
+            IsDefault = true
+         };
+
+         _modelOverwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = "Species", Value = "Human" });
+         _modelOverwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = "DiseaseState", Value = "Healthy" });
+         _modelOverwriteParameterSet.Add(new ModelParameterValue { Path = "Compound|Lipophilicity".ToObjectPath(), Value = 1.5 });
+         _modelOverwriteParameterSet.Add(new ModelParameterValue { Path = "Compound|Solubility".ToObjectPath(), Value = 0.5 });
+
+         return _completed;
+      }
+   }
+
+   public class When_mapping_an_overwrite_parameter_set_to_snapshot : concern_for_OverwriteParameterSetMapper
+   {
+      protected override async Task Because()
+      {
+         _snapshot = await sut.MapToSnapshot(_modelOverwriteParameterSet);
+      }
+
+      [Observation]
+      public void should_map_the_name()
+      {
+         _snapshot.Name.ShouldBeEqualTo("MyParameterSet");
+      }
+
+      [Observation]
+      public void should_map_the_is_default_flag()
+      {
+         _snapshot.IsDefault.ShouldBeEqualTo(true);
+      }
+
+      [Observation]
+      public void should_map_the_extended_properties()
+      {
+         _snapshot.ExtendedProperties.Length.ShouldBeEqualTo(2);
+         _snapshot.ExtendedProperties[0].Name.ShouldBeEqualTo("Species");
+         _snapshot.ExtendedProperties[0].Value.ShouldBeEqualTo("Human");
+         _snapshot.ExtendedProperties[1].Name.ShouldBeEqualTo("DiseaseState");
+         _snapshot.ExtendedProperties[1].Value.ShouldBeEqualTo("Healthy");
+      }
+
+      [Observation]
+      public void should_map_the_parameter_values()
+      {
+         _snapshot.ParameterValues.Length.ShouldBeEqualTo(2);
+         _snapshot.ParameterValues[0].Path.ShouldBeEqualTo("Compound|Lipophilicity");
+         _snapshot.ParameterValues[0].Value.ShouldBeEqualTo(1.5);
+         _snapshot.ParameterValues[1].Path.ShouldBeEqualTo("Compound|Solubility");
+         _snapshot.ParameterValues[1].Value.ShouldBeEqualTo(0.5);
+      }
+   }
+
+   public class When_mapping_an_overwrite_parameter_set_with_default_values_to_snapshot : concern_for_OverwriteParameterSetMapper
+   {
+      protected override Task Context()
+      {
+         _parameterValueMapper = new ParameterValueMapper();
+         _extendedPropertyMapper = new ExtendedPropertyMapper();
+         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper);
+
+         _modelOverwriteParameterSet = new ModelOverwriteParameterSet
+         {
+            Name = "EmptySet",
+            IsDefault = false
+         };
+
+         return _completed;
+      }
+
+      protected override async Task Because()
+      {
+         _snapshot = await sut.MapToSnapshot(_modelOverwriteParameterSet);
+      }
+
+      [Observation]
+      public void should_not_set_is_default_when_false()
+      {
+         _snapshot.IsDefault.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_not_set_extended_properties_when_empty()
+      {
+         _snapshot.ExtendedProperties.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_not_set_parameter_values_when_empty()
+      {
+         _snapshot.ParameterValues.ShouldBeNull();
+      }
+   }
+
+   public class When_mapping_a_snapshot_to_an_overwrite_parameter_set : concern_for_OverwriteParameterSetMapper
+   {
+      private ModelOverwriteParameterSet _result;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _snapshot = await sut.MapToSnapshot(_modelOverwriteParameterSet);
+      }
+
+      protected override async Task Because()
+      {
+         _result = await sut.MapToModel(_snapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current));
+      }
+
+      [Observation]
+      public void should_set_the_name()
+      {
+         _result.Name.ShouldBeEqualTo("MyParameterSet");
+      }
+
+      [Observation]
+      public void should_set_the_is_default_flag()
+      {
+         _result.IsDefault.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_restore_the_extended_properties()
+      {
+         _result.ExtendedProperties.Count().ShouldBeEqualTo(2);
+         _result.ExtendedProperties["Species"].ValueAsObject.ShouldBeEqualTo("Human");
+         _result.ExtendedProperties["DiseaseState"].ValueAsObject.ShouldBeEqualTo("Healthy");
+      }
+
+      [Observation]
+      public void should_restore_the_parameter_values()
+      {
+         _result.ParameterValues.Count.ShouldBeEqualTo(2);
+         _result.ParameterValueByPath("Compound|Lipophilicity").Value.ShouldBeEqualTo(1.5);
+         _result.ParameterValueByPath("Compound|Solubility").Value.ShouldBeEqualTo(0.5);
+      }
+   }
+
+   public class When_mapping_a_snapshot_with_null_collections_to_an_overwrite_parameter_set : concern_for_OverwriteParameterSetMapper
+   {
+      private ModelOverwriteParameterSet _result;
+
+      protected override async Task Because()
+      {
+         _snapshot = new SnapshotOverwriteParameterSet
+         {
+            Name = "EmptySet"
+         };
+
+         _result = await sut.MapToModel(_snapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current));
+      }
+
+      [Observation]
+      public void should_create_a_model_with_empty_collections()
+      {
+         _result.Name.ShouldBeEqualTo("EmptySet");
+         _result.IsDefault.ShouldBeFalse();
+         _result.ExtendedProperties.Count().ShouldBeEqualTo(0);
+         _result.ParameterValues.Count.ShouldBeEqualTo(0);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionMapperSpecs.cs
@@ -1,0 +1,158 @@
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Services;
+using OSPSuite.Core.Snapshots;
+using OSPSuite.Core.Snapshots.Mappers;
+using PKSim.Core.Model;
+using PKSim.Core.Snapshots.Mappers;
+using ModelOverwriteParameterSetSelection = PKSim.Core.Model.OverwriteParameterSetSelection;
+using SnapshotOverwriteParameterSetSelection = PKSim.Core.Snapshots.OverwriteParameterSetSelection;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_OverwriteParameterSetSelectionMapper : ContextSpecificationAsync<OverwriteParameterSetSelectionMapper>
+   {
+      protected IOSPSuiteLogger _logger;
+      protected PKSimProject _project;
+      protected Compound _compound;
+      protected OverwriteParameterSet _overwriteParameterSet;
+
+      protected override Task Context()
+      {
+         _logger = A.Fake<IOSPSuiteLogger>();
+
+         sut = new OverwriteParameterSetSelectionMapper(_logger);
+
+         _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet" };
+         _compound = new Compound { Name = "Aspirin" };
+         _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_compound);
+
+         return _completed;
+      }
+   }
+
+   public class When_round_tripping_an_overwrite_parameter_set_selection_through_snapshot : concern_for_OverwriteParameterSetSelectionMapper
+   {
+      private ModelOverwriteParameterSetSelection _original;
+      private SnapshotOverwriteParameterSetSelection _snapshot;
+      private ModelOverwriteParameterSetSelection _result;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _original = new ModelOverwriteParameterSetSelection
+         {
+            CompoundName = _compound.Name,
+            OverwriteParameterSet = _overwriteParameterSet
+         };
+
+         _snapshot = await sut.MapToSnapshot(_original, _project);
+      }
+
+      protected override async Task Because()
+      {
+         _result = await sut.MapToModel(_snapshot, new SnapshotContext(_project, SnapshotVersions.Current));
+      }
+
+      [Observation]
+      public void should_restore_the_compound_name()
+      {
+         _result.CompoundName.ShouldBeEqualTo(_compound.Name);
+      }
+
+      [Observation]
+      public void should_resolve_the_overwrite_parameter_set_from_the_compound()
+      {
+         _result.OverwriteParameterSet.ShouldBeEqualTo(_overwriteParameterSet);
+      }
+   }
+
+   public class When_mapping_a_selection_to_snapshot : concern_for_OverwriteParameterSetSelectionMapper
+   {
+      private ModelOverwriteParameterSetSelection _selection;
+      private SnapshotOverwriteParameterSetSelection _snapshot;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _selection = new ModelOverwriteParameterSetSelection
+         {
+            CompoundName = _compound.Name,
+            OverwriteParameterSet = _overwriteParameterSet
+         };
+      }
+
+      protected override async Task Because()
+      {
+         _snapshot = await sut.MapToSnapshot(_selection, _project);
+      }
+
+      [Observation]
+      public void should_map_the_compound_name()
+      {
+         _snapshot.CompoundName.ShouldBeEqualTo(_compound.Name);
+      }
+
+      [Observation]
+      public void should_map_the_overwrite_parameter_set_name()
+      {
+         _snapshot.OverwriteParameterSetName.ShouldBeEqualTo(_overwriteParameterSet.Name);
+      }
+   }
+
+   public class When_mapping_a_snapshot_with_a_missing_compound_to_model : concern_for_OverwriteParameterSetSelectionMapper
+   {
+      private ModelOverwriteParameterSetSelection _result;
+
+      protected override async Task Because()
+      {
+         var snapshot = new SnapshotOverwriteParameterSetSelection
+         {
+            CompoundName = "DoesNotExist",
+            OverwriteParameterSetName = _overwriteParameterSet.Name
+         };
+
+         _result = await sut.MapToModel(snapshot, new SnapshotContext(_project, SnapshotVersions.Current));
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _result.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_log_a_warning()
+      {
+         A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Warning, A<string>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_mapping_a_snapshot_with_a_missing_overwrite_parameter_set_to_model : concern_for_OverwriteParameterSetSelectionMapper
+   {
+      private ModelOverwriteParameterSetSelection _result;
+
+      protected override async Task Because()
+      {
+         var snapshot = new SnapshotOverwriteParameterSetSelection
+         {
+            CompoundName = _compound.Name,
+            OverwriteParameterSetName = "DoesNotExist"
+         };
+
+         _result = await sut.MapToModel(snapshot, new SnapshotContext(_project, SnapshotVersions.Current));
+      }
+
+      [Observation]
+      public void should_return_null()
+      {
+         _result.ShouldBeNull();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/SimulationMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimulationMapperSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
@@ -19,7 +18,6 @@ using PKSim.Core.Model.PopulationAnalyses;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots;
 using PKSim.Core.Snapshots.Mappers;
-using PKSim.Infrastructure.Services;
 using AdvancedParameter = PKSim.Core.Snapshots.AdvancedParameter;
 using Compound = PKSim.Core.Model.Compound;
 using CompoundProperties = PKSim.Core.Model.CompoundProperties;
@@ -31,10 +29,11 @@ using ObserverSet = PKSim.Core.Model.ObserverSet;
 using OutputSchema = OSPSuite.Core.Domain.OutputSchema;
 using OutputSchemaMapper = PKSim.Core.Snapshots.Mappers.OutputSchemaMapper;
 using OutputSelections = OSPSuite.Core.Snapshots.OutputSelections;
+using OverwriteParameterSet = PKSim.Core.Model.OverwriteParameterSet;
+using OverwriteParameterSetSelection = PKSim.Core.Snapshots.OverwriteParameterSetSelection;
 using PopulationAnalysisChart = PKSim.Core.Model.PopulationAnalyses.PopulationAnalysisChart;
 using Protocol = PKSim.Core.Model.Protocol;
 using Simulation = PKSim.Core.Snapshots.Simulation;
-using SimulationRunOptions = PKSim.Core.Services.SimulationRunOptions;
 using SnapshotOutputMapping = OSPSuite.Core.Snapshots.OutputMapping;
 using SolverSettings = OSPSuite.Core.Domain.SolverSettings;
 using SolverSettingsMapper = PKSim.Core.Snapshots.Mappers.SolverSettingsMapper;
@@ -99,6 +98,7 @@ namespace PKSim.Core
       protected OutputMappingMapper _outputMappingMapper;
       protected SnapshotOutputMapping _snapshotOutputMapping;
       protected IChartTask _chartTask;
+      protected OverwriteParameterSetSelectionMapper _overwriteParameterSetSelectionMapper;
 
       protected override Task Context()
       {
@@ -113,6 +113,7 @@ namespace PKSim.Core
          _curveChartMapper = A.Fake<SimulationTimeProfileChartMapper>();
          _processMappingMapper = A.Fake<ProcessMappingMapper>();
          _outputMappingMapper = A.Fake<OutputMappingMapper>();
+         _overwriteParameterSetSelectionMapper = A.Fake<OverwriteParameterSetSelectionMapper>();
          _simulationFactory = A.Fake<ISimulationFactory>();
          _executionContext = A.Fake<IExecutionContext>();
          _simulationModelCreator = A.Fake<ISimulationModelCreator>();
@@ -129,6 +130,7 @@ namespace PKSim.Core
             _outputSelectionMapper, _compoundPropertiesMapper, _parameterMapper,
             _advancedParameterMapper, _eventMappingMapper, _observerSetMappingMapper, _curveChartMapper,
             _populationAnalysisChartMapper, _processMappingMapper, _outputMappingMapper,
+            _overwriteParameterSetSelectionMapper,
             _simulationFactory, _executionContext, _simulationModelCreator,
             _simulationBuildingBlockUpdater, _modelPropertiesTask,
             _simulationParameterOriginIdUpdater,
@@ -136,16 +138,16 @@ namespace PKSim.Core
          );
 
          _project = new PKSimProject();
-         _individual = new Individual {Name = "IND", Id = "IndTemplateId"};
-         _compound = new Compound {Name = "COMP", Id = "COMP"};
-         _observerSet = new ObserverSet {Name = "OBS_SET", Id = "OBS_SET"};
-         _protocol = new SimpleProtocol {Name = "PROT", Id = "PROT"};
+         _individual = new Individual { Name = "IND", Id = "IndTemplateId" };
+         _compound = new Compound { Name = "COMP", Id = "COMP" };
+         _observerSet = new ObserverSet { Name = "OBS_SET", Id = "OBS_SET" };
+         _protocol = new SimpleProtocol { Name = "PROT", Id = "PROT" };
          _inductionProcess = new InductionProcess().WithName("Interaction process");
          _compound.AddProcess(_inductionProcess);
 
 
-         _event = new PKSimEvent {Name = "Event"};
-         _population = new RandomPopulation() {Name = "POP", Id = "PopTemplateId"};
+         _event = new PKSimEvent { Name = "Event" };
+         _population = new RandomPopulation() { Name = "POP", Id = "PopTemplateId" };
          _observedData = new DataRepository("OBS_ID").WithName("OBS");
          _project.AddBuildingBlock(_individual);
          _project.AddBuildingBlock(_compound);
@@ -158,18 +160,18 @@ namespace PKSim.Core
          {
             ModelProperties = new ModelProperties
             {
-               ModelConfiguration = new ModelConfiguration {ModelName = "4Comp"}
+               ModelConfiguration = new ModelConfiguration { ModelName = "4Comp" }
             }
          };
-         _interactionSelection = new InteractionSelection {ProcessName = _inductionProcess.Name};
-         _noInteractionSelection = new InteractionSelection {MoleculeName = "CYP2D6"};
+         _interactionSelection = new InteractionSelection { ProcessName = _inductionProcess.Name };
+         _noInteractionSelection = new InteractionSelection { MoleculeName = "CYP2D6" };
 
          _simulationProperties.InteractionProperties.AddInteraction(_interactionSelection);
          _simulationProperties.InteractionProperties.AddInteraction(_noInteractionSelection);
 
          _settings = new SimulationSettings();
          _rootContainer = new Container().WithName("Sim");
-         _model = new OSPSuite.Core.Domain.Model {Root = _rootContainer};
+         _model = new OSPSuite.Core.Domain.Model { Root = _rootContainer };
 
          _individualSimulation = new IndividualSimulation
          {
@@ -222,7 +224,7 @@ namespace PKSim.Core
          _noSelectionSnapshotInteraction.MoleculeName = _noInteractionSelection.MoleculeName;
 
          _compoundProperties = new CompoundProperties();
-         _snapshotCompoundProperties = new Snapshots.CompoundProperties {Name = _compound.Name};
+         _snapshotCompoundProperties = new Snapshots.CompoundProperties { Name = _compound.Name };
          _individualSimulation.Properties.AddCompoundProperties(_compoundProperties);
 
          _eventMapping = new EventMapping();
@@ -292,7 +294,7 @@ namespace PKSim.Core
       protected override async Task Context()
       {
          await base.Context();
-         _mobiSimulation = new IndividualSimulation {Properties = new SimulationProperties {Origin = Origins.MoBi}};
+         _mobiSimulation = new IndividualSimulation { Properties = new SimulationProperties { Origin = Origins.MoBi } };
       }
 
       [Observation]
@@ -349,15 +351,15 @@ namespace PKSim.Core
          _rootContainer.Add(_simulationParameter);
          _rootContainer.Add(_protocolParameter);
 
-         _localizedParameters = new[] {_individualChangedParameterSnapshot, _simulationParameterSnapshot, _protocolParameterSnapshot};
+         _localizedParameters = new[] { _individualChangedParameterSnapshot, _simulationParameterSnapshot, _protocolParameterSnapshot };
 
-         A.CallTo(() => _parameterMapper.LocalizedParametersFrom(A<IEnumerable<IParameter>>.That.Matches(x => x.ContainsAll(new[] {_individualParameterChanged, _simulationParameter, _protocolParameter}))))
+         A.CallTo(() => _parameterMapper.LocalizedParametersFrom(A<IEnumerable<IParameter>>.That.Matches(x => x.ContainsAll(new[] { _individualParameterChanged, _simulationParameter, _protocolParameter }))))
             .Returns(_localizedParameters);
 
          A.CallTo(() => _executionContext.Get<IParameter>(_individualParameterChanged.Origin.ParameterId)).Returns(_individualParameterChangedTemplate);
          A.CallTo(() => _executionContext.Get<IParameter>(_individualParameter.Origin.ParameterId)).Returns(_individualParameterTemplate);
 
-         _protocolTemplateBuildingBlock = new SimpleProtocol {Id = "ProtTemplateId"};
+         _protocolTemplateBuildingBlock = new SimpleProtocol { Id = "ProtTemplateId" };
          _project.AddBuildingBlock(_protocolTemplateBuildingBlock);
 
          var allIndividualTemplateParameters = new PathCacheForSpecs<IParameter>();
@@ -440,6 +442,12 @@ namespace PKSim.Core
       public void should_save_interactions()
       {
          _snapshot.Interactions.ShouldContain(_snapshotInteraction, _noSelectionSnapshotInteraction);
+      }
+
+      [Observation]
+      public void should_not_save_overwrite_parameter_set_selections_when_empty()
+      {
+         _snapshot.OverwriteParameterSetSelections.ShouldBeNull();
       }
 
       [Observation]
@@ -690,6 +698,44 @@ namespace PKSim.Core
          _simulation.ShouldBeAnInstanceOf<PopulationSimulation>();
          var populationSimulation = _simulation.DowncastTo<PopulationSimulation>();
          A.CallTo(() => _advancedParameterMapper.MapToModel(_snapshot.AdvancedParameters, populationSimulation, _snapshotSimulationContext)).MustHaveHappened();
+      }
+   }
+
+   public class When_mapping_a_simulation_with_overwrite_parameter_set_selections_to_snapshot : concern_for_SimulationMapper
+   {
+      private OverwriteParameterSet _overwriteParameterSet;
+      private OverwriteParameterSetSelection _snapshotOverwriteParameterSetSelection;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet" };
+         _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+         _individualSimulation.AddOverwriteParameterSetSelection(_compound.Name, _overwriteParameterSet);
+
+         _snapshotOverwriteParameterSetSelection = new OverwriteParameterSetSelection
+         {
+            CompoundName = _compound.Name,
+            OverwriteParameterSetName = "MySet"
+         };
+
+         A.CallTo(() => _overwriteParameterSetSelectionMapper.MapToSnapshot(
+               A<Model.OverwriteParameterSetSelection>.That.Matches(x => x.CompoundName == _compound.Name), _project))
+            .Returns(_snapshotOverwriteParameterSetSelection);
+      }
+
+      protected override async Task Because()
+      {
+         _snapshot = await sut.MapToSnapshot(_individualSimulation, _project);
+      }
+
+      [Observation]
+      public void should_save_the_overwrite_parameter_set_selections()
+      {
+         _snapshot.OverwriteParameterSetSelections.ShouldNotBeNull();
+         _snapshot.OverwriteParameterSetSelections.Length.ShouldBeEqualTo(1);
+         _snapshot.OverwriteParameterSetSelections[0].CompoundName.ShouldBeEqualTo(_compound.Name);
+         _snapshot.OverwriteParameterSetSelections[0].OverwriteParameterSetName.ShouldBeEqualTo("MySet");
       }
    }
 }


### PR DESCRIPTION
Fixes #3428 Add snapshot save/load for OverwriteParameterSet

## Summary
- Project serialization had been handled in a prior PR
- Add snapshot classes (`OverwriteParameterSet`, `ParameterValue`, `OverwriteParameterSetSelection`) and dedicated mappers for serializing `OverwriteParameterSet` on `Compound` and `OverwriteParameterSetSelections` on `Simulation`
- Each domain↔snapshot conversion uses a dedicated mapper (`OverwriteParameterSetMapper`, `ParameterValueMapper`, `OverwriteParameterSetSelectionMapper`) following the established codebase pattern, reusing `ExtendedPropertyMapper` from OSPSuite.Core
- Update `CompoundMapper` and `SimulationMapper` to persist and restore the new structures during snapshot save/load

## Test plan
- [x] All 5119 existing tests pass with 0 failures
- [x] Round-trip tests for `OverwriteParameterSetMapper` (model → snapshot → model)
- [x] Round-trip test for `OverwriteParameterSetSelectionMapper` including compound/parameter set resolution from project
- [x] Edge case tests: empty collections, missing compound, missing parameter set
- [x] `CompoundMapper` test verifies overwrite parameter sets appear in snapshot
- [x] `SimulationMapper` tests verify selections are saved/loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for overwrite parameter sets on compounds, allowing custom parameter value definitions.
  * Added the ability to associate overwrite parameter sets with simulations.
  * Enhanced snapshot functionality to preserve and restore parameter set configurations and their relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->