### PR TITLE
Add event placeholder mapping to simulation protocol configuration

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -8,6 +8,15 @@ When fixing bugs, follow a red-green approach:
 ## New features
 For every model and presentation change, write corresponding unit tests.
 
+## Test coverage expectations
+Every new addition must have tests at all layers except UI (views are difficult to test):
+- **Domain model** (Core): new classes, properties, methods, clone/update behavior
+- **Serialization** (Infrastructure): XML round-trip, snapshot mapper round-trip
+- **Presentation**: presenters, DTOs, mappers, validation rules
+- **Integration**: end-to-end scenarios for simulation creation workflows
+
+Do NOT skip domain model tests — even simple POCOs like mappings need specs for clone, equality, and collection behavior.
+
 ## Conventions
 - Tests use BDDHelper with `ContextSpecification<T>`, `Context/Because/[Observation]` pattern and FakeItEasy for mocking
 - Async tests use `ContextSpecificationAsync<T>`

--- a/.claude/rules/issue-workflow.md
+++ b/.claude/rules/issue-workflow.md
@@ -1,0 +1,10 @@
+## Issue Workflow
+
+When asked to fix or implement a GitHub issue, follow this workflow:
+
+1. **Branch** — Create a new branch from the current branch. Name it `<issue-number>-<short-description>` (e.g. `3461-event-placeholder-mapping`). Always start with the issue number, no `feature/` prefix.
+2. **Implement with tests** — Write the code and corresponding tests, following the testing document (`.claude/docs/testing.md`)
+3. **Code review** — Do a thorough code review of what was implemented
+4. **Verify quality** — Build and run tests to confirm everything passes
+5. **Commit** — Commit the changes
+6. **Push and PR** — Push the branch and create a PR targeting the branch it was created from

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1787,6 +1787,7 @@ namespace PKSim.Assets
          public static readonly string EventOffset = "Event offset";
          public static readonly string NoEvent = "<None>";
          public static readonly string PlaceholderFormulation = "Placeholder for formulation";
+         public static readonly string PlaceholderEvent = "Placeholder for event";
          public static readonly string Placeholder = "Placeholder";
          public static readonly string ProtocolProperties = "Protocol Properties";
          public static readonly string Dermal = "Dermal";

--- a/src/PKSim.Core/Model/EventPlaceholderMapping.cs
+++ b/src/PKSim.Core/Model/EventPlaceholderMapping.cs
@@ -1,0 +1,21 @@
+namespace PKSim.Core.Model
+{
+   public class EventPlaceholderMapping
+   {
+      /// <summary>
+      ///    Key used in the protocol for which a mapping is required (e.g. "EVENT_1")
+      /// </summary>
+      public string EventKey { get; set; }
+
+      /// <summary>
+      ///    Id of template event in project used for mapping
+      /// </summary>
+      public string TemplateEventId { get; set; }
+
+      /// <summary>
+      ///    Actual event reference used in the mapping (not serialized, used temporarily to create the simulation).
+      ///    The Event referenced here is either the template building block or the simulation building block changed in the simulation.
+      /// </summary>
+      public PKSimEvent Event { get; set; }
+   }
+}

--- a/src/PKSim.Core/Model/ProtocolProperties.cs
+++ b/src/PKSim.Core/Model/ProtocolProperties.cs
@@ -7,7 +7,8 @@ namespace PKSim.Core.Model
    public class ProtocolProperties
    {
       private readonly List<FormulationMapping> _formulationMappings;
-      
+      private readonly List<EventPlaceholderMapping> _eventPlaceholderMappings;
+
       /// <summary>
       /// Reference to <see cref="Protocol"/> used in the simulation.
       /// </summary>
@@ -16,35 +17,38 @@ namespace PKSim.Core.Model
       public ProtocolProperties()
       {
          _formulationMappings = new List<FormulationMapping>();
+         _eventPlaceholderMappings = new List<EventPlaceholderMapping>();
       }
 
       public virtual ProtocolProperties Clone()
       {
          var clone = new ProtocolProperties();
          FormulationMappings.Each(clone.AddFormulationMapping);
-        
+         EventPlaceholderMappings.Each(clone.AddEventPlaceholderMapping);
+
          //do not clone: simply update reference that should be changed if required
          clone.Protocol = Protocol;
 
          return clone;
       }
 
-      public virtual void AddFormulationMapping(FormulationMapping formulationMapping)
-      {
-         _formulationMappings.Add(formulationMapping);
-      }
+      public virtual void AddFormulationMapping(FormulationMapping formulationMapping) => _formulationMappings.Add(formulationMapping);
 
-      public virtual void ClearFormulationMapping()
-      {
-         _formulationMappings.Clear();
-      }
+      public virtual void ClearFormulationMapping() => _formulationMappings.Clear();
 
-      public virtual FormulationMapping MappingWith(string formulationKey)
-      {
-         return _formulationMappings.FirstOrDefault(x => string.Equals(x.FormulationKey, formulationKey));
-      }
+      public virtual FormulationMapping MappingWith(string formulationKey) =>
+         _formulationMappings.FirstOrDefault(x => string.Equals(x.FormulationKey, formulationKey));
 
       public virtual IReadOnlyList<FormulationMapping> FormulationMappings => _formulationMappings;
+
+      public virtual void AddEventPlaceholderMapping(EventPlaceholderMapping eventPlaceholderMapping) => _eventPlaceholderMappings.Add(eventPlaceholderMapping);
+
+      public virtual void ClearEventPlaceholderMappings() => _eventPlaceholderMappings.Clear();
+
+      public virtual EventPlaceholderMapping EventMappingWith(string eventKey) =>
+         _eventPlaceholderMappings.FirstOrDefault(x => string.Equals(x.EventKey, eventKey));
+
+      public virtual IReadOnlyList<EventPlaceholderMapping> EventPlaceholderMappings => _eventPlaceholderMappings;
 
       public bool IsAdministered => Protocol != null;
    }

--- a/src/PKSim.Core/Model/SimpleProtocol.cs
+++ b/src/PKSim.Core/Model/SimpleProtocol.cs
@@ -22,8 +22,8 @@ namespace PKSim.Core.Model
       }
 
       private static IBusinessRule eventPlaceholderValid { get; } = CreateRule.For<SimpleProtocol>()
-         .Property(x => x.HasEvent)
-         .WithRule((protocol, hasEvent) => !hasEvent || !string.IsNullOrEmpty(protocol.EventKey))
+         .Property(x => x.EventKey)
+         .WithRule((protocol, eventKey) => !protocol.HasEvent || !string.IsNullOrEmpty(eventKey))
          .WithError(PKSimConstants.Error.EventPlaceholderRequired);
 
       public virtual ApplicationType ApplicationType

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -668,6 +668,17 @@ namespace PKSim.Core.Model
       }
 
       /// <summary>
+      ///    Returns all distinct PKSimEvent building blocks referenced by event placeholder mappings across all compounds
+      /// </summary>
+      public virtual IReadOnlyList<PKSimEvent> AllEventsFromProtocolPlaceholderMappings() =>
+         CompoundPropertiesList
+            .SelectMany(x => x.ProtocolProperties.EventPlaceholderMappings)
+            .Select(x => x.Event)
+            .Where(x => x != null)
+            .Distinct()
+            .ToList();
+
+      /// <summary>
       ///    Returns the model used in the simulation
       /// </summary>
       public virtual ModelConfiguration ModelConfiguration

--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -148,7 +148,9 @@ namespace PKSim.Core.Services
 
          eventGroup.SourceCriteria.Add(new MatchTagCondition(CoreConstants.Tags.EVENTS));
 
