### PR TITLE
Fixes #1296 Add DTO layer to UserSettingsView

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1397,6 +1397,7 @@ namespace PKSim.Assets
 
          public static readonly string AtLeastTwoBinsRequired = "At least two bins are required";
          public static readonly string ExceededMaximumOfBins = "Maximum of bins exceeded";
+         public static readonly string DecimalPlaceMustBeBetween0And15 = "Number of decimal places must be between 0 and 15";
       }
 
       public static class UI

--- a/src/PKSim.Presentation/DTO/Mappers/UserSettingsToUserSettingsDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/UserSettingsToUserSettingsDTOMapper.cs
@@ -1,0 +1,85 @@
+using OSPSuite.Utility;
+
+namespace PKSim.Presentation.DTO.Mappers
+{
+   public interface IUserSettingsToUserSettingsDTOMapper : IMapper<IUserSettings, UserSettingsDTO>
+   {
+      void UpdateUserSettingsFrom(UserSettingsDTO userSettingsDTO, IUserSettings userSettings);
+   }
+
+   public class UserSettingsToUserSettingsDTOMapper : IUserSettingsToUserSettingsDTOMapper
+   {
+      public UserSettingsDTO MapFrom(IUserSettings userSettings)
+      {
+         return new UserSettingsDTO
+         {
+            DecimalPlace = userSettings.DecimalPlace,
+            AllowsScientificNotation = userSettings.AllowsScientificNotation,
+            ShouldRestoreWorkspaceLayout = userSettings.ShouldRestoreWorkspaceLayout,
+            ShowUpdateNotification = userSettings.ShowUpdateNotification,
+            ColorGroupObservedDataFromSameFolder = userSettings.ColorGroupObservedDataFromSameFolder,
+            ActiveSkin = userSettings.ActiveSkin,
+            IconSizeTreeView = userSettings.IconSizeTreeView,
+            IconSizeTab = userSettings.IconSizeTab,
+            IconSizeContextMenu = userSettings.IconSizeContextMenu,
+            DefaultSpecies = userSettings.DefaultSpecies,
+            DefaultPopulation = userSettings.DefaultPopulation,
+            DefaultParameterGroupingMode = userSettings.DefaultParameterGroupingMode,
+            DefaultParameterGroupingModeForPIAndSA = userSettings.DefaultParameterGroupingModeForPIAndSA,
+            AbsTol = userSettings.AbsTol,
+            RelTol = userSettings.RelTol,
+            NumberOfBins = userSettings.NumberOfBins,
+            NumberOfIndividualsPerBin = userSettings.NumberOfIndividualsPerBin,
+            MaximumNumberOfCoresToUse = userSettings.MaximumNumberOfCoresToUse,
+            MRUListItemCount = userSettings.MRUListItemCount,
+            TemplateDatabasePath = userSettings.TemplateDatabasePath,
+            ChangedColor = userSettings.ChangedColor,
+            FormulaColor = userSettings.FormulaColor,
+            ChartDiagramBackColor = userSettings.ChartDiagramBackColor,
+            ChartBackColor = userSettings.ChartBackColor,
+            DefaultFractionUnboundName = userSettings.DefaultFractionUnboundName,
+            DefaultLipophilicityName = userSettings.DefaultLipophilicityName,
+            DefaultSolubilityName = userSettings.DefaultSolubilityName,
+            LoadTemplateWithReference = userSettings.LoadTemplateWithReference,
+            DefaultPopulationAnalysis = userSettings.DefaultPopulationAnalysis,
+            DefaultChartYScaling = userSettings.DefaultChartYScaling,
+            PreferredViewLayout = userSettings.PreferredViewLayout,
+         };
+      }
+
+      public void UpdateUserSettingsFrom(UserSettingsDTO userSettingsDTO, IUserSettings userSettings)
+      {
+         userSettings.DecimalPlace = userSettingsDTO.DecimalPlace;
+         userSettings.AllowsScientificNotation = userSettingsDTO.AllowsScientificNotation;
+         userSettings.ShouldRestoreWorkspaceLayout = userSettingsDTO.ShouldRestoreWorkspaceLayout;
+         userSettings.ShowUpdateNotification = userSettingsDTO.ShowUpdateNotification;
+         userSettings.ColorGroupObservedDataFromSameFolder = userSettingsDTO.ColorGroupObservedDataFromSameFolder;
+         userSettings.ActiveSkin = userSettingsDTO.ActiveSkin;
+         userSettings.IconSizeTreeView = userSettingsDTO.IconSizeTreeView;
+         userSettings.IconSizeTab = userSettingsDTO.IconSizeTab;
+         userSettings.IconSizeContextMenu = userSettingsDTO.IconSizeContextMenu;
+         userSettings.DefaultSpecies = userSettingsDTO.DefaultSpecies;
+         userSettings.DefaultPopulation = userSettingsDTO.DefaultPopulation;
+         userSettings.DefaultParameterGroupingMode = userSettingsDTO.DefaultParameterGroupingMode;
+         userSettings.DefaultParameterGroupingModeForPIAndSA = userSettingsDTO.DefaultParameterGroupingModeForPIAndSA;
+         userSettings.AbsTol = userSettingsDTO.AbsTol;
+         userSettings.RelTol = userSettingsDTO.RelTol;
+         userSettings.NumberOfBins = userSettingsDTO.NumberOfBins;
+         userSettings.NumberOfIndividualsPerBin = userSettingsDTO.NumberOfIndividualsPerBin;
+         userSettings.MaximumNumberOfCoresToUse = userSettingsDTO.MaximumNumberOfCoresToUse;
+         userSettings.MRUListItemCount = userSettingsDTO.MRUListItemCount;
+         userSettings.TemplateDatabasePath = userSettingsDTO.TemplateDatabasePath;
+         userSettings.ChangedColor = userSettingsDTO.ChangedColor;
+         userSettings.FormulaColor = userSettingsDTO.FormulaColor;
+         userSettings.ChartDiagramBackColor = userSettingsDTO.ChartDiagramBackColor;
+         userSettings.ChartBackColor = userSettingsDTO.ChartBackColor;
+         userSettings.DefaultFractionUnboundName = userSettingsDTO.DefaultFractionUnboundName;
+         userSettings.DefaultLipophilicityName = userSettingsDTO.DefaultLipophilicityName;
+         userSettings.DefaultSolubilityName = userSettingsDTO.DefaultSolubilityName;
+         userSettings.LoadTemplateWithReference = userSettingsDTO.LoadTemplateWithReference;
+         userSettings.DefaultPopulationAnalysis = userSettingsDTO.DefaultPopulationAnalysis;
+         userSettings.DefaultChartYScaling = userSettingsDTO.DefaultChartYScaling;
+         userSettings.PreferredViewLayout = userSettingsDTO.PreferredViewLayout;
+      }
+   }
+}

