### PR TITLE
Add event placeholder mapping to simulation protocol configuration

### DIFF
--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -1,0 +1,10 @@
+## Issue Workflow
+
+When asked to fix or implement a GitHub issue, follow this workflow:
+
+1. **Branch** — Create a new branch from the current branch
+2. **Implement with tests** — Write the code and corresponding tests, following the testing document (`.claude/docs/testing.md`)
+3. **Code review** — Do a thorough code review of what was implemented
+4. **Verify quality** — Build and run tests to confirm everything passes
+5. **Commit** — Commit the changes
+6. **Push and PR** — Push the branch and create a PR targeting the branch it was created from

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1787,6 +1787,7 @@ namespace PKSim.Assets
          public static readonly string EventOffset = "Event offset";
          public static readonly string NoEvent = "<None>";
          public static readonly string PlaceholderFormulation = "Placeholder for formulation";
+         public static readonly string PlaceholderEvent = "Placeholder for event";
          public static readonly string Placeholder = "Placeholder";
          public static readonly string ProtocolProperties = "Protocol Properties";
          public static readonly string Dermal = "Dermal";

--- a/src/PKSim.Core/Model/EventPlaceholderMapping.cs
+++ b/src/PKSim.Core/Model/EventPlaceholderMapping.cs
@@ -1,0 +1,21 @@
+namespace PKSim.Core.Model
+{
+   public class EventPlaceholderMapping
+   {
+      /// <summary>
+      ///    Key used in the protocol for which a mapping is required (e.g. "EVENT_1")
+      /// </summary>
+      public string EventKey { get; set; }
+
+      /// <summary>
+      ///    Id of template event in project used for mapping
+      /// </summary>
+      public string TemplateEventId { get; set; }
+
+      /// <summary>
+      ///    Actual event reference used in the mapping (not serialized, used temporarily to create the simulation).
+      ///    The Event referenced here is either the template building block or the simulation building block changed in the simulation.
+      /// </summary>
+      public PKSimEvent Event { get; set; }
+   }
+}

--- a/src/PKSim.Core/Model/ProtocolProperties.cs
+++ b/src/PKSim.Core/Model/ProtocolProperties.cs
@@ -7,7 +7,8 @@ namespace PKSim.Core.Model
    public class ProtocolProperties
    {
       private readonly List<FormulationMapping> _formulationMappings;
-      
+      private readonly List<EventPlaceholderMapping> _eventPlaceholderMappings;
+
       /// <summary>
       /// Reference to <see cref="Protocol"/> used in the simulation.
       /// </summary>
@@ -16,35 +17,38 @@ namespace PKSim.Core.Model
       public ProtocolProperties()
       {
          _formulationMappings = new List<FormulationMapping>();
+         _eventPlaceholderMappings = new List<EventPlaceholderMapping>();
       }
 
       public virtual ProtocolProperties Clone()
       {
          var clone = new ProtocolProperties();
          FormulationMappings.Each(clone.AddFormulationMapping);
-        
+         EventPlaceholderMappings.Each(clone.AddEventPlaceholderMapping);
+
          //do not clone: simply update reference that should be changed if required
          clone.Protocol = Protocol;
 
          return clone;
       }
 
-      public virtual void AddFormulationMapping(FormulationMapping formulationMapping)
-      {
-         _formulationMappings.Add(formulationMapping);
-      }
+      public virtual void AddFormulationMapping(FormulationMapping formulationMapping) => _formulationMappings.Add(formulationMapping);
 
-      public virtual void ClearFormulationMapping()
-      {
-         _formulationMappings.Clear();
-      }
+      public virtual void ClearFormulationMapping() => _formulationMappings.Clear();
 
-      public virtual FormulationMapping MappingWith(string formulationKey)
-      {
-         return _formulationMappings.FirstOrDefault(x => string.Equals(x.FormulationKey, formulationKey));
-      }
+      public virtual FormulationMapping MappingWith(string formulationKey) =>
+         _formulationMappings.FirstOrDefault(x => string.Equals(x.FormulationKey, formulationKey));
 
       public virtual IReadOnlyList<FormulationMapping> FormulationMappings => _formulationMappings;
+
+      public virtual void AddEventPlaceholderMapping(EventPlaceholderMapping eventPlaceholderMapping) => _eventPlaceholderMappings.Add(eventPlaceholderMapping);
+
+      public virtual void ClearEventPlaceholderMappings() => _eventPlaceholderMappings.Clear();
+
+      public virtual EventPlaceholderMapping EventMappingWith(string eventKey) =>
+         _eventPlaceholderMappings.FirstOrDefault(x => string.Equals(x.EventKey, eventKey));
+
+      public virtual IReadOnlyList<EventPlaceholderMapping> EventPlaceholderMappings => _eventPlaceholderMappings;
 
       public bool IsAdministered => Protocol != null;
    }

--- a/src/PKSim.Core/Services/SimulationBuildingBlockUpdater.cs
+++ b/src/PKSim.Core/Services/SimulationBuildingBlockUpdater.cs
@@ -60,6 +60,12 @@ namespace PKSim.Core.Services
       /// </summary>
       void UpdateFormulationsInSimulation(Simulation simulation);
 
+      /// <summary>
+      ///    Update the used <see cref="PKSimEvent" /> building blocks used in the <paramref name="simulation" /> based
+      ///    on the event placeholder mappings in protocol properties
+      /// </summary>
+      void UpdateEventsInSimulation(Simulation simulation);
+
       bool BuildingBlockSupportsQuickUpdate(IPKSimBuildingBlock templateBuildingBlock);
 
       /// <summary>
@@ -185,6 +191,17 @@ namespace PKSim.Core.Services
          var allFormulationUsed = allFormulationMappings.Select(x => x.Formulation).Distinct().ToList();
          checkThatFormulationIsUsedEitherAsTemplateOrAsSimulationFormulation(allFormulationUsed);
          UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, allFormulationUsed, PKSimBuildingBlockType.Formulation);