-         _schemaItemsMapper.MapFrom(protocol).Each((schemaItem, index) =>
+         //Filter out event schema items - they are not applications.
+         //TODO: Create event groups for event schema items based on EventPlaceholderMappings in ProtocolProperties
+         _schemaItemsMapper.MapFrom(protocol).Where(item => !item.IsEvent).ToList().Each((schemaItem, index) =>
          {
             //+1 to start at 1 for the nomenclature
             var applicationName = $"{CoreConstants.APPLICATION_NAME_TEMPLATE}{index + 1}";

--- a/src/PKSim.Core/Services/EventFromMappingRetriever.cs
+++ b/src/PKSim.Core/Services/EventFromMappingRetriever.cs
@@ -1,0 +1,42 @@
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+
+namespace PKSim.Core.Services
+{
+   public interface IEventFromMappingRetriever
+   {
+      /// <summary>
+      ///    Returns the template event building block used in the simulation for the given mapping.
+      ///    If the status of the building block is changed, returns the used building block in the simulation, otherwise the
+      ///    template building block
+      /// </summary>
+      PKSimEvent TemplateEventUsedBy(Simulation simulation, EventPlaceholderMapping eventPlaceholderMapping);
+   }
+
+   public class EventFromMappingRetriever : IEventFromMappingRetriever
+   {
+      private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+      private readonly IBuildingBlockRepository _buildingBlockRepository;
+
+      public EventFromMappingRetriever(IBuildingBlockInProjectManager buildingBlockInProjectManager, IBuildingBlockRepository buildingBlockRepository)
+      {
+         _buildingBlockInProjectManager = buildingBlockInProjectManager;
+         _buildingBlockRepository = buildingBlockRepository;
+      }
+
+      public PKSimEvent TemplateEventUsedBy(Simulation simulation, EventPlaceholderMapping eventPlaceholderMapping)
+      {
+         if (eventPlaceholderMapping == null || eventPlaceholderMapping.TemplateEventId.IsNullOrEmpty())
+            return null;
+
+         var templateEvent = _buildingBlockRepository.ById<PKSimEvent>(eventPlaceholderMapping.TemplateEventId);
+         var usedBuildingBlock = simulation.UsedBuildingBlockByTemplateId(eventPlaceholderMapping.TemplateEventId);
+
+         if (usedBuildingBlock == null)
+            return templateEvent;
+
+         return _buildingBlockInProjectManager.TemplateBuildingBlockUsedBy<PKSimEvent>(usedBuildingBlock) ?? templateEvent;
+      }
+   }
+}

--- a/src/PKSim.Core/Services/FormulationFromMappingRetriever.cs
+++ b/src/PKSim.Core/Services/FormulationFromMappingRetriever.cs
@@ -63,7 +63,7 @@ namespace PKSim.Core.Services
          var templateFormulation = _buildingBlockRepository.ById<Formulation>(formulationMapping.TemplateFormulationId);
          var usedBuildingBlock = simulation.UsedBuildingBlockByTemplateId(formulationMapping.TemplateFormulationId);
 
-         //this forumation was not used in the simulation yet, return the template
+         //this formulation was not used in the simulation yet, return the template
          if (usedBuildingBlock == null)
             return templateFormulation;
 

--- a/src/PKSim.Core/Services/SimulationBuildingBlockUpdater.cs
+++ b/src/PKSim.Core/Services/SimulationBuildingBlockUpdater.cs
@@ -60,6 +60,12 @@ namespace PKSim.Core.Services
       /// </summary>
       void UpdateFormulationsInSimulation(Simulation simulation);
 
+      /// <summary>
+      ///    Update the used <see cref="PKSimEvent" /> building blocks used in the <paramref name="simulation" /> based
+      ///    on the event placeholder mappings in protocol properties
+      /// </summary>
+      void UpdateEventsInSimulation(Simulation simulation);
+
       bool BuildingBlockSupportsQuickUpdate(IPKSimBuildingBlock templateBuildingBlock);
 
       /// <summary>
@@ -186,6 +192,9 @@ namespace PKSim.Core.Services
          checkThatFormulationIsUsedEitherAsTemplateOrAsSimulationFormulation(allFormulationUsed);
          UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, allFormulationUsed, PKSimBuildingBlockType.Formulation);
       }
+
+      public void UpdateEventsInSimulation(Simulation simulation) =>
+         UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, simulation.AllEventsFromProtocolPlaceholderMappings(), PKSimBuildingBlockType.Event);
 
       private static void checkThatFormulationIsUsedEitherAsTemplateOrAsSimulationFormulation(IReadOnlyList<Formulation> allFormulationUsed)
       {

--- a/src/PKSim.Core/Snapshots/EventPlaceholderSelection.cs
+++ b/src/PKSim.Core/Snapshots/EventPlaceholderSelection.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Snapshots
+{
+   public class EventPlaceholderSelection : IWithName
+   {
+      [Required]
+      public string Name { get; set; }
+
+      [Required]
+      public string Key { get; set; }
+   }
+}

--- a/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
@@ -49,7 +49,8 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       return new ProtocolSelection
       {
          Name = protocolProperties.Protocol.Name,
-         Formulations = formulationMappingFrom(protocolProperties.FormulationMappings, project)
+         Formulations = formulationMappingFrom(protocolProperties.FormulationMappings, project),
+         Events = eventPlaceholderMappingFrom(protocolProperties.EventPlaceholderMappings, project)
       };
    }
 
@@ -87,6 +88,22 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       return new FormulationSelection { Name = formulation.Name, Key = formulationMapping.FormulationKey };
    }
 
+   private EventPlaceholderSelection[] eventPlaceholderMappingFrom(IReadOnlyList<EventPlaceholderMapping> eventPlaceholderMappings, PKSimProject project)
+   {
+      if (!eventPlaceholderMappings.Any())
+         return null;
+
+      return eventPlaceholderMappings
+         .Select(x => eventPlaceholderSelectionFrom(x, project))
+         .ToArray();
+   }
+
+   private EventPlaceholderSelection eventPlaceholderSelectionFrom(EventPlaceholderMapping eventPlaceholderMapping, PKSimProject project)
+   {
+      var pkSimEvent = project.BuildingBlockById(eventPlaceholderMapping.TemplateEventId) ?? eventPlaceholderMapping.Event;
+      return new EventPlaceholderSelection { Name = pkSimEvent.Name, Key = eventPlaceholderMapping.EventKey };
+   }
+
    public override async Task<ModelCompoundProperties> MapToModel(SnapshotCompoundProperties snapshot, SnapshotContextWithSimulation snapshotContext)
    {
       var simulation = snapshotContext.Simulation as Model.Simulation;
@@ -110,6 +127,7 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
       var protocol = project.BuildingBlockByName<Model.Protocol>(snapshotProtocol.Name);
       protocolProperties.Protocol = protocol;
       updateFormulationMapping(protocolProperties, snapshotProtocol.Formulations, project);
+      updateEventPlaceholderMapping(protocolProperties, snapshotProtocol.Events, project);
       return protocolProperties;
    }
 
@@ -125,6 +143,21 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
             TemplateFormulationId = formulation.Id
          };
          protocolProperties.AddFormulationMapping(formulationMapping);
+      });
+   }
+
+   private void updateEventPlaceholderMapping(ProtocolProperties protocolProperties, EventPlaceholderSelection[] snapshotProtocolEvents, PKSimProject project)
+   {
+      snapshotProtocolEvents?.Each(x =>
+      {
+         var pkSimEvent = project.BuildingBlockByName<PKSimEvent>(x.Name);
+         var eventPlaceholderMapping = new EventPlaceholderMapping
+         {
+            Event = pkSimEvent,
+            EventKey = x.Key,
+            TemplateEventId = pkSimEvent.Id
+         };
+         protocolProperties.AddEventPlaceholderMapping(eventPlaceholderMapping);
       });
    }
 

--- a/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
@@ -385,8 +385,9 @@ namespace PKSim.Core.Snapshots.Mappers
          _simulationBuildingBlockUpdater.UpdateFormulationsInSimulation(simulation);
          _simulationBuildingBlockUpdater.UpdateProtocolsInSimulation(simulation);
 
-         var events = simulation.EventProperties.EventMappings.Select(x => project.BuildingBlockById<PKSimEvent>(x.TemplateEventId));
-         _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, events, PKSimBuildingBlockType.Event);
+         var standaloneEvents = simulation.EventProperties.EventMappings.Select(x => project.BuildingBlockById<PKSimEvent>(x.TemplateEventId));
+         var allEvents = standaloneEvents.Concat(simulation.AllEventsFromProtocolPlaceholderMappings()).Distinct();
+         _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, allEvents, PKSimBuildingBlockType.Event);
 
          var observerSets = simulation.ObserverSetProperties.ObserverSetMappings.Select(x => project.BuildingBlockById<Model.ObserverSet>(x.TemplateObserverSetId));
          _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(simulation, observerSets, PKSimBuildingBlockType.ObserverSet);

--- a/src/PKSim.Core/Snapshots/ProtocolSelection.cs
+++ b/src/PKSim.Core/Snapshots/ProtocolSelection.cs
@@ -9,5 +9,7 @@ namespace PKSim.Core.Snapshots
       public string Name { get; set; }
 
       public FormulationSelection[] Formulations { get; set; }
+
+      public EventPlaceholderSelection[] Events { get; set; }
    }
 }

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/EventPlaceholderMappingXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/EventPlaceholderMappingXmlSerializer.cs
@@ -1,0 +1,13 @@
+using PKSim.Core.Model;
+
+namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+{
+   public class EventPlaceholderMappingXmlSerializer : BaseXmlSerializer<EventPlaceholderMapping>
+   {
+      public override void PerformMapping()
+      {
+         Map(x => x.TemplateEventId);
+         Map(x => x.EventKey);
+      }
+   }
+}

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ProtocolPropertiesXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ProtocolPropertiesXmlSerializer.cs
@@ -7,7 +7,8 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
       public override void PerformMapping()
       {
          MapReference(x => x.Protocol);
-         MapEnumerable(x => x.FormulationMappings,x => x.AddFormulationMapping);
+         MapEnumerable(x => x.FormulationMappings, x => x.AddFormulationMapping);
+         MapEnumerable(x => x.EventPlaceholderMappings, x => x.AddEventPlaceholderMapping);
       }
    }
 }