--- a/src/PKSim.Presentation/DTO/UserSettingsDTO.cs
+++ b/src/PKSim.Presentation/DTO/UserSettingsDTO.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq.Expressions;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Presentation.DTO
+{
+   public class UserSettingsDTO : ValidatableDTO
+   {
+      private uint _decimalPlace;
+      private bool _allowsScientificNotation;
+      private bool _shouldRestoreWorkspaceLayout;
+      private bool _showUpdateNotification;
+      private bool _colorGroupObservedDataFromSameFolder;
+      private string _activeSkin;
+      private IconSize _iconSizeTreeView;
+      private IconSize _iconSizeTab;
+      private IconSize _iconSizeContextMenu;
+      private string _defaultSpecies;
+      private string _defaultPopulation;
+      private ParameterGroupingModeId _defaultParameterGroupingMode;
+      private ParameterGroupingModeIdForParameterAnalyzable _defaultParameterGroupingModeForPIAndSA;
+      private double _absTol;
+      private double _relTol;
+      private int _numberOfBins;
+      private int _numberOfIndividualsPerBin;
+      private int _maximumNumberOfCoresToUse;
+      private uint _mruListItemCount;
+      private string _templateDatabasePath;
+      private Color _changedColor;
+      private Color _formulaColor;
+      private Color _chartDiagramBackColor;
+      private Color _chartBackColor;
+      private string _defaultFractionUnboundName;
+      private string _defaultLipophilicityName;
+      private string _defaultSolubilityName;
+      private LoadTemplateWithReference _loadTemplateWithReference;
+      private PopulationAnalysisType _defaultPopulationAnalysis;
+      private Scalings _defaultChartYScaling;
+      private ViewLayout _preferredViewLayout;
+
+      public UserSettingsDTO()
+      {
+         Rules.AddRange(AllRules.All());
+      }
+
+      public virtual uint DecimalPlace
+      {
+         get => _decimalPlace;
+         set => SetProperty(ref _decimalPlace, value);
+      }
+
+      public virtual bool AllowsScientificNotation
+      {
+         get => _allowsScientificNotation;
+         set => SetProperty(ref _allowsScientificNotation, value);
+      }
+
+      public virtual bool ShouldRestoreWorkspaceLayout
+      {
+         get => _shouldRestoreWorkspaceLayout;
+         set => SetProperty(ref _shouldRestoreWorkspaceLayout, value);
+      }
+
+      public virtual bool ShowUpdateNotification
+      {
+         get => _showUpdateNotification;
+         set => SetProperty(ref _showUpdateNotification, value);
+      }
+
+      public virtual bool ColorGroupObservedDataFromSameFolder
+      {
+         get => _colorGroupObservedDataFromSameFolder;
+         set => SetProperty(ref _colorGroupObservedDataFromSameFolder, value);
+      }
+
+      public virtual string ActiveSkin
+      {
+         get => _activeSkin;
+         set => SetProperty(ref _activeSkin, value);
+      }
+
+      public virtual IconSize IconSizeTreeView
+      {
+         get => _iconSizeTreeView;
+         set => SetProperty(ref _iconSizeTreeView, value);
+      }
+
+      public virtual IconSize IconSizeTab
+      {
+         get => _iconSizeTab;
+         set => SetProperty(ref _iconSizeTab, value);
+      }
+
+      public virtual IconSize IconSizeContextMenu
+      {
+         get => _iconSizeContextMenu;
+         set => SetProperty(ref _iconSizeContextMenu, value);
+      }
+
+      public virtual string DefaultSpecies
+      {
+         get => _defaultSpecies;
+         set => SetProperty(ref _defaultSpecies, value);
+      }
+
+      public virtual string DefaultPopulation
+      {
+         get => _defaultPopulation;
+         set => SetProperty(ref _defaultPopulation, value);
+      }
+
+      public virtual ParameterGroupingModeId DefaultParameterGroupingMode
+      {
+         get => _defaultParameterGroupingMode;
+         set => SetProperty(ref _defaultParameterGroupingMode, value);
+      }
+
+      public virtual ParameterGroupingModeIdForParameterAnalyzable DefaultParameterGroupingModeForPIAndSA
+      {
+         get => _defaultParameterGroupingModeForPIAndSA;
+         set => SetProperty(ref _defaultParameterGroupingModeForPIAndSA, value);
+      }
+
+      public virtual double AbsTol
+      {
+         get => _absTol;
+         set => SetProperty(ref _absTol, value);
+      }
+
+      public virtual double RelTol
+      {
+         get => _relTol;
+         set => SetProperty(ref _relTol, value);
+      }
+
+      public virtual int NumberOfBins
+      {
+         get => _numberOfBins;
+         set => SetProperty(ref _numberOfBins, value);
+      }
+
+      public virtual int NumberOfIndividualsPerBin
+      {
+         get => _numberOfIndividualsPerBin;
+         set => SetProperty(ref _numberOfIndividualsPerBin, value);
+      }
+
+      public virtual int MaximumNumberOfCoresToUse
+      {
+         get => _maximumNumberOfCoresToUse;
+         set => SetProperty(ref _maximumNumberOfCoresToUse, value);
+      }
+
+      public virtual uint MRUListItemCount
+      {
+         get => _mruListItemCount;
+         set => SetProperty(ref _mruListItemCount, value);
+      }
+
+      public virtual string TemplateDatabasePath
+      {
+         get => _templateDatabasePath;
+         set => SetProperty(ref _templateDatabasePath, value);
+      }
+
+      public virtual Color ChangedColor
+      {
+         get => _changedColor;
+         set => SetProperty(ref _changedColor, value);
+      }
+
+      public virtual Color FormulaColor
+      {
+         get => _formulaColor;
+         set => SetProperty(ref _formulaColor, value);
+      }
+
+      public virtual Color ChartDiagramBackColor
+      {
+         get => _chartDiagramBackColor;
+         set => SetProperty(ref _chartDiagramBackColor, value);
+      }
+
+      public virtual Color ChartBackColor
+      {
+         get => _chartBackColor;
+         set => SetProperty(ref _chartBackColor, value);
+      }
+
+      public virtual string DefaultFractionUnboundName
+      {
+         get => _defaultFractionUnboundName;
+         set => SetProperty(ref _defaultFractionUnboundName, value);
+      }
+
+      public virtual string DefaultLipophilicityName
+      {
+         get => _defaultLipophilicityName;
+         set => SetProperty(ref _defaultLipophilicityName, value);
+      }
+
+      public virtual string DefaultSolubilityName
+      {
+         get => _defaultSolubilityName;
+         set => SetProperty(ref _defaultSolubilityName, value);
+      }
+
+      public virtual LoadTemplateWithReference LoadTemplateWithReference
+      {
+         get => _loadTemplateWithReference;
+         set => SetProperty(ref _loadTemplateWithReference, value);
+      }
+
+      public virtual PopulationAnalysisType DefaultPopulationAnalysis
+      {
+         get => _defaultPopulationAnalysis;
+         set => SetProperty(ref _defaultPopulationAnalysis, value);
+      }
+
+      public virtual Scalings DefaultChartYScaling
+      {
+         get => _defaultChartYScaling;
+         set => SetProperty(ref _defaultChartYScaling, value);
+      }
+
+      public virtual ViewLayout PreferredViewLayout
+      {
+         get => _preferredViewLayout;
+         set => SetProperty(ref _preferredViewLayout, value);
+      }
+
+      private static class AllRules
+      {
+         private static IBusinessRule nonEmpty(Expression<Func<UserSettingsDTO, string>> expression) => GenericRules.NonEmptyRule(expression);
+
+         private static IBusinessRule numberOfCoreSmallerThanNumberOfProcessor { get; } = CreateRule.For<UserSettingsDTO>()
+            .Property(x => x.MaximumNumberOfCoresToUse)
+            .WithRule((x, numCore) => numCore > 0 && numCore <= Environment.ProcessorCount)
+            .WithError(Error.NumberOfCoreToUseShouldBeInferiorAsTheNumberOfProcessor(Environment.ProcessorCount));
+
+         private static IBusinessRule decimalPlaceInRange { get; } = CreateRule.For<UserSettingsDTO>()
+            .Property(x => x.DecimalPlace)
+            .WithRule((x, decimalPlace) => decimalPlace <= 15)
+            .WithError(PKSimConstants.Rules.DecimalPlaceMustBeBetween0And15);
+
+         public static IEnumerable<IBusinessRule> All()
+         {
+            return new[]
+            {
+               nonEmpty(x => x.DefaultFractionUnboundName),
+               nonEmpty(x => x.DefaultSolubilityName),
+               nonEmpty(x => x.DefaultLipophilicityName),
+               numberOfCoreSmallerThanNumberOfProcessor,
+               decimalPlaceInRange
+            };
+         }
+      }
+   }
+}