+      }
+
+      public void UpdateEventsInSimulation(Simulation simulation)
+      {
+         var allEventsFromProtocol = simulation.CompoundPropertiesList
+            .SelectMany(x => x.ProtocolProperties.EventPlaceholderMappings)
+            .Select(x => x.Event)
+            .Where(x => x != null);
+
+         var allEventsUsed = allEventsFromProtocol.Distinct().ToList();
+         UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, allEventsUsed, PKSimBuildingBlockType.Event);
       }
 
       private static void checkThatFormulationIsUsedEitherAsTemplateOrAsSimulationFormulation(IReadOnlyList<Formulation> allFormulationUsed)

--- a/src/PKSim.Core/Snapshots/EventPlaceholderSelection.cs
+++ b/src/PKSim.Core/Snapshots/EventPlaceholderSelection.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Snapshots
+{
+   public class EventPlaceholderSelection : IWithName
+   {
+      [Required]
+      public string Name { get; set; }
+
+      [Required]
+      public string Key { get; set; }
+   }
+}

--- a/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
@@ -49,7 +49,8 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       return new ProtocolSelection
       {
          Name = protocolProperties.Protocol.Name,
-         Formulations = formulationMappingFrom(protocolProperties.FormulationMappings, project)
+         Formulations = formulationMappingFrom(protocolProperties.FormulationMappings, project),
+         Events = eventPlaceholderMappingFrom(protocolProperties.EventPlaceholderMappings, project)
       };
    }
 
@@ -87,6 +88,22 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       return new FormulationSelection { Name = formulation.Name, Key = formulationMapping.FormulationKey };
    }
 
+   private EventPlaceholderSelection[] eventPlaceholderMappingFrom(IReadOnlyList<EventPlaceholderMapping> eventPlaceholderMappings, PKSimProject project)
+   {
+      if (!eventPlaceholderMappings.Any())
+         return null;
+
+      return eventPlaceholderMappings
+         .Select(x => eventPlaceholderSelectionFrom(x, project))
+         .ToArray();
+   }
+
+   private EventPlaceholderSelection eventPlaceholderSelectionFrom(EventPlaceholderMapping eventPlaceholderMapping, PKSimProject project)
+   {
+      var pkSimEvent = project.BuildingBlockById(eventPlaceholderMapping.TemplateEventId) ?? eventPlaceholderMapping.Event;
+      return new EventPlaceholderSelection { Name = pkSimEvent.Name, Key = eventPlaceholderMapping.EventKey };
+   }
+
    public override async Task<ModelCompoundProperties> MapToModel(SnapshotCompoundProperties snapshot, SnapshotContextWithSimulation snapshotContext)
    {
       var simulation = snapshotContext.Simulation as Model.Simulation;
@@ -110,6 +127,7 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       var protocol = project.BuildingBlockByName<Model.Protocol>(snapshotProtocol.Name);
       protocolProperties.Protocol = protocol;
       updateFormulationMapping(protocolProperties, snapshotProtocol.Formulations, project);
+      updateEventPlaceholderMapping(protocolProperties, snapshotProtocol.Events, project);
       return protocolProperties;
    }
 
@@ -125,6 +143,21 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
             TemplateFormulationId = formulation.Id
          };
          protocolProperties.AddFormulationMapping(formulationMapping);
+      });
+   }
+
+   private void updateEventPlaceholderMapping(ProtocolProperties protocolProperties, EventPlaceholderSelection[] snapshotProtocolEvents, PKSimProject project)
+   {
+      snapshotProtocolEvents?.Each(x =>
+      {
+         var pkSimEvent = project.BuildingBlockByName<PKSimEvent>(x.Name);
+         var eventPlaceholderMapping = new EventPlaceholderMapping
+         {
+            Event = pkSimEvent,
+            EventKey = x.Key,
+            TemplateEventId = pkSimEvent.Id
+         };
+         protocolProperties.AddEventPlaceholderMapping(eventPlaceholderMapping);
       });
    }
 

--- a/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
@@ -385,8 +385,13 @@ namespace PKSim.Core.Snapshots.Mappers
          _simulationBuildingBlockUpdater.UpdateFormulationsInSimulation(simulation);
          _simulationBuildingBlockUpdater.UpdateProtocolsInSimulation(simulation);
 
-         var events = simulation.EventProperties.EventMappings.Select(x => project.BuildingBlockById<PKSimEvent>(x.TemplateEventId));
-         _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, events, PKSimBuildingBlockType.Event);
+         var standaloneEvents = simulation.EventProperties.EventMappings.Select(x => project.BuildingBlockById<PKSimEvent>(x.TemplateEventId));
+         var protocolEvents = simulation.CompoundPropertiesList
+            .SelectMany(x => x.ProtocolProperties.EventPlaceholderMappings)
+            .Select(x => x.Event)
+            .Where(x => x != null);
+         var allEvents = standaloneEvents.Concat(protocolEvents).Distinct();
+         _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, allEvents, PKSimBuildingBlockType.Event);
 
          var observerSets = simulation.ObserverSetProperties.ObserverSetMappings.Select(x => project.BuildingBlockById<Model.ObserverSet>(x.TemplateObserverSetId));
          _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, observerSets, PKSimBuildingBlockType.ObserverSet);

--- a/src/PKSim.Core/Snapshots/ProtocolSelection.cs
+++ b/src/PKSim.Core/Snapshots/ProtocolSelection.cs
@@ -9,5 +9,7 @@ namespace PKSim.Core.Snapshots
       public string Name { get; set; }
 
       public FormulationSelection[] Formulations { get; set; }