--- a/src/PKSim.Presentation/DTO/Protocols/SchemaItemDTO.cs
+++ b/src/PKSim.Presentation/DTO/Protocols/SchemaItemDTO.cs
@@ -39,7 +39,7 @@ namespace PKSim.Presentation.DTO.Protocols
                return CompositeNameFor(ApplicationType.DisplayName, FormulationKey);
 
             if (IsEvent)
-               return CompositeNameFor(ApplicationType.DisplayName, EventKey);
+               return EventKey;
 
             return ApplicationType.DisplayName;
          }

--- a/src/PKSim.Presentation/DTO/Simulations/BuildingBlockSelectionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/BuildingBlockSelectionDTO.cs
@@ -41,6 +41,24 @@ namespace PKSim.Presentation.DTO.Simulations
       }
    }
 
+   public class EventSelectionDTO : BuildingBlockSelectionDTO<PKSimEvent>
+   {
+      public string DisplayName { get; set; }
+
+      public override bool Equals(object obj) => Equals(obj as EventSelectionDTO);
+
+      public bool Equals(EventSelectionDTO other)
+      {
+         if (ReferenceEquals(null, other)) return false;
+         if (ReferenceEquals(this, other)) return true;
+         return Equals(BuildingBlock, other.BuildingBlock);
+      }
+
+      public override int GetHashCode() => BuildingBlock?.GetHashCode() ?? 0;
+
+      public override string ToString() => DisplayName;
+   }
+
    public class FormulationSelectionDTO : BuildingBlockSelectionDTO<Formulation>
    {
       public string DisplayName { get; set; }

--- a/src/PKSim.Presentation/DTO/Simulations/EventPlaceholderMappingDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/EventPlaceholderMappingDTO.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Presentation.DTO.Simulations
+{
+   public class EventPlaceholderMappingDTO : DxValidatableDTO
+   {
+      public string EventKey { get; set; }
+      public EventSelectionDTO Selection { get; set; }
+      public PKSimEvent Event => Selection?.BuildingBlock;
+
+      public EventPlaceholderMappingDTO()
+      {
+         Rules.AddRange(AllRules.All());
+      }
+
+      private static class AllRules
+      {
+         private static IBusinessRule eventNotNull { get; } = CreateRule.For<EventPlaceholderMappingDTO>()
+            .Property(x => x.Selection)
+            .WithRule((dto, s) => s?.BuildingBlock != null)
+            .WithError((dto, s) => PKSimConstants.Error.BuildingBlockNotDefined(PKSimConstants.ObjectTypes.Event));
+
+         public static IEnumerable<IBusinessRule> All()
+         {
+            yield return eventNotNull;
+         }
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Protocols/ProtocolItemPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/ProtocolItemPresenter.cs
@@ -58,11 +58,6 @@ namespace PKSim.Presentation.Presenters.Protocols
 
       public IEnumerable<string> AllEventKeys() => _protocolTask.AllEventKeys();
 
-      public IEnumerable<string> AllEventKeys()
-      {
-         return _protocolTask.AllEventKeys();
-      }
-
       public void SetParameterValue(IParameterDTO parameterDTO, double newValue)
       {
          AddCommand(_parameterTask.SetParameterDisplayValue(ParameterFrom(parameterDTO), newValue));

--- a/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
@@ -85,21 +85,6 @@ namespace PKSim.Presentation.Presenters.Protocols
          AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
       }
 
-      public void SetEvent(bool hasEvent)
-      {
-         if (hasEvent == _protocol.HasEvent) return;
-
-         var eventKey = hasEvent ? CoreConstants.DEFAULT_EVENT_KEY : string.Empty;
-         AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
-         _view.BindTo(_simpleProtocolDTOMapper.MapFrom(_protocol));
-         bindToDynamicParameters();
-      }
-
-      public void SetSimpleProtocolEventKey(string eventKey)
-      {
-         AddCommand(_protocolTask.SetEventKey(_protocol, eventKey));
-      }
-
       public void SetApplicationType(ApplicationType applicationType)
       {
          SetApplicationType(applicationType, _protocol);

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
@@ -47,6 +47,7 @@ namespace PKSim.Presentation.Presenters.Simulations
 
          _simulationBuildingBlockUpdater.UpdateProtocolsInSimulation(_simulation);
          _simulationBuildingBlockUpdater.UpdateFormulationsInSimulation(_simulation);
+         _simulationBuildingBlockUpdater.UpdateEventsInSimulation(_simulation);
       }
 
       public void UpdateSelectedProtocol(Protocol templateProtocol)

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Services;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation.Presenters.Simulations
+{
+   public interface ISimulationCompoundProtocolEventPresenter : IPresenter<ISimulationCompoundProtocolEventView>, IEditSimulationCompoundPresenter
+   {
+      IEnumerable<EventSelectionDTO> AllEventsFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      void CreateEventFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      Task LoadEventForAsync(EventPlaceholderMappingDTO eventPlaceholderMappingDTO);
+      bool EventVisible { get; }
+   }
+
+   public class SimulationCompoundProtocolEventPresenter : AbstractSubPresenter<ISimulationCompoundProtocolEventView, ISimulationCompoundProtocolEventPresenter>,
+      ISimulationCompoundProtocolEventPresenter
+   {
+      private readonly IEventTask _eventTask;
+      private readonly IEventFromMappingRetriever _eventFromMappingRetriever;
+      private readonly IBuildingBlockSelectionDisplayer _buildingBlockSelectionDisplayer;
+      private Protocol _protocol;
+      private ProtocolProperties _protocolProperties;
+      private IEnumerable<EventPlaceholderMappingDTO> _allEventMappingDTO;
+      private Simulation _simulation;
+
+      public SimulationCompoundProtocolEventPresenter(
+         ISimulationCompoundProtocolEventView view,
+         IEventTask eventTask,
+         IEventFromMappingRetriever eventFromMappingRetriever,
+         IBuildingBlockSelectionDisplayer buildingBlockSelectionDisplayer)
+         : base(view)
+      {
+         _eventTask = eventTask;
+         _eventFromMappingRetriever = eventFromMappingRetriever;
+         _buildingBlockSelectionDisplayer = buildingBlockSelectionDisplayer;
+      }
+
+      public void EditSimulation(Simulation simulation, Compound compound)
+      {
+         var compoundProperties = simulation.CompoundPropertiesFor(compound);
+         _protocolProperties = compoundProperties.ProtocolProperties;
+         _protocol = _protocolProperties.Protocol;
+         _simulation = simulation;
+         _allEventMappingDTO = createEventMapping().ToList();
+         _view.EventVisible = _allEventMappingDTO.Any();
+         _view.BindTo(_allEventMappingDTO);
+      }
+
+      private IEnumerable<EventPlaceholderMappingDTO> createEventMapping()
+      {
+         if (_protocol == null)
+            return Enumerable.Empty<EventPlaceholderMappingDTO>();
+
+         return (from usedEventKey in _protocol.UsedEventKeys
+            where !usedEventKey.IsNullOrEmpty()
+            let pkSimEvent = eventUsedInSimulationFor(usedEventKey) ?? defaultEvent()
+            select new EventPlaceholderMappingDTO
+            {
+               Selection = selectionFrom(pkSimEvent),
+               EventKey = usedEventKey
+            }).ToList();
+      }
+
+      private PKSimEvent defaultEvent() => _eventTask.All().FirstOrDefault();
+
+      private PKSimEvent eventUsedInSimulationFor(string eventKey) =>
+         _eventFromMappingRetriever.TemplateEventUsedBy(_simulation, _protocolProperties.EventMappingWith(eventKey));
+
+      public IEnumerable<EventSelectionDTO> AllEventsFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var eventSelections = _eventTask.All().Select(selectionFrom);
+         var hashSet = new HashSet<EventSelectionDTO>(eventSelections);
+         if (eventPlaceholderMappingDTO.Selection != null)
+            hashSet.Add(eventPlaceholderMappingDTO.Selection);
+
+         return hashSet;
+      }
+
+      private EventSelectionDTO selectionFrom(PKSimEvent pkSimEvent) => new EventSelectionDTO
+      {
+         BuildingBlock = pkSimEvent,
+         DisplayName = _buildingBlockSelectionDisplayer.DisplayNameFor(pkSimEvent)
+      };
+
+      public void CreateEventFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var pkSimEvent = _eventTask.AddToProject();
+         if (pkSimEvent == null) return;
+         updateEventInMapping(eventPlaceholderMappingDTO, pkSimEvent);
+      }
+
+      public async Task LoadEventForAsync(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         var pkSimEvent = await _eventTask.SecureAwait(x => x.LoadSingleFromTemplateAsync());
+         updateEventInMapping(eventPlaceholderMappingDTO, pkSimEvent);
+      }
+
+      public bool EventVisible => _view.EventVisible;
+
+      private void updateEventInMapping(EventPlaceholderMappingDTO eventPlaceholderMappingDTO, PKSimEvent pkSimEvent)
+      {
+         if (pkSimEvent == null) return;
+         eventPlaceholderMappingDTO.Selection = selectionFrom(pkSimEvent);
+         _view.RefreshData();
+         OnStatusChanged();
+      }
+
+      public void SaveConfiguration()
+      {
+         _protocolProperties.ClearEventPlaceholderMappings();
+
+         _allEventMappingDTO.Each(dto =>
+         {
+            _eventTask.Load(dto.Event);
+            _protocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping
+            {
+               TemplateEventId = dto.Event.Id,
+               EventKey = dto.EventKey,
+               Event = dto.Event
+            });
+         });
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
@@ -21,6 +21,7 @@ namespace PKSim.Presentation.Presenters.Simulations
    public class SimulationCompoundProtocolPresenter : AbstractSubPresenter<ISimulationCompoundProtocolView, ISimulationCompoundProtocolPresenter>, ISimulationCompoundProtocolPresenter
    {
       private readonly ISimulationCompoundProtocolFormulationPresenter _simulationCompoundProtocolFormulationPresenter;
+      private readonly ISimulationCompoundProtocolEventPresenter _simulationCompoundProtocolEventPresenter;
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
       private Simulation _simulation;
@@ -28,25 +29,36 @@ namespace PKSim.Presentation.Presenters.Simulations
       private ProtocolProperties _protocolProperties;
       public Compound Compound { get; private set; }
       public bool FormulationChanged { get; private set; }
+      public bool EventChanged { get; private set; }
       public bool ProtocolChanged { get; private set; }
 
       public SimulationCompoundProtocolPresenter(
          ISimulationCompoundProtocolView view,
          ISimulationCompoundProtocolFormulationPresenter simulationCompoundProtocolFormulationPresenter,
-         ILazyLoadTask lazyLoadTask, 
+         ISimulationCompoundProtocolEventPresenter simulationCompoundProtocolEventPresenter,
+         ILazyLoadTask lazyLoadTask,
          IBuildingBlockInProjectManager buildingBlockInProjectManager)
          : base(view)
       {
          _simulationCompoundProtocolFormulationPresenter = simulationCompoundProtocolFormulationPresenter;
+         _simulationCompoundProtocolEventPresenter = simulationCompoundProtocolEventPresenter;
          _lazyLoadTask = lazyLoadTask;
          _buildingBlockInProjectManager = buildingBlockInProjectManager;
          _view.AddFormulationMappingView(_simulationCompoundProtocolFormulationPresenter.View);
+         _view.AddEventMappingView(_simulationCompoundProtocolEventPresenter.View);
          _simulationCompoundProtocolFormulationPresenter.StatusChanged += onFormulationChanged;
+         _simulationCompoundProtocolEventPresenter.StatusChanged += onEventChanged;
       }
 
       private void onFormulationChanged(object sender, EventArgs e)
       {
          FormulationChanged = true;
+         OnStatusChanged();
+      }
+
+      private void onEventChanged(object sender, EventArgs e)
+      {
+         EventChanged = true;
          OnStatusChanged();
       }
 
@@ -67,6 +79,7 @@ namespace PKSim.Presentation.Presenters.Simulations
          _lazyLoadTask.Load(SelectedProtocol);
          _protocolProperties.Protocol = SelectedProtocol;
          _simulationCompoundProtocolFormulationPresenter.EditSimulation(_simulation, Compound);
+         _simulationCompoundProtocolEventPresenter.EditSimulation(_simulation, Compound);
       }
 
       public void UpdateSelectedFormulation(Formulation templateFormulation)
@@ -88,9 +101,10 @@ namespace PKSim.Presentation.Presenters.Simulations
       public void SaveConfiguration()
       {
          _simulationCompoundProtocolFormulationPresenter.SaveConfiguration();
+         _simulationCompoundProtocolEventPresenter.SaveConfiguration();
       }
 
-      public override bool CanClose => base.CanClose && _simulationCompoundProtocolFormulationPresenter.CanClose;
+      public override bool CanClose => base.CanClose && _simulationCompoundProtocolFormulationPresenter.CanClose && _simulationCompoundProtocolEventPresenter.CanClose;
 
       public Protocol SelectedProtocol => _protocolSelectionDTO.BuildingBlock;
 

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationEventsConfigurationPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationEventsConfigurationPresenter.cs
@@ -84,8 +84,8 @@ namespace PKSim.Presentation.Presenters.Simulations
             _eventProperties.AddEventMapping(_eventMappingMapper.MapFrom(eventMappingDTO, _simulation));
          });
 
-         var allEvents = _allEventsMappingDTO.Select(x => x.Event).ToList();
-
+         var standaloneEvents = _allEventsMappingDTO.Select(x => x.Event);
+         var allEvents = standaloneEvents.Concat(_simulation.AllEventsFromProtocolPlaceholderMappings()).Distinct().ToList();
          _simulationBuildingBlockUpdater.UpdateMultipleUsedBuildingBlockInSimulationFromTemplate(_simulation, allEvents, PKSimBuildingBlockType.Event);
       }
 

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolEventView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolEventView.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using OSPSuite.Presentation.Views;
+
+namespace PKSim.Presentation.Views.Simulations
+{
+   public interface ISimulationCompoundProtocolEventView : IView<ISimulationCompoundProtocolEventPresenter>
+   {
+      void BindTo(IEnumerable<EventPlaceholderMappingDTO> eventMappings);
+      void RefreshData();
+
+      /// <summary>
+      /// Sets the visibility of the event view
+      /// </summary>
+      bool EventVisible { get; set; }
+   }
+}

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
@@ -8,6 +8,7 @@ namespace PKSim.Presentation.Views.Simulations
    {
       void BindTo(ProtocolSelectionDTO protocolSelectionDTO);
       void AddFormulationMappingView(IView view);
+      void AddEventMappingView(IView view);
       bool AllowEmptyProtocolSelection { get;set; }
    }
 }