--- a/src/PKSim.Presentation/Presenters/UserSettingsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/UserSettingsPresenter.cs
@@ -1,17 +1,19 @@
 using System.Collections.Generic;
 using System.Linq;
-using PKSim.Assets;
-using PKSim.Core;
-using PKSim.Core.Model;
-using PKSim.Core.Repositories;
-using PKSim.Presentation.Services;
-using PKSim.Presentation.Views;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Services;
-using OSPSuite.Assets;
 using OSPSuite.Utility;
+using PKSim.Assets;
+using PKSim.Core;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Presentation.DTO;
+using PKSim.Presentation.DTO.Mappers;
+using PKSim.Presentation.Services;
+using PKSim.Presentation.Views;
 
 namespace PKSim.Presentation.Presenters
 {
@@ -65,7 +67,6 @@ namespace PKSim.Presentation.Presenters
 
       IReadOnlyList<ViewLayout> AllViewLayouts();
       IReadOnlyList<Scalings> AllScalings();
-      
    }
 
    public class UserSettingsPresenter : AbstractSubPresenter<IUserSettingsView, IUserSettingsPresenter>, IUserSettingsPresenter
@@ -76,10 +77,13 @@ namespace PKSim.Presentation.Presenters
       private readonly IDialogCreator _dialogCreator;
       private readonly IPKSimConfiguration _configuration;
       private readonly ISpeciesRepository _speciesRepository;