+
+      public EventPlaceholderSelection[] Events { get; set; }
    }
 }

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/EventPlaceholderMappingXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/EventPlaceholderMappingXmlSerializer.cs
@@ -1,0 +1,13 @@
+using PKSim.Core.Model;
+
+namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+{
+   public class EventPlaceholderMappingXmlSerializer : BaseXmlSerializer<EventPlaceholderMapping>
+   {
+      public override void PerformMapping()
+      {
+         Map(x => x.TemplateEventId);
+         Map(x => x.EventKey);
+      }
+   }
+}

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ProtocolPropertiesXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ProtocolPropertiesXmlSerializer.cs
@@ -7,7 +7,8 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
       public override void PerformMapping()
       {
          MapReference(x => x.Protocol);
-         MapEnumerable(x => x.FormulationMappings,x => x.AddFormulationMapping);
+         MapEnumerable(x => x.FormulationMappings, x => x.AddFormulationMapping);
+         MapEnumerable(x => x.EventPlaceholderMappings, x => x.AddEventPlaceholderMapping);
       }
    }
 }

--- a/src/PKSim.Presentation/DTO/Simulations/BuildingBlockSelectionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/BuildingBlockSelectionDTO.cs
@@ -41,6 +41,24 @@ namespace PKSim.Presentation.DTO.Simulations
       }
    }
 