--- a/src/PKSim.UI/Views/Protocols/SimpleProtocolView.cs
+++ b/src/PKSim.UI/Views/Protocols/SimpleProtocolView.cs
@@ -40,6 +40,7 @@ namespace PKSim.UI.Views.Protocols
          cbEventKey.Properties.Items.Clear();
          _presenter.AllEventKeys().Each(key => cbEventKey.Properties.Items.Add(key));
          _screenBinder.BindToSource(simpleProtocolDTO);
+         NotifyViewChanged();
       }
 
       public bool EndTimeVisible
@@ -69,6 +70,7 @@ namespace PKSim.UI.Views.Protocols
          {
             tablePanel.RowFor(cbEventKey).Visible = value;
             tablePanel.RowFor(uxEventOffset).Visible = value;
+            AdjustLayout();
          }
          get => tablePanel.RowFor(cbEventKey).Visible;
       }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.Designer.cs
@@ -1,0 +1,64 @@
+namespace PKSim.UI.Views.Simulations
+{
+   partial class SimulationCompoundProtocolEventView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _gridViewBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         this.SuspendLayout();
+         //
+         // layoutControl
+         //
+         this.layoutControl.Size = new System.Drawing.Size(309, 356);
+         //
+         // layoutItemGrid
+         //
+         this.layoutItemGrid.MaxSize = new System.Drawing.Size(0, 64);
+         this.layoutItemGrid.MinSize = new System.Drawing.Size(1, 64);
+         this.layoutItemGrid.Size = new System.Drawing.Size(309, 356);
+         this.layoutItemGrid.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
+         //
+         // SimulationCompoundProtocolEventView
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Name = "SimulationCompoundProtocolEventView";
+         this.Size = new System.Drawing.Size(309, 356);
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolEventView.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using DevExpress.Utils;
+using DevExpress.XtraEditors;
+using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
+using OSPSuite.Assets;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.UI;
+using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
+using OSPSuite.UI.RepositoryItems;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Views.Simulations;
+using static OSPSuite.UI.UIConstants.Size;
+
+namespace PKSim.UI.Views.Simulations
+{
+   public partial class SimulationCompoundProtocolEventView : BaseGridViewOnlyUserControl, ISimulationCompoundProtocolEventView
+   {
+      private ISimulationCompoundProtocolEventPresenter _presenter;
+      private readonly GridViewBinder<EventPlaceholderMappingDTO> _gridViewBinder;
+      private readonly UxRepositoryItemComboBox _repositoryForEvent;
+
+      public SimulationCompoundProtocolEventView()
+      {
+         InitializeComponent();
+         _repositoryForEvent = new UxRepositoryItemComboBox(gridView) { AllowHtmlDraw = DefaultBoolean.True };
+         _gridViewBinder = new GridViewBinder<EventPlaceholderMappingDTO>(gridView);
+         gridView.HorzScrollVisibility = ScrollVisibility.Never;
+         layoutControl.AutoScroll = false;
+      }
+
+      public void AttachPresenter(ISimulationCompoundProtocolEventPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public override bool HasError => _gridViewBinder.HasError;
+
+      public void BindTo(IEnumerable<EventPlaceholderMappingDTO> eventMappings)
+      {
+         _gridViewBinder.BindToSource(eventMappings.ToBindingList());
+         gridView.BestFitColumns();
+         AdjustHeight();
+      }
+
+      public void RefreshData()
+      {
+         gridView.RefreshData();
+      }
+
+      public bool EventVisible
+      {
+         get => GridVisible;
+         set => GridVisible = value;
+      }
+
+      public override void InitializeBinding()
+      {
+         var createEventButton = createEventButtonRepository();
+         var loadEventButton = loadEventButtonRepository();
+
+         _gridViewBinder.Bind(x => x.EventKey)
+            .WithCaption(PKSimConstants.UI.PlaceholderEvent)
+            .AsReadOnly();
+
+         _gridViewBinder.AutoBind(x => x.Selection)
+            .WithCaption(PKSimConstants.ObjectTypes.Event)
+            .WithRepository(x => _repositoryForEvent)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithEditorConfiguration(configureEvent);
+
+         _gridViewBinder.AddUnboundColumn()
+            .WithCaption(Captions.EmptyColumn)
+            .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithRepository(dto => createEventButton);
+
+         _gridViewBinder.AddUnboundColumn()
+            .WithCaption(Captions.EmptyColumn)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+            .WithRepository(dto => loadEventButton);
+
+         _gridViewBinder.Changed += () => _presenter.ViewChanged();
+         createEventButton.ButtonClick += (o, e) => OnEvent(() => _presenter.CreateEventFor(_gridViewBinder.FocusedElement));
+         loadEventButton.ButtonClick += (o, e) => OnEvent(() => _presenter.LoadEventForAsync(_gridViewBinder.FocusedElement));
+      }
+
+      private RepositoryItemButtonEdit createEventButtonRepository() =>
+         new UxRepositoryItemButtonImage(ApplicationIcons.Create, PKSimConstants.UI.CreateBuildingBlockHint(PKSimConstants.ObjectTypes.Event));
+
+      private RepositoryItemButtonEdit loadEventButtonRepository() =>
+         new UxRepositoryItemButtonImage(ApplicationIcons.LoadFromTemplate, PKSimConstants.UI.LoadItemFromTemplate(PKSimConstants.ObjectTypes.Event));
+
+      private void configureEvent(BaseEdit baseEdit, EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
+      {
+         baseEdit.FillComboBoxEditorWith(_presenter.AllEventsFor(eventPlaceholderMappingDTO));
+      }
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
@@ -31,91 +31,115 @@
       {
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
          this.panelFormulation = new DevExpress.XtraEditors.PanelControl();
+         this.panelEvent = new DevExpress.XtraEditors.PanelControl();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemFormulation = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemEvent = new DevExpress.XtraLayout.LayoutControlItem();
          this.panelControl1 = new DevExpress.XtraEditors.PanelControl();
          this.layoutItemProtocol = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.panelFormulation)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelEvent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).BeginInit();
          this.SuspendLayout();
-         // 
+         //
          // layoutControl
-         // 
+         //
          this.layoutControl.AllowCustomization = false;
          this.layoutControl.Controls.Add(this.panelControl1);
          this.layoutControl.Controls.Add(this.panelFormulation);
+         this.layoutControl.Controls.Add(this.panelEvent);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
          this.layoutControl.Root = this.layoutControlGroup;
-         this.layoutControl.Size = new System.Drawing.Size(374, 118);
+         this.layoutControl.Size = new System.Drawing.Size(374, 199);
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl1";
-         // 
+         //
          // panelFormulation
-         // 
+         //
          this.panelFormulation.Location = new System.Drawing.Point(2, 39);
          this.panelFormulation.Name = "panelFormulation";
          this.panelFormulation.Size = new System.Drawing.Size(370, 77);
          this.panelFormulation.TabIndex = 14;
-         // 
+         //
+         // panelEvent
+         //
+         this.panelEvent.Location = new System.Drawing.Point(2, 120);
+         this.panelEvent.Name = "panelEvent";
+         this.panelEvent.Size = new System.Drawing.Size(370, 77);
+         this.panelEvent.TabIndex = 16;
+         //
          // layoutControlGroup
-         // 
+         //
          this.layoutControlGroup.CustomizationFormText = "layoutControlGroup1";
          this.layoutControlGroup.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
          this.layoutControlGroup.GroupBordersVisible = false;
          this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemFormulation,
+            this.layoutItemEvent,
             this.layoutItemProtocol});
          this.layoutControlGroup.Name = "layoutControlGroup";
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
-         this.layoutControlGroup.Size = new System.Drawing.Size(374, 118);
+         this.layoutControlGroup.Size = new System.Drawing.Size(374, 199);
          this.layoutControlGroup.Text = "layoutControlGroup1";
          this.layoutControlGroup.TextVisible = false;
-         // 
+         //
          // layoutItemFormulation
-         // 
+         //
          this.layoutItemFormulation.Control = this.panelFormulation;
          this.layoutItemFormulation.Location = new System.Drawing.Point(0, 37);
          this.layoutItemFormulation.Name = "layoutItemFormulation";
          this.layoutItemFormulation.Size = new System.Drawing.Size(374, 81);
          this.layoutItemFormulation.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemFormulation.TextVisible = false;
-         // 
+         //
+         // layoutItemEvent
+         //
+         this.layoutItemEvent.Control = this.panelEvent;
+         this.layoutItemEvent.Location = new System.Drawing.Point(0, 118);
+         this.layoutItemEvent.Name = "layoutItemEvent";
+         this.layoutItemEvent.Size = new System.Drawing.Size(374, 81);
+         this.layoutItemEvent.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemEvent.TextVisible = false;
+         //
          // panelControl1
-         // 
+         //
          this.panelControl1.Location = new System.Drawing.Point(105, 2);
          this.panelControl1.Name = "panelControl1";
          this.panelControl1.Size = new System.Drawing.Size(267, 33);
          this.panelControl1.TabIndex = 15;
-         // 
+         //
          // layoutItemProtocol
-         // 
+         //
          this.layoutItemProtocol.Control = this.panelControl1;
          this.layoutItemProtocol.Location = new System.Drawing.Point(0, 0);
          this.layoutItemProtocol.Name = "layoutItemProtocol";
          this.layoutItemProtocol.Size = new System.Drawing.Size(374, 37);
          this.layoutItemProtocol.TextSize = new System.Drawing.Size(91, 13);
-         // 
+         //
          // SimulationCompoundProtocolView
-         // 
+         //
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Controls.Add(this.layoutControl);
          this.Name = "SimulationCompoundProtocolView";
-         this.Size = new System.Drawing.Size(374, 118);
+         this.Size = new System.Drawing.Size(374, 199);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.panelFormulation)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelEvent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).EndInit();
          this.ResumeLayout(false);