+      private readonly IUserSettingsToUserSettingsDTOMapper _mapper;
+      private UserSettingsDTO _userSettingsDTO;
 
       public UserSettingsPresenter(IUserSettingsView view, IUserSettings userSettings,
          ISkinManager skinManager, IUserSettingsPersistor userSettingsPersistor,
-         IDialogCreator dialogCreator, IPKSimConfiguration configuration, ISpeciesRepository speciesRepository) : base(view)
+         IDialogCreator dialogCreator, IPKSimConfiguration configuration, ISpeciesRepository speciesRepository,
+         IUserSettingsToUserSettingsDTOMapper mapper) : base(view)
       {
          _userSettings = userSettings;
          _skinManager = skinManager;
@@ -87,11 +91,13 @@ namespace PKSim.Presentation.Presenters
          _dialogCreator = dialogCreator;
          _configuration = configuration;
          _speciesRepository = speciesRepository;
+         _mapper = mapper;
       }
 
       public void EditSettings()
       {
-         _view.BindTo(_userSettings);
+         _userSettingsDTO = _mapper.MapFrom(_userSettings);
+         _view.BindTo(_userSettingsDTO);
       }
 
       public IEnumerable<string> AvailableSkins => _skinManager.All();
@@ -102,9 +108,9 @@ namespace PKSim.Presentation.Presenters
       {
          var dataBaseFile = _dialogCreator.AskForFileToOpen(PKSimConstants.UI.SelectTemplateDatabasePath, CoreConstants.Filter.TEMPLATE_DATABASE_FILE_FILTER, CoreConstants.DirectoryKey.DATABASE);
          if (string.IsNullOrEmpty(dataBaseFile)) return;
-         if (string.Equals(_userSettings.TemplateDatabasePath, dataBaseFile))
+         if (string.Equals(_userSettingsDTO.TemplateDatabasePath, dataBaseFile))
             return;
-         _userSettings.TemplateDatabasePath = dataBaseFile;
+         _userSettingsDTO.TemplateDatabasePath = dataBaseFile;
       }
 
       public void CreateTemplateDatabase()
@@ -112,7 +118,7 @@ namespace PKSim.Presentation.Presenters
          var dataBaseFile = _dialogCreator.AskForFileToSave(PKSimConstants.UI.CreateTemplateDatabasePath, CoreConstants.Filter.TEMPLATE_DATABASE_FILE_FILTER, CoreConstants.DirectoryKey.DATABASE);
          if (string.IsNullOrEmpty(dataBaseFile)) return;
          FileHelper.Copy(_configuration.TemplateUserDatabaseTemplatePath, dataBaseFile);
-         _userSettings.TemplateDatabasePath = dataBaseFile;
+         _userSettingsDTO.TemplateDatabasePath = dataBaseFile;
       }
 
       public IEnumerable<string> AllSpecies()