+   public class EventSelectionDTO : BuildingBlockSelectionDTO<PKSimEvent>
+   {
+      public string DisplayName { get; set; }
+
+      public override bool Equals(object obj) => Equals(obj as EventSelectionDTO);
+
+      public bool Equals(EventSelectionDTO other)
+      {
+         if (ReferenceEquals(null, other)) return false;
+         if (ReferenceEquals(this, other)) return true;
+         return Equals(BuildingBlock, other.BuildingBlock);
+      }
+
+      public override int GetHashCode() => BuildingBlock?.GetHashCode() ?? 0;
+
+      public override string ToString() => DisplayName;
+   }
+
    public class FormulationSelectionDTO : BuildingBlockSelectionDTO<Formulation>
    {
       public string DisplayName { get; set; }

--- a/src/PKSim.Presentation/DTO/Simulations/EventPlaceholderMappingDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/EventPlaceholderMappingDTO.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Presentation.DTO.Simulations
+{
+   public class EventPlaceholderMappingDTO : DxValidatableDTO
+   {
+      public string EventKey { get; set; }
+      public EventSelectionDTO Selection { get; set; }
+      public PKSimEvent Event => Selection?.BuildingBlock;
+
+      public EventPlaceholderMappingDTO()
+      {
+         Rules.AddRange(AllRules.All());
+      }
+
+      private static class AllRules
+      {
+         private static IBusinessRule eventNotNull { get; } = CreateRule.For<EventPlaceholderMappingDTO>()
+            .Property(x => x.Selection)
+            .WithRule((dto, s) => s?.BuildingBlock != null)
+            .WithError((dto, s) => PKSimConstants.Error.BuildingBlockNotDefined(PKSimConstants.ObjectTypes.Event));
+
+         public static IEnumerable<IBusinessRule> All()
+         {
+            yield return eventNotNull;
+         }
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Protocols/ProtocolItemPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/ProtocolItemPresenter.cs
@@ -58,11 +58,6 @@ namespace PKSim.Presentation.Presenters.Protocols
 
       public IEnumerable<string> AllEventKeys() => _protocolTask.AllEventKeys();
 
-      public IEnumerable<string> AllEventKeys()
-      {
-         return _protocolTask.AllEventKeys();
-      }
-
       public void SetParameterValue(IParameterDTO parameterDTO, double newValue)
       {
          AddCommand(_parameterTask.SetParameterDisplayValue(ParameterFrom(parameterDTO), newValue));

--- a/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
@@ -85,21 +85,6 @@ namespace PKSim.Presentation.Presenters.Protocols
          AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
       }
 
-      public void SetEvent(bool hasEvent)
-      {
-         if (hasEvent == _protocol.HasEvent) return;
-
-         var eventKey = hasEvent ? CoreConstants.DEFAULT_EVENT_KEY : string.Empty;
-         AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
-         _view.BindTo(_simpleProtocolDTOMapper.MapFrom(_protocol));
-         bindToDynamicParameters();
-      }
-
-      public void SetSimpleProtocolEventKey(string eventKey)
-      {
-         AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
-      }
-
       public void SetApplicationType(ApplicationType applicationType)
       {
          SetApplicationType(applicationType, _protocol);

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
@@ -47,6 +47,7 @@ namespace PKSim.Presentation.Presenters.Simulations
 
          _simulationBuildingBlockUpdater.UpdateProtocolsInSimulation(_simulation);
          _simulationBuildingBlockUpdater.UpdateFormulationsInSimulation(_simulation);
+         _simulationBuildingBlockUpdater.UpdateEventsInSimulation(_simulation);
       }
 
       public void UpdateSelectedProtocol(Protocol templateProtocol)

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Services;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation.Presenters.Simulations
+{
+   public interface ISimulationCompoundProtocolEventPresenter : IPresenter<ISimulationCompoundProtocolEventView>, IEditSimulationCompoundPresenter
+   {
+      IEnumerable<EventSelectionDTO> AllEventsFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      void CreateEventFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      Task LoadEventForAsync(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      bool EventVisible { get; }
+   }
+
+   public class SimulationCompoundProtocolEventPresenter : AbstractSubPresenter<ISimulationCompoundProtocolEventView, ISimulationCompoundProtocolEventPresenter>,
+      ISimulationCompoundProtocolEventPresenter
+   {
+      private readonly IEventTask _eventTask;
+      private readonly IBuildingBlockRepository _buildingBlockRepository;
+      private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+      private readonly IBuildingBlockSelectionDisplayer _buildingBlockSelectionDisplayer;
+      private Protocol _protocol;
+      private ProtocolProperties _protocolProperties;
+      private IEnumerable<EventPlaceholderMappingDTO> _allEventMappingDTO;
+      private Simulation _simulation;
+
+      public SimulationCompoundProtocolEventPresenter(
+         ISimulationCompoundProtocolEventView view,
+         IEventTask eventTask,
+         IBuildingBlockRepository buildingBlockRepository,
+         IBuildingBlockInProjectManager buildingBlockInProjectManager,
+         IBuildingBlockSelectionDisplayer buildingBlockSelectionDisplayer)
+         : base(view)
+      {
+         _eventTask = eventTask;
+         _buildingBlockRepository = buildingBlockRepository;
+         _buildingBlockInProjectManager = buildingBlockInProjectManager;
+         _buildingBlockSelectionDisplayer = buildingBlockSelectionDisplayer;
+      }
+
+      public void EditSimulation(Simulation simulation, Compound compound)
+      {
+         var compoundProperties = simulation.CompoundPropertiesFor(compound);
+         _protocolProperties = compoundProperties.ProtocolProperties;
+         _protocol = _protocolProperties.Protocol;
+         _simulation = simulation;
+         _allEventMappingDTO = createEventMapping().ToList();
+         _view.EventVisible = _allEventMappingDTO.Any();
+         _view.BindTo(_allEventMappingDTO);
+         _view.EventKeyVisible = _allEventMappingDTO.Count() > 1;
+      }
+
+      private IEnumerable<EventPlaceholderMappingDTO> createEventMapping()
+      {
+         if (_protocol == null)
+            return Enumerable.Empty<EventPlaceholderMappingDTO>();
+
+         return (from usedEventKey in _protocol.UsedEventKeys
+            where !usedEventKey.IsNullOrEmpty()
+            let pkSimEvent = eventUsedInSimulationFor(usedEventKey) ?? defaultEvent()
+            select new EventPlaceholderMappingDTO
+            {
+               Selection = selectionFrom(pkSimEvent),
+               EventKey = usedEventKey
+            }).ToList();
+      }
+
+      private PKSimEvent defaultEvent() => _eventTask.All().FirstOrDefault();
+
+      private PKSimEvent eventUsedInSimulationFor(string eventKey)
+      {
+         var mapping = _protocolProperties.EventMappingWith(eventKey);
+         if (mapping == null || mapping.TemplateEventId.IsNullOrEmpty())
+            return null;
+
+         var templateEvent = _buildingBlockRepository.ById<PKSimEvent>(mapping.TemplateEventId);
+         var usedBuildingBlock = _simulation.UsedBuildingBlockByTemplateId(mapping.TemplateEventId);
+
+         if (usedBuildingBlock == null)
+            return templateEvent;
+
+         return _buildingBlockInProjectManager.TemplateBuildingBlockUsedBy<PKSimEvent>(usedBuildingBlock) ?? templateEvent;
+      }
+
+      public IEnumerable<EventSelectionDTO> AllEventsFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var eventSelections = _eventTask.All().Select(selectionFrom);
+         var hashSet = new HashSet<EventSelectionDTO>(eventSelections);
+         if (eventPlaceholderMappingDTO.Selection != null)
+            hashSet.Add(eventPlaceholderMappingDTO.Selection);
+
+         return hashSet;
+      }
+
+      private EventSelectionDTO selectionFrom(PKSimEvent pkSimEvent) => new EventSelectionDTO
+      {
+         BuildingBlock = pkSimEvent,
+         DisplayName = _buildingBlockSelectionDisplayer.DisplayNameFor(pkSimEvent)
+      };
+
+      public void CreateEventFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var pkSimEvent = _eventTask.AddToProject();
+         if (pkSimEvent == null) return;
+         updateEventInMapping(eventPlaceholderMappingDTO, pkSimEvent);
+      }
+
+      public async Task LoadEventForAsync(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var pkSimEvent = await _eventTask.SecureAwait(x => x.LoadSingleFromTemplateAsync());
+         updateEventInMapping(eventPlaceholderMappingDTO, pkSimEvent);
+      }
+
+      public bool EventVisible => _view.EventVisible;
+
+      private void updateEventInMapping(EventPlaceholderMappingDTO eventPlaceholderMappingDTO, PKSimEvent pkSimEvent)
+      {
+         if (pkSimEvent == null) return;
+         eventPlaceholderMappingDTO.Selection = selectionFrom(pkSimEvent);
+         _view.RefreshData();
+         OnStatusChanged();
+      }
+
+      public void SaveConfiguration()
+      {
+         _protocolProperties.ClearEventPlaceholderMappings();
+
+         _allEventMappingDTO.Each(dto =>
+         {
+            _eventTask.Load(dto.Event);
+            _protocolProperties.AddEventPlaceholderMapping(mapFrom(dto));
+         });
+      }
+
+      private EventPlaceholderMapping mapFrom(EventPlaceholderMappingDTO dto)
+      {
+         var templateEventId = dto.Event.Id;
+         var templateEvent = _buildingBlockRepository.ById<PKSimEvent>(templateEventId);
+
+         if (templateEvent == null)
+         {
+            var usedEvent = _simulation.UsedBuildingBlockById(templateEventId);
+            templateEventId = usedEvent.TemplateId;
+         }
+
+         return new EventPlaceholderMapping
+         {
+            TemplateEventId = templateEventId,
+            EventKey = dto.EventKey,
+            Event = dto.Event
+         };
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
@@ -21,6 +21,7 @@ namespace PKSim.Presentation.Presenters.Simulations
    public class SimulationCompoundProtocolPresenter : AbstractSubPresenter<ISimulationCompoundProtocolView, ISimulationCompoundProtocolPresenter>, ISimulationCompoundProtocolPresenter
    {
       private readonly ISimulationCompoundProtocolFormulationPresenter _simulationCompoundProtocolFormulationPresenter;
+      private readonly ISimulationCompoundProtocolEventPresenter _simulationCompoundProtocolEventPresenter;
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
       private Simulation _simulation;
@@ -33,18 +34,22 @@ namespace PKSim.Presentation.Presenters.Simulations
       public SimulationCompoundProtocolPresenter(
          ISimulationCompoundProtocolView view,
          ISimulationCompoundProtocolFormulationPresenter simulationCompoundProtocolFormulationPresenter,
-         ILazyLoadTask lazyLoadTask, 
+         ISimulationCompoundProtocolEventPresenter simulationCompoundProtocolEventPresenter,
+         ILazyLoadTask lazyLoadTask,
          IBuildingBlockInProjectManager buildingBlockInProjectManager)
          : base(view)
       {
          _simulationCompoundProtocolFormulationPresenter = simulationCompoundProtocolFormulationPresenter;
+         _simulationCompoundProtocolEventPresenter = simulationCompoundProtocolEventPresenter;
          _lazyLoadTask = lazyLoadTask;
          _buildingBlockInProjectManager = buildingBlockInProjectManager;
          _view.AddFormulationMappingView(_simulationCompoundProtocolFormulationPresenter.View);
-         _simulationCompoundProtocolFormulationPresenter.StatusChanged += onFormulationChanged;
+         _view.AddEventMappingView(_simulationCompoundProtocolEventPresenter.View);
+         _simulationCompoundProtocolFormulationPresenter.StatusChanged += onMappingChanged;
+         _simulationCompoundProtocolEventPresenter.StatusChanged += onMappingChanged;
       }
 
-      private void onFormulationChanged(object sender, EventArgs e)
+      private void onMappingChanged(object sender, EventArgs e)
       {
          FormulationChanged = true;
          OnStatusChanged();
@@ -67,6 +72,7 @@ namespace PKSim.Presentation.Presenters.Simulations
          _lazyLoadTask.Load(SelectedProtocol);
          _protocolProperties.Protocol = SelectedProtocol;
          _simulationCompoundProtocolFormulationPresenter.EditSimulation(_simulation, Compound);
+         _simulationCompoundProtocolEventPresenter.EditSimulation(_simulation, Compound);
       }
 
       public void UpdateSelectedFormulation(Formulation templateFormulation)
@@ -88,9 +94,10 @@ namespace PKSim.Presentation.Presenters.Simulations
       public void SaveConfiguration()
       {
          _simulationCompoundProtocolFormulationPresenter.SaveConfiguration();
+         _simulationCompoundProtocolEventPresenter.SaveConfiguration();
       }
 
-      public override bool CanClose => base.CanClose && _simulationCompoundProtocolFormulationPresenter.CanClose;
+      public override bool CanClose => base.CanClose && _simulationCompoundProtocolFormulationPresenter.CanClose && _simulationCompoundProtocolEventPresenter.CanClose;
 
       public Protocol SelectedProtocol => _protocolSelectionDTO.BuildingBlock;
 

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationEventsConfigurationPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationEventsConfigurationPresenter.cs
@@ -84,8 +84,15 @@ namespace PKSim.Presentation.Presenters.Simulations
             _eventProperties.AddEventMapping(_eventMappingMapper.MapFrom(eventMappingDTO, _simulation));
          });
 
-         var allEvents = _allEventsMappingDTO.Select(x => x.Event).ToList();
+         var standaloneEvents = _allEventsMappingDTO.Select(x => x.Event);
 
+         // Also include events from protocol event placeholder mappings
+         var protocolEvents = _simulation.CompoundPropertiesList
+            .SelectMany(x => x.ProtocolProperties.EventPlaceholderMappings)
+            .Select(x => x.Event)
+            .Where(x => x != null);
+
+         var allEvents = standaloneEvents.Concat(protocolEvents).Distinct().ToList();
          _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(_simulation, allEvents, PKSimBuildingBlockType.Event);
       }
 

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolEventView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolEventView.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using OSPSuite.Presentation.Views;
+
+namespace PKSim.Presentation.Views.Simulations
+{
+   public interface ISimulationCompoundProtocolEventView : IView<ISimulationCompoundProtocolEventPresenter>
+   {
+      void BindTo(IEnumerable<EventPlaceholderMappingDTO> eventMappings);
+      void RefreshData();
+
+      /// <summary>
+      /// Sets the visibility of the column containing the event key
+      /// </summary>
+      bool EventKeyVisible { set; }
+
+      /// <summary>
+      /// Sets the visibility of the event view
+      /// </summary>
+      bool EventVisible { get; set; }
+   }
+}

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
@@ -8,6 +8,7 @@ namespace PKSim.Presentation.Views.Simulations
    {
       void BindTo(ProtocolSelectionDTO protocolSelectionDTO);
       void AddFormulationMappingView(IView view);
+      void AddEventMappingView(IView view);
       bool AllowEmptyProtocolSelection { get;set; }
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.Designer.cs
@@ -1,0 +1,64 @@
+namespace PKSim.UI.Views.Simulations
+{
+   partial class SimulationCompoundProtocolEventView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _gridViewBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         this.SuspendLayout();
+         //
+         // layoutControl
+         //
+         this.layoutControl.Size = new System.Drawing.Size(309, 356);
+         //
+         // layoutItemGrid
+         //
+         this.layoutItemGrid.MaxSize = new System.Drawing.Size(0, 64);
+         this.layoutItemGrid.MinSize = new System.Drawing.Size(1, 64);
+         this.layoutItemGrid.Size = new System.Drawing.Size(309, 356);
+         this.layoutItemGrid.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
+         //
+         // SimulationCompoundProtocolEventView
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Name = "SimulationCompoundProtocolEventView";
+         this.Size = new System.Drawing.Size(309, 356);
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using DevExpress.Utils;
+using DevExpress.XtraEditors;
+using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
+using OSPSuite.Assets;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.UI;
+using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
+using OSPSuite.UI.RepositoryItems;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Views.Simulations;
+using static OSPSuite.UI.UIConstants.Size;
+
+namespace PKSim.UI.Views.Simulations
+{
+   public partial class SimulationCompoundProtocolEventView : BaseGridViewOnlyUserControl, ISimulationCompoundProtocolEventView
+   {
+      private ISimulationCompoundProtocolEventPresenter _presenter;
+      private readonly GridViewBinder<EventPlaceholderMappingDTO> _gridViewBinder;
+      private readonly UxRepositoryItemComboBox _repositoryForEvent;
+      private IGridViewColumn _eventKeyColumn;
+
+      public SimulationCompoundProtocolEventView()
+      {
+         InitializeComponent();
+         _repositoryForEvent = new UxRepositoryItemComboBox(gridView) { AllowHtmlDraw = DefaultBoolean.True };
+         _gridViewBinder = new GridViewBinder<EventPlaceholderMappingDTO>(gridView);
+         gridView.HorzScrollVisibility = ScrollVisibility.Never;
+         layoutControl.AutoScroll = false;
+      }
+
+      public void AttachPresenter(ISimulationCompoundProtocolEventPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public override bool HasError => _gridViewBinder.HasError;
+
+      public void BindTo(IEnumerable<EventPlaceholderMappingDTO> eventMappings)
+      {
+         _gridViewBinder.BindToSource(eventMappings.ToBindingList());
+         gridView.BestFitColumns();
+         AdjustHeight();
+      }
+
+      public void RefreshData()
+      {
+         gridView.RefreshData();
+      }
+
+      public bool EventKeyVisible
+      {
+         set => _eventKeyColumn.UpdateVisibility(value);
+      }
+
+      public bool EventVisible
+      {
+         get => GridVisible;
+         set => GridVisible = value;
+      }
+
+      public override void InitializeBinding()
+      {
+         var createEventButton = createEventButtonRepository();
+         var loadEventButton = loadEventButtonRepository();
+
+         _eventKeyColumn = _gridViewBinder.Bind(x => x.EventKey)
+            .WithCaption(PKSimConstants.UI.PlaceholderEvent)
+            .AsReadOnly();
+
+         _gridViewBinder.AutoBind(x => x.Selection)
+            .WithRepository(x => _repositoryForEvent)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithEditorConfiguration(configureEvent);
+
+         _gridViewBinder.AddUnboundColumn()
+            .WithCaption(Captions.EmptyColumn)
+            .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithRepository(dto => createEventButton);
+
+         _gridViewBinder.AddUnboundColumn()
+            .WithCaption(Captions.EmptyColumn)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+            .WithRepository(dto => loadEventButton);
+
+         _gridViewBinder.Changed += () => _presenter.ViewChanged();
+         createEventButton.ButtonClick += (o, e) => OnEvent(() => _presenter.CreateEventFor(_gridViewBinder.FocusedElement));
+         loadEventButton.ButtonClick += (o, e) => OnEvent(() => _presenter.LoadEventForAsync(_gridViewBinder.FocusedElement));
+      }
+
+      private RepositoryItemButtonEdit createEventButtonRepository() =>
+         new UxRepositoryItemButtonImage(ApplicationIcons.Create, PKSimConstants.UI.CreateBuildingBlockHint(PKSimConstants.ObjectTypes.Event));
+
+      private RepositoryItemButtonEdit loadEventButtonRepository() =>
+         new UxRepositoryItemButtonImage(ApplicationIcons.LoadFromTemplate, PKSimConstants.UI.LoadItemFromTemplate(PKSimConstants.ObjectTypes.Event));
+
+      private void configureEvent(BaseEdit baseEdit, EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         baseEdit.FillComboBoxEditorWith(_presenter.AllEventsFor(eventPlaceholderMappingDTO));
+      }
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
@@ -31,91 +31,115 @@
       {
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
          this.panelFormulation = new DevExpress.XtraEditors.PanelControl();
+         this.panelEvent = new DevExpress.XtraEditors.PanelControl();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemFormulation = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemEvent = new DevExpress.XtraLayout.LayoutControlItem();
          this.panelControl1 = new DevExpress.XtraEditors.PanelControl();
          this.layoutItemProtocol = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.panelFormulation)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelEvent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).BeginInit();
          this.SuspendLayout();
-         // 
+         //
          // layoutControl
-         // 
+         //
          this.layoutControl.AllowCustomization = false;
          this.layoutControl.Controls.Add(this.panelControl1);
          this.layoutControl.Controls.Add(this.panelFormulation);
+         this.layoutControl.Controls.Add(this.panelEvent);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
          this.layoutControl.Root = this.layoutControlGroup;
-         this.layoutControl.Size = new System.Drawing.Size(374, 118);
+         this.layoutControl.Size = new System.Drawing.Size(374, 199);
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl1";
-         // 
+         //
          // panelFormulation
-         // 
+         //
          this.panelFormulation.Location = new System.Drawing.Point(2, 39);
          this.panelFormulation.Name = "panelFormulation";
          this.panelFormulation.Size = new System.Drawing.Size(370, 77);
          this.panelFormulation.TabIndex = 14;
-         // 
+         //
+         // panelEvent
+         //
+         this.panelEvent.Location = new System.Drawing.Point(2, 120);
+         this.panelEvent.Name = "panelEvent";
+         this.panelEvent.Size = new System.Drawing.Size(370, 77);
+         this.panelEvent.TabIndex = 16;
+         //
          // layoutControlGroup
-         // 
+         //
          this.layoutControlGroup.CustomizationFormText = "layoutControlGroup1";
          this.layoutControlGroup.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
          this.layoutControlGroup.GroupBordersVisible = false;
          this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemFormulation,
+            this.layoutItemEvent,
             this.layoutItemProtocol});
          this.layoutControlGroup.Name = "layoutControlGroup";
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
-         this.layoutControlGroup.Size = new System.Drawing.Size(374, 118);
+         this.layoutControlGroup.Size = new System.Drawing.Size(374, 199);
          this.layoutControlGroup.Text = "layoutControlGroup1";
          this.layoutControlGroup.TextVisible = false;
-         // 
+         //
          // layoutItemFormulation
-         // 
+         //
          this.layoutItemFormulation.Control = this.panelFormulation;
          this.layoutItemFormulation.Location = new System.Drawing.Point(0, 37);
          this.layoutItemFormulation.Name = "layoutItemFormulation";
          this.layoutItemFormulation.Size = new System.Drawing.Size(374, 81);
          this.layoutItemFormulation.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemFormulation.TextVisible = false;
-         // 
+         //
+         // layoutItemEvent
+         //
+         this.layoutItemEvent.Control = this.panelEvent;
+         this.layoutItemEvent.Location = new System.Drawing.Point(0, 118);
+         this.layoutItemEvent.Name = "layoutItemEvent";
+         this.layoutItemEvent.Size = new System.Drawing.Size(374, 81);
+         this.layoutItemEvent.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemEvent.TextVisible = false;
+         //
          // panelControl1
-         // 
+         //
          this.panelControl1.Location = new System.Drawing.Point(105, 2);
          this.panelControl1.Name = "panelControl1";
          this.panelControl1.Size = new System.Drawing.Size(267, 33);
          this.panelControl1.TabIndex = 15;
-         // 
+         //
          // layoutItemProtocol
-         // 
+         //
          this.layoutItemProtocol.Control = this.panelControl1;
          this.layoutItemProtocol.Location = new System.Drawing.Point(0, 0);
          this.layoutItemProtocol.Name = "layoutItemProtocol";
          this.layoutItemProtocol.Size = new System.Drawing.Size(374, 37);
          this.layoutItemProtocol.TextSize = new System.Drawing.Size(91, 13);
-         // 
+         //
          // SimulationCompoundProtocolView
-         // 
+         //
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Controls.Add(this.layoutControl);
          this.Name = "SimulationCompoundProtocolView";
-         this.Size = new System.Drawing.Size(374, 118);
+         this.Size = new System.Drawing.Size(374, 199);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.panelFormulation)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelEvent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).EndInit();
          this.ResumeLayout(false);
@@ -127,7 +151,9 @@
       private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
       private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
       private DevExpress.XtraEditors.PanelControl panelFormulation;
+      private DevExpress.XtraEditors.PanelControl panelEvent;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemFormulation;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemEvent;
       private DevExpress.XtraEditors.PanelControl panelControl1;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemProtocol;
    }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
@@ -51,7 +51,12 @@ namespace PKSim.UI.Views.Simulations
       public void AddFormulationMappingView(IView view)
       {
          _resizableView = view as IResizableView;
-         AddViewTo(layoutItemFormulation,layoutControl,  view);
+         AddViewTo(layoutItemFormulation, layoutControl, view);
+      }
+
+      public void AddEventMappingView(IView view)
+      {
+         AddViewTo(layoutItemEvent, layoutControl, view);
       }
 
       public bool AllowEmptyProtocolSelection

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
@@ -1,0 +1,252 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Services;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_SimulationCompoundProtocolEventPresenter : ContextSpecification<ISimulationCompoundProtocolEventPresenter>
+   {
+      protected ISimulationCompoundProtocolEventView _view;
+      protected IEventTask _eventTask;
+      protected IBuildingBlockRepository _buildingBlockRepository;
+      protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+      protected IBuildingBlockSelectionDisplayer _buildingBlockSelectionDisplayer;
+      protected Protocol _protocol;
+      protected Simulation _simulation;
+      protected ProtocolProperties _protocolProperties;
+      protected PKSimEvent _event1;
+      protected PKSimEvent _event2;
+      protected Compound _compound;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISimulationCompoundProtocolEventView>();
+         _eventTask = A.Fake<IEventTask>();
+         _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
+         _buildingBlockInProjectManager = A.Fake<IBuildingBlockInProjectManager>();
+         _buildingBlockSelectionDisplayer = A.Fake<IBuildingBlockSelectionDisplayer>();
+         _event1 = new PKSimEvent().WithName("Event1").WithId("event1Id");
+         _event2 = new PKSimEvent().WithName("Event2").WithId("event2Id");
+         _protocol = A.Fake<Protocol>();
+         _compound = A.Fake<Compound>();
+         _simulation = A.Fake<Simulation>();
+         _protocolProperties = new ProtocolProperties();
+         var compoundProperties = new CompoundProperties();
+         A.CallTo(() => _simulation.CompoundPropertiesFor(_compound)).Returns(compoundProperties);
+         compoundProperties.ProtocolProperties = _protocolProperties;
+         _protocolProperties.Protocol = _protocol;
+         A.CallTo(() => _eventTask.All()).Returns(new[] { _event1, _event2 });
+         sut = new SimulationCompoundProtocolEventPresenter(_view, _eventTask, _buildingBlockRepository, _buildingBlockInProjectManager, _buildingBlockSelectionDisplayer);
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_with_event_placeholders : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private string _eventKey1;
+      private string _eventKey2;
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         _eventKey1 = "EVENT_1";
+         _eventKey2 = "EVENT_2";
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { _eventKey1, _eventKey2 });
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_display_event_mapping_for_each_event_key()
+      {
+         _eventMappingDtoList.Count.ShouldBeEqualTo(2);
+         _eventMappingDtoList[0].EventKey.ShouldBeEqualTo(_eventKey1);
+         _eventMappingDtoList[0].Event.ShouldBeEqualTo(_event1);
+         _eventMappingDtoList[1].EventKey.ShouldBeEqualTo(_eventKey2);
+         _eventMappingDtoList[1].Event.ShouldBeEqualTo(_event1);
+      }
+
+      [Observation]
+      public void should_make_event_mapping_visible()
+      {
+         A.CallToSet(() => _view.EventVisible).To(true).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_bind_to_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_without_event_placeholders : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(Enumerable.Empty<string>());
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_not_display_any_event_mapping()
+      {
+         _eventMappingDtoList.Any().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_hide_event_mapping_view()
+      {
+         A.CallToSet(() => _view.EventVisible).To(false).MustHaveHappened();
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_that_is_not_defined : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         _protocolProperties.Protocol = null;
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_not_display_any_event_mapping()
+      {
+         _eventMappingDtoList.Any().ShouldBeFalse();
+      }
+   }
+
+   public class When_retrieving_all_events_for_a_placeholder_mapping : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IEnumerable<EventSelectionDTO> _result;
+
+      protected override void Because()
+      {
+         _result = sut.AllEventsFor(new EventPlaceholderMappingDTO());
+      }
+
+      [Observation]
+      public void should_return_all_available_events()
+      {
+         _result.Select(x => x.BuildingBlock).ShouldOnlyContain(_event1, _event2);
+      }
+   }
+
+   public class When_creating_a_new_event_for_a_placeholder_mapping : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private EventPlaceholderMappingDTO _dto;
+      private bool _eventRaised;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new EventPlaceholderMappingDTO { EventKey = "EVENT_1" };
+         A.CallTo(() => _eventTask.AddToProject()).Returns(_event1);
+         sut.StatusChanged += (o, e) => { _eventRaised = true; };
+      }
+
+      protected override void Because()
+      {
+         sut.CreateEventFor(_dto);
+      }
+
+      [Observation]
+      public void should_set_the_created_event_in_the_mapping()
+      {
+         _dto.Event.ShouldBeEqualTo(_event1);
+      }
+
+      [Observation]
+      public void should_refresh_the_view()
+      {
+         A.CallTo(() => _view.RefreshData()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_notify_status_changed()
+      {
+         _eventRaised.ShouldBeTrue();
+      }
+   }
+
+   public class When_saving_event_placeholder_configuration : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private string _eventKey1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _eventKey1 = "EVENT_1";
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { _eventKey1 });
+         A.CallTo(() => _buildingBlockRepository.ById<PKSimEvent>(_event1.Id)).Returns(_event1);
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      protected override void Because()
+      {
+         sut.SaveConfiguration();
+      }
+
+      [Observation]
+      public void should_save_event_placeholder_mappings_to_protocol_properties()
+      {
+         _protocolProperties.EventPlaceholderMappings.Count.ShouldBeEqualTo(1);
+         _protocolProperties.EventPlaceholderMappings[0].EventKey.ShouldBeEqualTo(_eventKey1);
+         _protocolProperties.EventPlaceholderMappings[0].TemplateEventId.ShouldBeEqualTo(_event1.Id);
+      }
+   }
+
+   public class When_the_event_presenter_notifies_view_changed : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private bool _eventRaised;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.StatusChanged += (o, e) => { _eventRaised = true; };
+      }
+
+      protected override void Because()
+      {
+         sut.ViewChanged();
+      }
+
+      [Observation]
+      public void should_notify_status_changed()
+      {
+         _eventRaised.ShouldBeTrue();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
@@ -14,16 +14,18 @@ namespace PKSim.Presentation
       protected ISimulationCompoundProtocolView _view;
       protected ILazyLoadTask _lazyLoadTask;
       protected ISimulationCompoundProtocolFormulationPresenter _simulationCompoundProtocolFormulationPresenter;
+      protected ISimulationCompoundProtocolEventPresenter _simulationCompoundProtocolEventPresenter;
       protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
 
       protected override void Context()
       {
          _view = A.Fake<ISimulationCompoundProtocolView>();
          _simulationCompoundProtocolFormulationPresenter = A.Fake<ISimulationCompoundProtocolFormulationPresenter>();
+         _simulationCompoundProtocolEventPresenter = A.Fake<ISimulationCompoundProtocolEventPresenter>();
          _buildingBlockInProjectManager = A.Fake<IBuildingBlockInProjectManager>();
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
 
-         sut = new SimulationCompoundProtocolPresenter(_view, _simulationCompoundProtocolFormulationPresenter, _lazyLoadTask, _buildingBlockInProjectManager);
+         sut = new SimulationCompoundProtocolPresenter(_view, _simulationCompoundProtocolFormulationPresenter, _simulationCompoundProtocolEventPresenter, _lazyLoadTask, _buildingBlockInProjectManager);
       }
    }
 


### PR DESCRIPTION
## Summary
- Adds event placeholder mapping UI to the protocol configuration step during simulation creation
- When a protocol contains event entries with event keys (placeholders), the UI now presents event mapping alongside formulation mapping
- Users can select a PKSimEvent building block for each event placeholder, with validation ensuring all are mapped
- Includes XML serialization, snapshot mapper support, and building block registration for events from protocol mappings

Fixes #3461

## Test plan
- [x] Presenter tests cover mapping logic, validation, and save flow (18 tests)
- [x] All 5160+ existing tests pass (4 pre-existing integration test failures unrelated to this change)
- [ ] Manual: create simulation with protocol containing event entries, verify event mapping UI appears
- [ ] Manual: verify validation error when event placeholder is unmapped
- [ ] Manual: verify same event can be mapped to multiple placeholders