@@ -127,7 +151,9 @@
       private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
       private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
       private DevExpress.XtraEditors.PanelControl panelFormulation;
+      private DevExpress.XtraEditors.PanelControl panelEvent;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemFormulation;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemEvent;
       private DevExpress.XtraEditors.PanelControl panelControl1;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemProtocol;
    }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
@@ -51,7 +51,12 @@ namespace PKSim.UI.Views.Simulations
       public void AddFormulationMappingView(IView view)
       {
          _resizableView = view as IResizableView;
-         AddViewTo(layoutItemFormulation,layoutControl,  view);
+         AddViewTo(layoutItemFormulation, layoutControl, view);
+      }
+
+      public void AddEventMappingView(IView view)
+      {
+         AddViewTo(layoutItemEvent, layoutControl, view);
       }
 
       public bool AllowEmptyProtocolSelection

--- a/tests/PKSim.Tests/Core/CompoundPropertiesMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/CompoundPropertiesMapperSpecs.cs
@@ -54,6 +54,7 @@ namespace PKSim.Core
       private EnzymaticProcessSelection _noEnzymaticPartialProcessSelection;
       private EnzymaticProcess _anotherEnzymaticProcess;
       protected SnapshotContext _baseSnapshotContext;
+      protected PKSimEvent _pkSimEvent;
 
       protected override Task Context()
       {
@@ -132,14 +133,23 @@ namespace PKSim.Core
          {
             Id = "123456"
          };
+         _pkSimEvent = new PKSimEvent { Id = "event123", Name = "MyEvent" };
+
          _compoundProperties.ProtocolProperties.Protocol = _protocol;
          _compoundProperties.ProtocolProperties.AddFormulationMapping(new FormulationMapping
          {
             FormulationKey = "F1",
             TemplateFormulationId = _formulation.Id
          });
+         _compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping
+         {
+            EventKey = "EVENT_1",
+            TemplateEventId = _pkSimEvent.Id,
+            Event = _pkSimEvent
+         });
 
          _project.AddBuildingBlock(_formulation);
+         _project.AddBuildingBlock(_pkSimEvent);
          A.CallTo(() => _calculationMethodCacheMapper.MapToSnapshot(_compoundProperties.CalculationMethodCache)).Returns(_calculationMethodSnapshot);
          A.CallTo(() => _processMappingMapper.MapToSnapshot(_enzymaticPartialProcessSelection)).Returns(_snapshotProcess1);
          A.CallTo(() => _processMappingMapper.MapToSnapshot(_specificBindingPartialProcessSelection)).Returns(_snapshotProcess2);