@@ -127,7 +133,7 @@ namespace PKSim.Presentation.Presenters
 
       public void SpeciesChanged()
       {
-         _userSettings.DefaultPopulation = defaultPopulationFor(_userSettings.DefaultSpecies);
+         _userSettingsDTO.DefaultPopulation = defaultPopulationFor(_userSettingsDTO.DefaultSpecies);
          _view.RefreshAllIndividualList();
       }
 
@@ -206,6 +212,7 @@ namespace PKSim.Presentation.Presenters
 
       public void SaveSettings()
       {
+         _mapper.UpdateUserSettingsFrom(_userSettingsDTO, _userSettings);
          _userSettingsPersistor.Save(_userSettings);
       }
    }

--- a/src/PKSim.Presentation/Views/IUserSettingsView.cs
+++ b/src/PKSim.Presentation/Views/IUserSettingsView.cs
@@ -1,11 +1,12 @@
-using PKSim.Presentation.Presenters;
 using OSPSuite.Presentation.Views;
+using PKSim.Presentation.DTO;
+using PKSim.Presentation.Presenters;
 
 namespace PKSim.Presentation.Views
 {
    public interface IUserSettingsView : IView<IUserSettingsPresenter>
    {
-      void BindTo(IUserSettings userSettings);
+      void BindTo(UserSettingsDTO userSettingsDTO);
       void RefreshAllIndividualList();
    }
 }

--- a/src/PKSim.UI/UserSettings.cs
+++ b/src/PKSim.UI/UserSettings.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq.Expressions;
 using DevExpress.XtraBars.Docking;
 using DevExpress.XtraBars.Ribbon;
 using OSPSuite.Assets;
@@ -17,7 +16,6 @@ using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Settings;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Format;
-using OSPSuite.Utility.Validation;
 using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Model;
@@ -82,9 +80,8 @@ namespace PKSim.UI
          DirectoryMapSettings = directoryMapSettings;
 
          DisplayUnits = new DisplayUnitsManager();
-         ComparerSettings = new ComparerSettings {CompareHiddenEntities = true};
+         ComparerSettings = new ComparerSettings { CompareHiddenEntities = true };
          ProjectFiles = new List<string>();
-         Rules.AddRange(AllRules.All());
          DiagramOptions = new DiagramOptions();
          TemplateDatabasePath = configuration.DefaultTemplateUserDatabasePath;
          JournalPageEditorSettings = new JournalPageEditorSettings();
@@ -277,27 +274,6 @@ namespace PKSim.UI
          {
             PKSimColors.ChartDiagramBack = value;
             OnPropertyChanged(() => ChartDiagramBackColor);
-         }
-      }
-
-      private static class AllRules
-      {
-         private static IBusinessRule nonEmpty(Expression<Func<ICoreUserSettings, string>> expression) => GenericRules.NonEmptyRule(expression);
-
-         private static IBusinessRule numberOfCoreSmallerThanNumberOfProcessor { get; } = CreateRule.For<ICoreUserSettings>()
-            .Property(x => x.MaximumNumberOfCoresToUse)
-            .WithRule((x, numCore) => numCore > 0 && numCore <= Environment.ProcessorCount)
-            .WithError(Error.NumberOfCoreToUseShouldBeInferiorAsTheNumberOfProcessor(Environment.ProcessorCount));
-
-         public static IEnumerable<IBusinessRule> All()
-         {
-            return new[]
-            {
-               nonEmpty(x => x.DefaultFractionUnboundName),
-               nonEmpty(x => x.DefaultSolubilityName),
-               nonEmpty(x => x.DefaultLipophilicityName),
-               numberOfCoreSmallerThanNumberOfProcessor
-            };
          }
       }
    }

--- a/src/PKSim.UI/Views/UserSettingsView.cs
+++ b/src/PKSim.UI/Views/UserSettingsView.cs
@@ -14,7 +14,7 @@ using OSPSuite.UI.Services;
 using OSPSuite.Utility;
 using PKSim.Assets;
 using PKSim.Core.Model;
-using PKSim.Presentation;
+using PKSim.Presentation.DTO;
 using PKSim.Presentation.Presenters;
 using PKSim.Presentation.Views;
 
@@ -25,7 +25,7 @@ namespace PKSim.UI.Views
       private readonly IImageListRetriever _imageListRetriever;
       private readonly IToolTipCreator _toolTipCreator;
       private IUserSettingsPresenter _presenter;
-      private ScreenBinder<IUserSettings> _screenBinder;
+      private ScreenBinder<UserSettingsDTO> _screenBinder;
 
       public UserSettingsView(IImageListRetriever imageListRetriever, IToolTipCreator toolTipCreator)
       {
@@ -45,7 +45,7 @@ namespace PKSim.UI.Views
 
       public override void InitializeBinding()
       {
-         _screenBinder = new ScreenBinder<IUserSettings>();
+         _screenBinder = new ScreenBinder<UserSettingsDTO>();
 
          _screenBinder.Bind(x => x.AllowsScientificNotation)
             .To(chkAllowsScientificNotation)
@@ -156,7 +156,7 @@ namespace PKSim.UI.Views
 
       private void templateDatabaseButtonClick(object sender, ButtonPressedEventArgs e)
       {
-         var editor = (ButtonEdit) sender;
+         var editor = (ButtonEdit)sender;
          var buttonIndex = editor.Properties.Buttons.IndexOf(e.Button);
          if (buttonIndex == 0)
             _presenter.SelectTemplateDatabase();
@@ -164,9 +164,9 @@ namespace PKSim.UI.Views
             _presenter.CreateTemplateDatabase();
       }
 
-      public void BindTo(IUserSettings userSettings)
+      public void BindTo(UserSettingsDTO userSettingsDTO)
       {
-         _screenBinder.BindToSource(userSettings);
+         _screenBinder.BindToSource(userSettingsDTO);
       }
 
       public void RefreshAllIndividualList()

--- a/tests/PKSim.Tests/Presentation/UserSettingsDTOSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/UserSettingsDTOSpecs.cs
@@ -1,0 +1,131 @@
+using System;
+using NUnit.Framework;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Utility.Validation;
+using PKSim.Presentation.DTO;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_UserSettingsDTO : ContextSpecification<UserSettingsDTO>
+   {
+      protected override void Context()
+      {
+         sut = new UserSettingsDTO
+         {
+            DefaultFractionUnboundName = "default",
+            DefaultSolubilityName = "default",
+            DefaultLipophilicityName = "default",
+            MaximumNumberOfCoresToUse = 1,
+         };
+      }
+   }
+
+   public class When_validating_decimal_places : concern_for_UserSettingsDTO
+   {
+      [TestCase(0u)]
+      [TestCase(5u)]
+      [TestCase(15u)]
+      public void should_be_valid_for_values_between_0_and_15(uint decimalPlace)
+      {
+         sut.DecimalPlace = decimalPlace;
+         sut.IsValid().ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_be_invalid_for_value_greater_than_15()
+      {
+         sut.DecimalPlace = 16;
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+
+   public class When_validating_maximum_number_of_cores_to_use : concern_for_UserSettingsDTO
+   {
+      [Observation]
+      public void should_be_valid_for_one_core()
+      {
+         sut.MaximumNumberOfCoresToUse = 1;
+         sut.IsValid().ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_be_valid_for_processor_count()
+      {
+         sut.MaximumNumberOfCoresToUse = Environment.ProcessorCount;
+         sut.IsValid().ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_be_invalid_for_zero()
+      {
+         sut.MaximumNumberOfCoresToUse = 0;
+         sut.IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_invalid_for_negative_value()
+      {
+         sut.MaximumNumberOfCoresToUse = -1;
+         sut.IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_invalid_when_exceeding_processor_count()
+      {
+         sut.MaximumNumberOfCoresToUse = Environment.ProcessorCount + 1;
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+
+   public class When_validating_default_fraction_unbound_name : concern_for_UserSettingsDTO
+   {
+      [Observation]
+      public void should_be_invalid_when_empty()
+      {
+         sut.DefaultFractionUnboundName = string.Empty;
+         sut.IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_valid_when_set()
+      {
+         sut.DefaultFractionUnboundName = "some value";
+         sut.IsValid().ShouldBeTrue();
+      }
+   }
+
+   public class When_validating_default_solubility_name : concern_for_UserSettingsDTO
+   {
+      [Observation]
+      public void should_be_invalid_when_empty()
+      {
+         sut.DefaultSolubilityName = string.Empty;
+         sut.IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_valid_when_set()
+      {
+         sut.DefaultSolubilityName = "some value";
+         sut.IsValid().ShouldBeTrue();
+      }
+   }
+
+   public class When_validating_default_lipophilicity_name : concern_for_UserSettingsDTO
+   {
+      [Observation]
+      public void should_be_invalid_when_empty()
+      {
+         sut.DefaultLipophilicityName = string.Empty;
+         sut.IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_valid_when_set()
+      {
+         sut.DefaultLipophilicityName = "some value";
+         sut.IsValid().ShouldBeTrue();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/UserSettingsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/UserSettingsPresenterSpecs.cs
@@ -120,15 +120,32 @@ namespace PKSim.Presentation
 
    public class When_saving_settings : concern_for_UserSettingsPresenter
    {
+      private UserSettingsDTO _capturedDTO;
+
       protected override void Context()
       {
          base.Context();
+         A.CallTo(() => _view.BindTo(A<UserSettingsDTO>.Ignored))
+            .Invokes(call => _capturedDTO = call.GetArgument<UserSettingsDTO>(0));
+
          sut.EditSettings();
+
+         _capturedDTO.DecimalPlace = 7;
+         _capturedDTO.ActiveSkin = "NewSkin";
+         _capturedDTO.AbsTol = 1e-10;
       }
 
       protected override void Because()
       {
          sut.SaveSettings();
+      }
+
+      [Observation]
+      public void should_update_user_settings_from_the_dto_before_persisting()
+      {
+         _userSettings.DecimalPlace.ShouldBeEqualTo((uint)7);
+         _userSettings.ActiveSkin.ShouldBeEqualTo("NewSkin");
+         _userSettings.AbsTol.ShouldBeEqualTo(1e-10);
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Presentation/UserSettingsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/UserSettingsPresenterSpecs.cs
@@ -1,21 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FakeItEasy;
+using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Services;
 using OSPSuite.Utility;
+using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Repositories;
+using PKSim.Presentation.DTO;
+using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.Presenters;
 using PKSim.Presentation.Services;
 using PKSim.Presentation.Views;
-using FakeItEasy;
-using PKSim.Assets;
-using OSPSuite.Core.Services;
-using OSPSuite.Presentation.Services;
-using OSPSuite.Assets;
-
-
 
 namespace PKSim.Presentation
 {
@@ -27,7 +27,8 @@ namespace PKSim.Presentation
       protected ISkinManager _skinManager;
       protected IDialogCreator _dialogCreator;
       protected IPKSimConfiguration _configuration;
-      protected ISpeciesRepository _speciesRepostiory;
+      protected ISpeciesRepository _speciesRepository;
+      protected IUserSettingsToUserSettingsDTOMapper _mapper;
 
       protected override void Context()
       {
@@ -37,12 +38,12 @@ namespace PKSim.Presentation
          _dialogCreator = A.Fake<IDialogCreator>();
          _configuration = A.Fake<IPKSimConfiguration>();
          _userSettings = A.Fake<IUserSettings>();
-         _speciesRepostiory =A.Fake<ISpeciesRepository>();
-         sut = new UserSettingsPresenter(_view, _userSettings, _skinManager, _userSettingsPersistor, _dialogCreator,  _configuration,_speciesRepostiory);
+         _speciesRepository = A.Fake<ISpeciesRepository>();
+         _mapper = new UserSettingsToUserSettingsDTOMapper();
+         sut = new UserSettingsPresenter(_view, _userSettings, _skinManager, _userSettingsPersistor, _dialogCreator, _configuration, _speciesRepository, _mapper);
       }
    }
 
-   
    public class When_resolving_the_list_of_all_available_skins : concern_for_UserSettingsPresenter
    {
       private IEnumerable<string> _result;
@@ -50,7 +51,7 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _skinManager.All()).Returns(new[] {"skin1", "skin2"});
+         A.CallTo(() => _skinManager.All()).Returns(new[] { "skin1", "skin2" });
       }
 
       protected override void Because()
@@ -65,16 +66,15 @@ namespace PKSim.Presentation
       }
    }
 
-   
    public class When_resolving_the_list_of_all_available_icon_sizes : concern_for_UserSettingsPresenter
    {
       private IEnumerable<IconSize> _result;
-      private IEnumerable<IconSize> _availbleIconSizes;
+      private IEnumerable<IconSize> _availableIconSizes;
 
       protected override void Context()
       {
          base.Context();
-         _availbleIconSizes = IconSizes.All();
+         _availableIconSizes = IconSizes.All();
       }
 
       protected override void Because()
@@ -85,24 +85,72 @@ namespace PKSim.Presentation
       [Observation]
       public void should_return_the_icon_sizes_define_in_the_application()
       {
-         _result.Count().ShouldBeEqualTo(_availbleIconSizes.Count());
+         _result.Count().ShouldBeEqualTo(_availableIconSizes.Count());
       }
    }
 
-   
+   public class When_editing_settings : concern_for_UserSettingsPresenter
+   {
+      private UserSettingsDTO _capturedDTO;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _userSettings.DecimalPlace).Returns((uint)3);
+         A.CallTo(() => _userSettings.ActiveSkin).Returns("TestSkin");
+         A.CallTo(() => _userSettings.DefaultSpecies).Returns("Human");
+         A.CallTo(() => _view.BindTo(A<UserSettingsDTO>.Ignored))
+            .Invokes(call => _capturedDTO = call.GetArgument<UserSettingsDTO>(0));
+      }
+
+      protected override void Because()
+      {
+         sut.EditSettings();
+      }
+
+      [Observation]
+      public void should_bind_the_view_to_a_dto_with_values_from_user_settings()
+      {
+         _capturedDTO.ShouldNotBeNull();
+         _capturedDTO.DecimalPlace.ShouldBeEqualTo((uint)3);
+         _capturedDTO.ActiveSkin.ShouldBeEqualTo("TestSkin");
+         _capturedDTO.DefaultSpecies.ShouldBeEqualTo("Human");
+      }
+   }
+
+   public class When_saving_settings : concern_for_UserSettingsPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.EditSettings();
+      }
+
+      protected override void Because()
+      {
+         sut.SaveSettings();
+      }
+
+      [Observation]
+      public void should_persist_the_user_settings()
+      {
+         A.CallTo(() => _userSettingsPersistor.Save(_userSettings)).MustHaveHappened();
+      }
+   }
+
    public class When_creating_a_new_template_database : concern_for_UserSettingsPresenter
    {
       private string _newFileToCreate;
       private string _defaultTemplateUserDatabase;
       private Action<string, string> _oldCopyAction;
       private bool _copyCalled;
+      private UserSettingsDTO _capturedDTO;
 
       public override void GlobalContext()
       {
          base.GlobalContext();
          _oldCopyAction = FileHelper.Copy;
-         FileHelper.Copy = (s1, s2) =>
-                              { _copyCalled = (s1 == _defaultTemplateUserDatabase && s2 == _newFileToCreate); };
+         FileHelper.Copy = (s1, s2) => { _copyCalled = (s1 == _defaultTemplateUserDatabase && s2 == _newFileToCreate); };
       }
 
       protected override void Context()
@@ -112,6 +160,10 @@ namespace PKSim.Presentation
          _defaultTemplateUserDatabase = "tata";
          A.CallTo(() => _dialogCreator.AskForFileToSave(PKSimConstants.UI.CreateTemplateDatabasePath, CoreConstants.Filter.TEMPLATE_DATABASE_FILE_FILTER, CoreConstants.DirectoryKey.DATABASE, null, null)).Returns(_newFileToCreate);
          A.CallTo(() => _configuration.TemplateUserDatabaseTemplatePath).Returns(_defaultTemplateUserDatabase);
+         A.CallTo(() => _view.BindTo(A<UserSettingsDTO>.Ignored))
+            .Invokes(call => _capturedDTO = call.GetArgument<UserSettingsDTO>(0));
+
+         sut.EditSettings();
       }
 
       protected override void Because()
@@ -126,15 +178,15 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void the_user_settins_presenter_should_save_a_copy_of_the_template_database_into_the_selected_path_()
+      public void the_user_settings_presenter_should_save_a_copy_of_the_template_database_into_the_selected_path()
       {
          _copyCalled.ShouldBeTrue();
       }
 
       [Observation]
-      public void the_user_settins_presenter_should_save_the_information_in_the_user_settings()
+      public void the_user_settings_presenter_should_update_the_dto_template_database_path()
       {
-         _userSettings.TemplateDatabasePath.ShouldBeEqualTo(_newFileToCreate);
+         _capturedDTO.TemplateDatabasePath.ShouldBeEqualTo(_newFileToCreate);
       }
 
       public override void GlobalCleanup()
@@ -144,8 +196,6 @@ namespace PKSim.Presentation
       }
    }
 
-
-   
    public class When_asked_to_reset_the_layout : concern_for_UserSettingsPresenter
    {
       protected override void Because()
@@ -160,7 +210,6 @@ namespace PKSim.Presentation
       }
    }
 
-   
    public class When_asked_to_reset_the_settings_and_the_user_cancel_the_action : concern_for_UserSettingsPresenter
    {
       protected override void Context()
@@ -168,6 +217,7 @@ namespace PKSim.Presentation
          base.Context();
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, ViewResult.Yes)).Returns(ViewResult.No);
       }
+
       protected override void Because()
       {
          sut.ResetLayout();
@@ -177,25 +227,22 @@ namespace PKSim.Presentation
       public void should_not_reset_the_settings()
       {
          A.CallTo(() => _userSettings.ResetLayout()).MustNotHaveHappened();
-
       }
    }
 
-
-   
    public class When_asked_to_reset_the_settings_and_the_user_cancel_accepts_the_action : concern_for_UserSettingsPresenter
    {
       protected override void Context()
       {
          base.Context();
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, ViewResult.Yes)).Returns(ViewResult.Yes);
-
       }
+
       protected override void Because()
       {
          sut.ResetLayout();
       }
-      
+
       [Observation]
       public void should_not_reset_the_settings()
       {


### PR DESCRIPTION
## Summary
- Adds `UserSettingsDTO` so that edits in the User Settings dialog are buffered and only applied when the user clicks OK. Cancel now correctly discards changes.
- Extracts mapping logic into `UserSettingsToUserSettingsDTOMapper` following existing mapper conventions.
- Moves validation rules from `UserSettings` to the DTO layer, and adds a new rule limiting decimal places to 0–15.

Fixes #1296

## Test plan
- [x] Open User Settings, change a setting (e.g. skin, color), click Cancel — verify the change is not applied
- [x] Open User Settings, change a setting, click OK — verify the change is applied and persisted
- [x] Verify validation: decimal places > 15 prevents OK, empty default names prevent OK, core count out of range prevents OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings UI now uses an intermediate settings DTO for editing, improving edit/save flow and validation feedback.
* **Bug Fixes**
  * Added validation enforcing decimal places between 0 and 15 and ensuring maximum cores is within allowed range.
* **Tests**
  * Added automated tests covering settings validation and presenter save/edit behavior.
* **Chores**
  * Refactored user settings infrastructure and validation wiring for clearer configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->