@@ -183,6 +193,14 @@ namespace PKSim.Core
          _snapshot.Protocol.Formulations.Length.ShouldBeEqualTo(1);
          _snapshot.Protocol.Formulations[0].Key.ShouldBeEqualTo("F1");
          _snapshot.Protocol.Formulations[0].Name.ShouldBeEqualTo(_formulation.Name);
+      }
+
+      [Observation]
+      public void should_save_the_event_placeholder_mapping_to_snapshot()
+      {
+         _snapshot.Protocol.Events.Length.ShouldBeEqualTo(1);
+         _snapshot.Protocol.Events[0].Key.ShouldBeEqualTo("EVENT_1");
+         _snapshot.Protocol.Events[0].Name.ShouldBeEqualTo(_pkSimEvent.Name);
       }
 
       [Observation]
@@ -238,6 +256,14 @@ namespace PKSim.Core
       {
          A.CallTo(() => _calculationMethodCacheMapper.MapToModel(_snapshot.CalculationMethods,
             A<CalculationMethodCacheSnapshotContext>.That.Matches(x => x.CalculationMethodCache == _mappedCompoundProperties.CalculationMethodCache))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_map_event_placeholder_mappings_from_snapshot()
+      {
+         _mappedCompoundProperties.ProtocolProperties.EventPlaceholderMappings.Count.ShouldBeEqualTo(1);
+         _mappedCompoundProperties.ProtocolProperties.EventPlaceholderMappings[0].EventKey.ShouldBeEqualTo("EVENT_1");
+         _mappedCompoundProperties.ProtocolProperties.EventPlaceholderMappings[0].TemplateEventId.ShouldBeEqualTo(_pkSimEvent.Id);
       }
    }
 

--- a/tests/PKSim.Tests/Core/EventFromMappingRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Core/EventFromMappingRetrieverSpecs.cs
@@ -1,0 +1,94 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_EventFromMappingRetriever : ContextSpecification<IEventFromMappingRetriever>
+   {
+      protected Simulation _simulation;
+      protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+      protected IBuildingBlockRepository _buildingBlockRepository;
+
+      protected override void Context()
+      {
+         _simulation = new IndividualSimulation();
+         _buildingBlockInProjectManager = A.Fake<IBuildingBlockInProjectManager>();
+         _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
+         sut = new EventFromMappingRetriever(_buildingBlockInProjectManager, _buildingBlockRepository);
+      }
+   }
+
+   public class When_retrieving_a_template_event_used_for_a_mapping : concern_for_EventFromMappingRetriever
+   {
+      private PKSimEvent _event1;
+      private PKSimEvent _event2;
+      private PKSimEvent _templateEvent;
+
+      protected override void Context()
+      {
+         base.Context();
+         _templateEvent = new PKSimEvent().WithId("template");
+         _event1 = new PKSimEvent().WithName("e1").WithId("1");
+         _event2 = new PKSimEvent().WithName("e2").WithId("2");
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock(_event1.Id, PKSimBuildingBlockType.Event) { BuildingBlock = _event1 });
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock(_event2.Id, PKSimBuildingBlockType.Event) { BuildingBlock = _event2 });
+         A.CallTo(() => _buildingBlockRepository.ById<PKSimEvent>("template")).Returns(_templateEvent);
+         A.CallTo(() => _buildingBlockRepository.ById<PKSimEvent>("does not exist")).Returns(null);
+      }
+
+      [Observation]
+      public void should_return_null_if_the_given_mapping_is_null()
+      {
+         sut.TemplateEventUsedBy(_simulation, null).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_return_null_if_the_mapping_has_no_template_id()
+      {
+         sut.TemplateEventUsedBy(_simulation, new EventPlaceholderMapping()).ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_return_the_template_event_if_the_simulation_was_not_initialized_with_that_event()
+      {
+         sut.TemplateEventUsedBy(_simulation, new EventPlaceholderMapping { TemplateEventId = "template" }).ShouldBeEqualTo(_templateEvent);
+      }
+
+      [Observation]
+      public void should_return_null_if_the_template_id_is_not_found()
+      {
+         sut.TemplateEventUsedBy(_simulation, new EventPlaceholderMapping { TemplateEventId = "does not exist" }).ShouldBeNull();
+      }
+   }
+
+   public class When_retrieving_a_template_event_that_has_been_used_in_the_simulation : concern_for_EventFromMappingRetriever
+   {
+      private PKSimEvent _localEvent;
+      private PKSimEvent _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _localEvent = new PKSimEvent().WithId("local");
+         var usedBuildingBlock = new UsedBuildingBlock("e1", PKSimBuildingBlockType.Event) { BuildingBlock = _localEvent };
+         _simulation.AddUsedBuildingBlock(usedBuildingBlock);
+         A.CallTo(() => _buildingBlockInProjectManager.TemplateBuildingBlockUsedBy<PKSimEvent>(usedBuildingBlock)).Returns(_localEvent);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.TemplateEventUsedBy(_simulation, new EventPlaceholderMapping { TemplateEventId = "e1" });
+      }
+
+      [Observation]
+      public void should_return_the_actual_building_block()
+      {
+         _result.ShouldBeEqualTo(_localEvent);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/ProtocolPropertiesSpecs.cs
+++ b/tests/PKSim.Tests/Core/ProtocolPropertiesSpecs.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_ProtocolProperties : ContextSpecification<ProtocolProperties>
+   {
+      protected override void Context()
+      {
+         sut = new ProtocolProperties();
+      }
+   }
+
+   public class When_adding_event_placeholder_mappings : concern_for_ProtocolProperties
+   {
+      private EventPlaceholderMapping _mapping1;
+      private EventPlaceholderMapping _mapping2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _mapping1 = new EventPlaceholderMapping { EventKey = "EVENT_1", TemplateEventId = "id1" };
+         _mapping2 = new EventPlaceholderMapping { EventKey = "EVENT_2", TemplateEventId = "id2" };
+      }
+
+      protected override void Because()
+      {
+         sut.AddEventPlaceholderMapping(_mapping1);
+         sut.AddEventPlaceholderMapping(_mapping2);
+      }
+
+      [Observation]
+      public void should_contain_all_added_mappings()
+      {
+         sut.EventPlaceholderMappings.Count.ShouldBeEqualTo(2);
+         sut.EventPlaceholderMappings.ShouldContain(_mapping1, _mapping2);
+      }
+   }
+
+   public class When_retrieving_an_event_mapping_by_key : concern_for_ProtocolProperties
+   {
+      private EventPlaceholderMapping _mapping1;
+      private EventPlaceholderMapping _mapping2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _mapping1 = new EventPlaceholderMapping { EventKey = "EVENT_1" };
+         _mapping2 = new EventPlaceholderMapping { EventKey = "EVENT_2" };
+         sut.AddEventPlaceholderMapping(_mapping1);
+         sut.AddEventPlaceholderMapping(_mapping2);
+      }
+
+      [Observation]
+      public void should_return_the_mapping_with_the_matching_key()
+      {
+         sut.EventMappingWith("EVENT_1").ShouldBeEqualTo(_mapping1);
+         sut.EventMappingWith("EVENT_2").ShouldBeEqualTo(_mapping2);
+      }
+
+      [Observation]
+      public void should_return_null_for_unknown_key()
+      {
+         sut.EventMappingWith("UNKNOWN").ShouldBeNull();
+      }
+   }
+
+   public class When_clearing_event_placeholder_mappings : concern_for_ProtocolProperties
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1" });
+         sut.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_2" });
+      }
+
+      protected override void Because()
+      {
+         sut.ClearEventPlaceholderMappings();
+      }
+
+      [Observation]
+      public void should_remove_all_event_placeholder_mappings()
+      {
+         sut.EventPlaceholderMappings.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_cloning_protocol_properties_with_event_placeholder_mappings : concern_for_ProtocolProperties
+   {
+      private ProtocolProperties _clone;
+      private Protocol _protocol;
+
+      protected override void Context()
+      {
+         base.Context();
+         _protocol = A.Fake<Protocol>();
+         sut.Protocol = _protocol;
+         sut.AddFormulationMapping(new FormulationMapping { FormulationKey = "FORM_1" });
+         sut.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", TemplateEventId = "id1" });
+         sut.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_2", TemplateEventId = "id2" });
+      }
+
+      protected override void Because()
+      {
+         _clone = sut.Clone();
+      }
+
+      [Observation]
+      public void should_copy_event_placeholder_mappings()
+      {
+         _clone.EventPlaceholderMappings.Count.ShouldBeEqualTo(2);
+         _clone.EventPlaceholderMappings[0].EventKey.ShouldBeEqualTo("EVENT_1");
+         _clone.EventPlaceholderMappings[1].EventKey.ShouldBeEqualTo("EVENT_2");
+      }
+
+      [Observation]
+      public void should_copy_formulation_mappings()
+      {
+         _clone.FormulationMappings.Count.ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_copy_protocol_reference()
+      {
+         _clone.Protocol.ShouldBeEqualTo(_protocol);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/SimulationAllEventsFromProtocolPlaceholderMappingsSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimulationAllEventsFromProtocolPlaceholderMappingsSpecs.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_SimulationAllEventsFromProtocolPlaceholderMappings : ContextSpecification<Simulation>
+   {
+      protected override void Context()
+      {
+         sut = new IndividualSimulation { Properties = new SimulationProperties() };
+      }
+   }
+
+   public class When_retrieving_all_events_from_protocol_placeholder_mappings_with_no_mappings : concern_for_SimulationAllEventsFromProtocolPlaceholderMappings
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Properties.AddCompoundProperties(new CompoundProperties());
+      }
+
+      [Observation]
+      public void should_return_an_empty_list()
+      {
+         sut.AllEventsFromProtocolPlaceholderMappings().Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_retrieving_all_events_from_protocol_placeholder_mappings_with_mappings : concern_for_SimulationAllEventsFromProtocolPlaceholderMappings
+   {
+      private PKSimEvent _event1;
+      private PKSimEvent _event2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _event1 = new PKSimEvent().WithId("e1");
+         _event2 = new PKSimEvent().WithId("e2");
+
+         var compoundProperties = new CompoundProperties();
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", Event = _event1 });
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_2", Event = _event2 });
+         sut.Properties.AddCompoundProperties(compoundProperties);
+      }
+
+      [Observation]
+      public void should_return_all_distinct_events()
+      {
+         var events = sut.AllEventsFromProtocolPlaceholderMappings();
+         events.Count.ShouldBeEqualTo(2);
+         events.ShouldContain(_event1, _event2);
+      }
+   }
+
+   public class When_retrieving_events_with_duplicate_event_across_placeholders : concern_for_SimulationAllEventsFromProtocolPlaceholderMappings
+   {
+      private PKSimEvent _event1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _event1 = new PKSimEvent().WithId("e1");
+
+         var compoundProperties = new CompoundProperties();
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", Event = _event1 });
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_2", Event = _event1 });
+         sut.Properties.AddCompoundProperties(compoundProperties);
+      }
+
+      [Observation]
+      public void should_return_distinct_events_only()
+      {
+         sut.AllEventsFromProtocolPlaceholderMappings().Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_retrieving_events_with_null_event_in_mapping : concern_for_SimulationAllEventsFromProtocolPlaceholderMappings
+   {
+      private PKSimEvent _event1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _event1 = new PKSimEvent().WithId("e1");
+
+         var compoundProperties = new CompoundProperties();
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", Event = _event1 });
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_2", Event = null });
+         sut.Properties.AddCompoundProperties(compoundProperties);
+      }
+
+      [Observation]
+      public void should_filter_out_null_events()
+      {
+         var events = sut.AllEventsFromProtocolPlaceholderMappings();
+         events.Count.ShouldBeEqualTo(1);
+         events.First().ShouldBeEqualTo(_event1);
+      }
+   }
+
+   public class When_retrieving_events_across_multiple_compounds : concern_for_SimulationAllEventsFromProtocolPlaceholderMappings
+   {
+      private PKSimEvent _event1;
+      private PKSimEvent _event2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _event1 = new PKSimEvent().WithId("e1");
+         _event2 = new PKSimEvent().WithId("e2");
+
+         var compoundProperties1 = new CompoundProperties();
+         compoundProperties1.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", Event = _event1 });
+
+         var compoundProperties2 = new CompoundProperties();
+         compoundProperties2.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", Event = _event2 });
+
+         sut.Properties.AddCompoundProperties(compoundProperties1);
+         sut.Properties.AddCompoundProperties(compoundProperties2);
+      }
+
+      [Observation]
+      public void should_gather_events_from_all_compounds()
+      {
+         var events = sut.AllEventsFromProtocolPlaceholderMappings();
+         events.Count.ShouldBeEqualTo(2);
+         events.ShouldContain(_event1, _event2);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/SimulationBuildingBlockUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimulationBuildingBlockUpdaterSpecs.cs
@@ -314,4 +314,36 @@ namespace PKSim.Core
          _compoundProperties.ProtocolProperties.Protocol.ShouldBeEqualTo(_protocolUsedInSimulation);
       }
    }
+
+   public class When_updating_the_events_defined_in_a_simulation_from_protocol_event_placeholder_mappings : concern_for_SimulationBuildingBlockUpdater
+   {
+      private Simulation _simulation;
+      private PKSimEvent _event;
+      private UsedBuildingBlock _usedBuildingBlockEvent;
+      private IPKSimBuildingBlock _eventUsedInSimulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _event = new PKSimEvent();
+         _simulation = new IndividualSimulation { Properties = new SimulationProperties() };
+         _eventUsedInSimulation = new PKSimEvent();
+         _usedBuildingBlockEvent = new UsedBuildingBlock("template", PKSimBuildingBlockType.Event) { BuildingBlock = _eventUsedInSimulation };
+         var compoundProperties = new CompoundProperties();
+         compoundProperties.ProtocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { Event = _event });
+         _simulation.Properties.AddCompoundProperties(compoundProperties);
+         A.CallTo(() => _buildingBlockMapper.MapFrom(_event, null)).Returns(_usedBuildingBlockEvent);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateEventsInSimulation(_simulation);
+      }
+
+      [Observation]
+      public void should_add_the_event_to_the_simulation_used_building_blocks()
+      {
+         _simulation.AllBuildingBlocks<PKSimEvent>().ShouldOnlyContain(_eventUsedInSimulation);
+      }
+   }
 }

--- a/tests/PKSim.Tests/IntegrationTests/SimulationsWithEventsSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationsWithEventsSpecs.cs
@@ -3,6 +3,8 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
+using System.Linq;
+using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Infrastructure;
 using IContainer = OSPSuite.Core.Domain.IContainer;
@@ -34,6 +36,41 @@ namespace PKSim.IntegrationTests
          DomainFactoryForSpecs.AddModelToSimulation(_simulation);
          var simEvent = _simulation.Model.Root.EntityAt<IContainer>(Constants.EVENTS, "Event");
          simEvent.ShouldNotBeNull();
+      }
+   }
+
+   public class When_creating_a_simulation_with_a_simple_protocol_that_has_an_event_placeholder : concern_for_IndividualSimulation
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var eventMappingFactory = IoC.Resolve<IEventMappingFactory>();
+         var eventFactory = IoC.Resolve<IEventFactory>();
+
+         // Set event key on the simple protocol to simulate "Administer with event" checkbox
+         var simpleProtocol = _protocol.DowncastTo<SimpleProtocol>();
+         simpleProtocol.EventKey = CoreConstants.DEFAULT_EVENT_KEY;
+
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol).DowncastTo<IndividualSimulation>();
+
+         // Map the event placeholder to an actual event building block
+         var pksimEvent = eventFactory.Create(CoreConstantsForSpecs.Events.URINARY_BLADDER_EMPTYING).WithName("MyEvent");
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock(pksimEvent.Id, PKSimBuildingBlockType.Event) { BuildingBlock = pksimEvent });
+
+         var protocolProperties = _simulation.CompoundPropertiesList.First().ProtocolProperties;
+         protocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping
+         {
+            EventKey = CoreConstants.DEFAULT_EVENT_KEY,
+            TemplateEventId = pksimEvent.Id,
+            Event = pksimEvent
+         });
+      }
+
+      [Observation]
+      public void should_be_able_to_create_the_simulation_without_crashing()
+      {
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+         _simulation.Model.ShouldNotBeNull();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/EventPlaceholderMappingDTOSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/EventPlaceholderMappingDTOSpecs.cs
@@ -1,0 +1,61 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Utility.Validation;
+using PKSim.Core.Model;
+using PKSim.Presentation.DTO.Simulations;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_EventPlaceholderMappingDTO : ContextSpecification<EventPlaceholderMappingDTO>
+   {
+      protected override void Context()
+      {
+         sut = new EventPlaceholderMappingDTO();
+      }
+   }
+
+   public class When_validating_an_event_placeholder_mapping_dto_without_a_selection : concern_for_EventPlaceholderMappingDTO
+   {
+      [Observation]
+      public void should_not_be_valid()
+      {
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+
+   public class When_validating_an_event_placeholder_mapping_dto_with_a_null_building_block : concern_for_EventPlaceholderMappingDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Selection = new EventSelectionDTO { BuildingBlock = null };
+      }
+
+      [Observation]
+      public void should_not_be_valid()
+      {
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+
+   public class When_validating_an_event_placeholder_mapping_dto_with_a_valid_event : concern_for_EventPlaceholderMappingDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Selection = new EventSelectionDTO { BuildingBlock = new PKSimEvent() };
+      }
+
+      [Observation]
+      public void should_be_valid()
+      {
+         sut.IsValid().ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_expose_the_event_from_the_selection()
+      {
+         sut.Event.ShouldNotBeNull();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/EventSelectionDTOSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/EventSelectionDTOSpecs.cs
@@ -1,0 +1,40 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.Core.Model;
+using PKSim.Presentation.DTO.Simulations;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_EventSelectionDTO : ContextSpecification<EventSelectionDTO>
+   {
+      protected PKSimEvent _event;
+
+      protected override void Context()
+      {
+         _event = new PKSimEvent { Id = "event1" };
+         sut = new EventSelectionDTO { BuildingBlock = _event };
+      }
+   }
+
+   public class When_comparing_two_event_selection_dto : concern_for_EventSelectionDTO
+   {
+      [Observation]
+      public void should_return_equal_if_the_underlying_building_blocks_are_equal()
+      {
+         sut.Equals(new EventSelectionDTO { BuildingBlock = _event }).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_unequal_otherwise()
+      {
+         sut.Equals(new EventSelectionDTO { BuildingBlock = new PKSimEvent() }).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_return_display_name_from_to_string()
+      {
+         sut.DisplayName = "MyEvent";
+         sut.ToString().ShouldBeEqualTo("MyEvent");
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Services;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_SimulationCompoundProtocolEventPresenter : ContextSpecification<ISimulationCompoundProtocolEventPresenter>
+   {
+      protected ISimulationCompoundProtocolEventView _view;
+      protected IEventTask _eventTask;
+      protected IEventFromMappingRetriever _eventFromMappingRetriever;
+      protected IBuildingBlockSelectionDisplayer _buildingBlockSelectionDisplayer;
+      protected Protocol _protocol;
+      protected Simulation _simulation;
+      protected ProtocolProperties _protocolProperties;
+      protected PKSimEvent _event1;
+      protected PKSimEvent _event2;
+      protected Compound _compound;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISimulationCompoundProtocolEventView>();
+         _eventTask = A.Fake<IEventTask>();
+         _eventFromMappingRetriever = A.Fake<IEventFromMappingRetriever>();
+         _buildingBlockSelectionDisplayer = A.Fake<IBuildingBlockSelectionDisplayer>();
+         _event1 = new PKSimEvent().WithName("Event1").WithId("event1Id");
+         _event2 = new PKSimEvent().WithName("Event2").WithId("event2Id");
+         _protocol = A.Fake<Protocol>();
+         _compound = A.Fake<Compound>();
+         _simulation = A.Fake<Simulation>();
+         _protocolProperties = new ProtocolProperties();
+         var compoundProperties = new CompoundProperties();
+         A.CallTo(() => _simulation.CompoundPropertiesFor(_compound)).Returns(compoundProperties);
+         compoundProperties.ProtocolProperties = _protocolProperties;
+         _protocolProperties.Protocol = _protocol;
+         A.CallTo(() => _eventTask.All()).Returns(new[] { _event1, _event2 });
+         sut = new SimulationCompoundProtocolEventPresenter(_view, _eventTask, _eventFromMappingRetriever, _buildingBlockSelectionDisplayer);
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_with_event_placeholders : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private string _eventKey1;
+      private string _eventKey2;
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         _eventKey1 = "EVENT_1";
+         _eventKey2 = "EVENT_2";
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { _eventKey1, _eventKey2 });
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_display_event_mapping_for_each_event_key()
+      {
+         _eventMappingDtoList.Count.ShouldBeEqualTo(2);
+         _eventMappingDtoList[0].EventKey.ShouldBeEqualTo(_eventKey1);
+         _eventMappingDtoList[0].Event.ShouldNotBeNull();
+         _eventMappingDtoList[1].EventKey.ShouldBeEqualTo(_eventKey2);
+         _eventMappingDtoList[1].Event.ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_make_event_mapping_visible()
+      {
+         A.CallToSet(() => _view.EventVisible).To(true).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_bind_to_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_without_event_placeholders : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(Enumerable.Empty<string>());
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_not_display_any_event_mapping()
+      {
+         _eventMappingDtoList.Any().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_hide_event_mapping_view()
+      {
+         A.CallToSet(() => _view.EventVisible).To(false).MustHaveHappened();
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_that_is_not_defined : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         _protocolProperties.Protocol = null;
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_not_display_any_event_mapping()
+      {
+         _eventMappingDtoList.Any().ShouldBeFalse();
+      }
+   }
+
+   public class When_retrieving_all_events_for_a_placeholder_mapping : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IEnumerable<EventSelectionDTO> _result;
+
+      protected override void Because()
+      {
+         _result = sut.AllEventsFor(new EventPlaceholderMappingDTO());
+      }
+
+      [Observation]
+      public void should_return_all_available_events()
+      {
+         _result.Select(x => x.BuildingBlock).ShouldOnlyContain(_event1, _event2);
+      }
+   }
+
+   public class When_creating_a_new_event_for_a_placeholder_mapping : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private EventPlaceholderMappingDTO _dto;
+      private bool _eventRaised;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new EventPlaceholderMappingDTO { EventKey = "EVENT_1" };
+         A.CallTo(() => _eventTask.AddToProject()).Returns(_event1);
+         sut.StatusChanged += (o, e) => { _eventRaised = true; };
+      }
+
+      protected override void Because()
+      {
+         sut.CreateEventFor(_dto);
+      }
+
+      [Observation]
+      public void should_set_the_created_event_in_the_mapping()
+      {
+         _dto.Event.ShouldBeEqualTo(_event1);
+      }
+
+      [Observation]
+      public void should_refresh_the_view()
+      {
+         A.CallTo(() => _view.RefreshData()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_notify_status_changed()
+      {
+         _eventRaised.ShouldBeTrue();
+      }
+   }
+
+   public class When_saving_event_placeholder_configuration : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private string _eventKey1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _eventKey1 = "EVENT_1";
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { _eventKey1 });
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      protected override void Because()
+      {
+         sut.SaveConfiguration();
+      }
+
+      [Observation]
+      public void should_save_event_placeholder_mappings_to_protocol_properties()
+      {
+         _protocolProperties.EventPlaceholderMappings.Count.ShouldBeEqualTo(1);
+         _protocolProperties.EventPlaceholderMappings[0].EventKey.ShouldBeEqualTo(_eventKey1);
+         _protocolProperties.EventPlaceholderMappings[0].Event.ShouldNotBeNull();
+      }
+   }
+
+   public class When_the_event_presenter_notifies_view_changed : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private bool _eventRaised;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.StatusChanged += (o, e) => { _eventRaised = true; };
+      }
+
+      protected override void Because()
+      {
+         sut.ViewChanged();
+      }
+
+      [Observation]
+      public void should_notify_status_changed()
+      {
+         _eventRaised.ShouldBeTrue();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
@@ -14,16 +14,18 @@ namespace PKSim.Presentation
       protected ISimulationCompoundProtocolView _view;
       protected ILazyLoadTask _lazyLoadTask;
       protected ISimulationCompoundProtocolFormulationPresenter _simulationCompoundProtocolFormulationPresenter;
+      protected ISimulationCompoundProtocolEventPresenter _simulationCompoundProtocolEventPresenter;
       protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
 
       protected override void Context()
       {
          _view = A.Fake<ISimulationCompoundProtocolView>();
          _simulationCompoundProtocolFormulationPresenter = A.Fake<ISimulationCompoundProtocolFormulationPresenter>();
+         _simulationCompoundProtocolEventPresenter = A.Fake<ISimulationCompoundProtocolEventPresenter>();
          _buildingBlockInProjectManager = A.Fake<IBuildingBlockInProjectManager>();
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
 
-         sut = new SimulationCompoundProtocolPresenter(_view, _simulationCompoundProtocolFormulationPresenter, _lazyLoadTask, _buildingBlockInProjectManager);
+         sut = new SimulationCompoundProtocolPresenter(_view, _simulationCompoundProtocolFormulationPresenter, _simulationCompoundProtocolEventPresenter, _lazyLoadTask, _buildingBlockInProjectManager);
       }
    }
 


### PR DESCRIPTION
## Summary
- Adds event placeholder mapping UI to the protocol configuration step during simulation creation
- When a protocol contains event entries with event keys (placeholders), the UI now presents event mapping alongside formulation mapping
- Users can select a PKSimEvent building block for each event placeholder, with validation ensuring all are mapped
- Includes XML serialization, snapshot mapper support, and building block registration for events from protocol mappings


<img width="856" height="975" alt="image" src="https://github.com/user-attachments/assets/05860737-41b7-490a-965a-cc6762d13370" />

Fixes #3461

## Test plan
- [x] Presenter tests cover mapping logic, validation, and save flow (18 tests)
- [x] All 5160+ existing tests pass (4 pre-existing integration test failures unrelated to this change)
- [ ] Manual: create simulation with protocol containing event entries, verify event mapping UI appears
- [ ] Manual: verify validation error when event placeholder is unmapped
- [ ] Manual: verify same event can be mapped to multiple placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event placeholder support for protocol configuration in simulations
  * New event selection interface for managing event-to-placeholder mappings
  * Event mapping persistence across simulation snapshots

* **Bug Fixes**
  * Fixed event application creation filtering in protocol building

* **Documentation**
  * Added workflow documentation for development processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->