### PR TITLE
Fixes #3505 Commit Overwrite Parameter Set does not add to the compound in the project

### DIFF
--- a/src/PKSim.Core/Commands/AddOverwriteParameterSetToCompoundCommand.cs
+++ b/src/PKSim.Core/Commands/AddOverwriteParameterSetToCompoundCommand.cs
@@ -1,6 +1,4 @@
-using System.Linq;
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Core.Domain;
 using PKSim.Assets;
 using PKSim.Core.Model;
 

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -31,16 +31,21 @@ namespace PKSim.Core.Services
       public IReadOnlyList<string> ParameterPaths { get; init; }
 
       /// <summary>
-      ///    If set, update this existing OverwriteParameterSet instead of creating a new one.
+      ///    If set, update this existing OverwriteParameterSet in the simulation compound instead of creating a new one.
       /// </summary>
-      public OverwriteParameterSet ExistingOverwriteParameterSet { get; init; }
+      public OverwriteParameterSet ExistingSimulationOverwriteParameterSet { get; init; }
 
       /// <summary>
-      ///    Name for the new OverwriteParameterSet. Only used when <see cref="ExistingOverwriteParameterSet" /> is null.
+      ///    The corresponding OverwriteParameterSet in the template compound to update.
+      /// </summary>
+      public OverwriteParameterSet ExistingTemplateOverwriteParameterSet { get; init; }
+
+      /// <summary>
+      ///    Name for the new OverwriteParameterSet. Only used when <see cref="ExistingSimulationOverwriteParameterSet" /> is null.
       /// </summary>
       public string NewOverwriteParameterSetName { get; init; }
 
-      public bool ShouldCreateNew => ExistingOverwriteParameterSet == null;
+      public bool ShouldCreateNew => ExistingSimulationOverwriteParameterSet == null;
    }
 
    public interface ICommitSimulationParametersTask
@@ -112,8 +117,8 @@ namespace PKSim.Core.Services
          var command = new PKSimMacroCommand();
          var pathsToRemove = pathsResetByUser(commitInfo, simulation);
 
-         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingOverwriteParameterSet, commitInfo.SimulationCompound, parameterValues, pathsToRemove));
-         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingOverwriteParameterSet, commitInfo.TemplateCompound, parameterValues, pathsToRemove));
+         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingSimulationOverwriteParameterSet, commitInfo.SimulationCompound, parameterValues, pathsToRemove));
+         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingTemplateOverwriteParameterSet, commitInfo.TemplateCompound, parameterValues, pathsToRemove));
 
          return command;
       }
@@ -145,7 +150,7 @@ namespace PKSim.Core.Services
       {
          var committedPaths = new HashSet<string>(info.ParameterPaths);
 
-         return info.ExistingOverwriteParameterSet.ParameterValues
+         return info.ExistingSimulationOverwriteParameterSet.ParameterValues
             .Select(pv => pv.Path.PathAsString)
             .Where(path => !committedPaths.Contains(path) && !simulation.ParameterChangeTracker.IsTracked(path))
             .ToList();

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -5,7 +5,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
-using PKSim.Assets;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 
@@ -17,9 +16,14 @@ namespace PKSim.Core.Services
    public class CompoundCommitInfo
    {
       /// <summary>
-      ///    The template compound to commit to.
+      ///    The simulation compound to commit to.
       /// </summary>
-      public Compound Compound { get; init; }
+      public Compound SimulationCompound { get; init; }
+
+      /// <summary>
+      ///    The project compound to commit to
+      /// </summary>
+      public Compound TemplateCompound { get; init; }
 
       /// <summary>
       ///    Parameter paths to commit.
@@ -64,12 +68,7 @@ namespace PKSim.Core.Services
          var parameterCache = _containerTask.CacheAllChildren<IParameter>(simulation.Model.Root);
          var parameterValues = createParameterValuesFor(commitInfo, parameterCache);
 
-         var command = commitInfo.ShouldCreateNew
-            ? createNewSetCommand(commitInfo, parameterValues)
-            : updateExistingSetCommand(commitInfo, parameterValues, simulation);
-
-         command.Run(_executionContext);
-         _executionContext.UpdateBuildingBlockPropertiesInCommand(command, commitInfo.Compound);
+         var command = createAndRunCommitCommands(commitInfo, parameterValues, simulation);
 
          //Only untrack paths that were actually resolved to parameter values
          parameterValues.Each(pv => simulation.ParameterChangeTracker.Untrack(pv.Path.PathAsString));
@@ -77,17 +76,46 @@ namespace PKSim.Core.Services
          return command;
       }
 
-      private IPKSimReversibleCommand createNewSetCommand(CompoundCommitInfo info, List<ParameterValue> parameterValues)
+      private PKSimMacroCommand createAndRunCommitCommands(CompoundCommitInfo commitInfo, List<ParameterValue> parameterValues, Simulation simulation)
       {
-         var newSet = new OverwriteParameterSet { Name = info.NewOverwriteParameterSetName };
-         parameterValues.Each(pv => newSet.Add(pv));
-         return new AddOverwriteParameterSetToCompoundCommand(newSet, info.Compound);
+         var command = commitInfo.ShouldCreateNew
+            ? createNewSetCommand(commitInfo, parameterValues)
+            : updateExistingSetCommand(commitInfo, parameterValues, simulation);
+
+         command.Run(_executionContext);
+
+         command.All().Each(subCommand => _executionContext.UpdateBuildingBlockPropertiesInCommand(subCommand, commitInfo.SimulationCompound));
+         _executionContext.UpdateBuildingBlockPropertiesInCommand(command, commitInfo.SimulationCompound);
+
+         return command;
       }
 
-      private IPKSimReversibleCommand updateExistingSetCommand(CompoundCommitInfo info, List<ParameterValue> parameterValues, Simulation simulation)
+      private PKSimMacroCommand createNewSetCommand(CompoundCommitInfo commitInfo, List<ParameterValue> parameterValues)
       {
-         var pathsToRemove = pathsResetByUser(info, simulation);
-         return new UpdateOverwriteParameterSetCommand(info.ExistingOverwriteParameterSet, info.Compound, parameterValues, pathsToRemove);
+         var command = new PKSimMacroCommand();
+
+         command.Add(addOverwriteParameterSetCommand(commitInfo.SimulationCompound, commitInfo.NewOverwriteParameterSetName, parameterValues));
+         command.Add(addOverwriteParameterSetCommand(commitInfo.TemplateCompound, commitInfo.NewOverwriteParameterSetName, parameterValues));
+
+         return command;
+      }
+
+      private ICommand addOverwriteParameterSetCommand(Compound compound, string setName, List<ParameterValue> parameterValues)
+      {
+         var newSet = new OverwriteParameterSet { Name = setName };
+         parameterValues.Each(newSet.Add);
+         return new AddOverwriteParameterSetToCompoundCommand(newSet, compound);
+      }
+
+      private PKSimMacroCommand updateExistingSetCommand(CompoundCommitInfo commitInfo, List<ParameterValue> parameterValues, Simulation simulation)
+      {
+         var command = new PKSimMacroCommand();
+         var pathsToRemove = pathsResetByUser(commitInfo, simulation);
+
+         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingOverwriteParameterSet, commitInfo.SimulationCompound, parameterValues, pathsToRemove));
+         command.Add(new UpdateOverwriteParameterSetCommand(commitInfo.ExistingOverwriteParameterSet, commitInfo.TemplateCompound, parameterValues, pathsToRemove));
+
+         return command;
       }
 
       private List<ParameterValue> createParameterValuesFor(CompoundCommitInfo info, PathCache<IParameter> parameterCache)

--- a/src/PKSim.Presentation/DTO/Mappers/SimulationToCompoundCommitDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/SimulationToCompoundCommitDTOMapper.cs
@@ -50,7 +50,7 @@ namespace PKSim.Presentation.DTO.Mappers
          return new CompoundCommitDTO
          {
             CompoundName = compound.Name,
-            TemplateCompound = templateCompound,
+            Compound = templateCompound,
             AvailableExistingSets = templateCompound.OverwriteParameterSets,
             CreateNew = !hasExistingSelection,
             SelectedExistingSet = hasExistingSelection ? existingSelection : null,

--- a/src/PKSim.Presentation/DTO/Simulations/CompoundCommitDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/CompoundCommitDTO.cs
@@ -10,7 +10,7 @@ namespace PKSim.Presentation.DTO.Simulations
    public class CompoundCommitDTO : DxValidatableDTO
    {
       public string CompoundName { get; init; }
-      public Compound TemplateCompound { get; init; }
+      public Compound Compound { get; init; }
       public IReadOnlyList<OverwriteParameterSet> AvailableExistingSets { get; init; }
       public List<ParameterCommitDTO> Parameters { get; init; } = new();
       public bool CreateNew { get; set; } = true;

--- a/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using OSPSuite.Presentation.Presenters;
 using PKSim.Assets;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.DTO.Simulations;
@@ -13,8 +14,8 @@ namespace PKSim.Presentation.Presenters.Simulations
    {
       /// <summary>
       ///    Shows a modal dialog allowing the user to select which tracked parameter changes
-      ///    should be committed to the compound overwrite parameter set for <paramref name="compound"/>.
-      ///    Returns a <see cref="CompoundCommitInfo"/> with the user's selections,
+      ///    should be committed to the compound overwrite parameter set for <paramref name="compound" />.
+      ///    Returns a <see cref="CompoundCommitInfo" /> with the user's selections,
       ///    or <c>null</c> if the user cancels or no parameters have uncommitted changes.
       /// </summary>
       CompoundCommitInfo ShowCommitDialog(Simulation simulation, Compound compound);
@@ -23,12 +24,15 @@ namespace PKSim.Presentation.Presenters.Simulations
    public class CommitSimulationParametersPresenter : AbstractDisposablePresenter<ICommitSimulationParametersView, ICommitSimulationParametersPresenter>, ICommitSimulationParametersPresenter
    {
       private readonly ISimulationToCompoundCommitDTOMapper _mapper;
+      private readonly IBuildingBlockRepository _buildingBlockRepository;
 
       public CommitSimulationParametersPresenter(
          ICommitSimulationParametersView view,
-         ISimulationToCompoundCommitDTOMapper mapper) : base(view)
+         ISimulationToCompoundCommitDTOMapper mapper,
+         IBuildingBlockRepository buildingBlockRepository) : base(view)
       {
          _mapper = mapper;
+         _buildingBlockRepository = buildingBlockRepository;
       }
 
       public CompoundCommitInfo ShowCommitDialog(Simulation simulation, Compound compound)
@@ -45,14 +49,18 @@ namespace PKSim.Presentation.Presenters.Simulations
          if (_view.Canceled)
             return null;
 
-         return commitInfoFrom(dto);
+         return commitInfoFrom(dto, simulation, compound);
       }
 
-      private CompoundCommitInfo commitInfoFrom(CompoundCommitDTO dto)
+      private CompoundCommitInfo commitInfoFrom(CompoundCommitDTO dto, Simulation simulation, Compound compound)
       {
+         var templateId = simulation.TemplateBuildingBlockIdUsedBy(compound);
+         var projectCompound = _buildingBlockRepository.ById<Compound>(templateId);
+
          return new CompoundCommitInfo
          {
-            Compound = dto.TemplateCompound,
+            SimulationCompound = dto.TemplateCompound,
+            TemplateCompound = projectCompound,
             ParameterPaths = dto.Parameters.Where(p => p.Selected).Select(p => p.Path).ToList(),
             ExistingOverwriteParameterSet = dto.CreateNew ? null : dto.SelectedExistingSet,
             NewOverwriteParameterSetName = dto.CreateNew ? dto.NewSetName : null

--- a/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
@@ -59,7 +59,7 @@ namespace PKSim.Presentation.Presenters.Simulations
 
          return new CompoundCommitInfo
          {
-            SimulationCompound = dto.TemplateCompound,
+            SimulationCompound = dto.Compound,
             TemplateCompound = projectCompound,
             ParameterPaths = dto.Parameters.Where(p => p.Selected).Select(p => p.Path).ToList(),
             ExistingOverwriteParameterSet = dto.CreateNew ? null : dto.SelectedExistingSet,

--- a/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/CommitSimulationParametersPresenter.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Presenters;
 using PKSim.Assets;
 using PKSim.Core.Model;
@@ -62,9 +63,13 @@ namespace PKSim.Presentation.Presenters.Simulations
             SimulationCompound = dto.Compound,
             TemplateCompound = projectCompound,
             ParameterPaths = dto.Parameters.Where(p => p.Selected).Select(p => p.Path).ToList(),
-            ExistingOverwriteParameterSet = dto.CreateNew ? null : dto.SelectedExistingSet,
+            ExistingSimulationOverwriteParameterSet = dto.CreateNew ? null : dto.SelectedExistingSet,
+            ExistingTemplateOverwriteParameterSet = dto.CreateNew ? null : existingOverwriteParameterSet(dto, projectCompound),
             NewOverwriteParameterSetName = dto.CreateNew ? dto.NewSetName : null
          };
       }
+
+      private static OverwriteParameterSet existingOverwriteParameterSet(CompoundCommitDTO dto, Compound projectCompound) => 
+         projectCompound.OverwriteParameterSets.FindByName(dto.SelectedExistingSet?.Name);
    }
 }

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -17,6 +17,7 @@ namespace PKSim.Core
       protected IExecutionContext _executionContext;
       protected IContainerTask _containerTask;
       protected IndividualSimulation _simulation;
+      protected Compound _simulationCompound;
       protected Compound _templateCompound;
       protected IParameter _lipophilicityParam;
       protected IParameter _permeabilityParam;
@@ -27,6 +28,7 @@ namespace PKSim.Core
          _executionContext = A.Fake<IExecutionContext>();
          _containerTask = A.Fake<IContainerTask>();
 
+         _simulationCompound = new Compound { Name = "Aspirin", Id = "SimCompId" };
          _templateCompound = new Compound { Name = "Aspirin", Id = "TemplateCompId" };
 
          _lipophilicityParam = DomainHelperForSpecs.ConstantParameterWithValue(3.5).WithName("Lipophilicity");
@@ -47,7 +49,7 @@ namespace PKSim.Core
          _parameterCache.Add("Organism|Aspirin|Permeability", _permeabilityParam);
 
          A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(_parameterCache);
-         A.CallTo(() => _executionContext.TypeFor(_templateCompound)).Returns("Compound");
+         A.CallTo(() => _executionContext.TypeFor(_simulationCompound)).Returns("Compound");
 
          sut = new CommitSimulationParametersTask(_executionContext, _containerTask);
       }
@@ -68,7 +70,8 @@ namespace PKSim.Core
       {
          _result = sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
          {
-            Compound = _templateCompound,
+            SimulationCompound = _simulationCompound,
+            TemplateCompound = _templateCompound,
             ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity", "Organism|Aspirin|Permeability" },
             NewOverwriteParameterSetName = "MyNewSet"
          });
@@ -81,7 +84,14 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_add_the_overwrite_parameter_set_to_the_compound()
+      public void should_add_the_overwrite_parameter_set_to_the_simulation_compound()
+      {
+         _simulationCompound.OverwriteParameterSets.Count.ShouldBeEqualTo(1);
+         _simulationCompound.OverwriteParameterSets[0].Name.ShouldBeEqualTo("MyNewSet");
+      }
+
+      [Observation]
+      public void should_add_the_overwrite_parameter_set_to_the_template_compound()
       {
          _templateCompound.OverwriteParameterSets.Count.ShouldBeEqualTo(1);
          _templateCompound.OverwriteParameterSets[0].Name.ShouldBeEqualTo("MyNewSet");
@@ -90,7 +100,7 @@ namespace PKSim.Core
       [Observation]
       public void should_set_building_block_properties_on_the_command()
       {
-         A.CallTo(() => _executionContext.UpdateBuildingBlockPropertiesInCommand(A<IOSPSuiteCommand>._, _templateCompound)).MustHaveHappened();
+         A.CallTo(() => _executionContext.UpdateBuildingBlockPropertiesInCommand(A<IOSPSuiteCommand>._, _simulationCompound)).MustHaveHappened();
       }
    }
 
@@ -104,7 +114,7 @@ namespace PKSim.Core
          base.Context();
          _existingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId" };
          _existingSet.Add(new ParameterValue { Path = "Organism|Aspirin|OldParam".ToObjectPath(), Value = 1.0 });
-         _templateCompound.AddOverwriteParameterSet(_existingSet);
+         _simulationCompound.AddOverwriteParameterSet(_existingSet);
 
          _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
       }
@@ -113,7 +123,8 @@ namespace PKSim.Core
       {
          _result = sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
          {
-            Compound = _templateCompound,
+            SimulationCompound = _simulationCompound,
+            TemplateCompound = _templateCompound,
             ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity" },
             ExistingOverwriteParameterSet = _existingSet
          });
@@ -146,7 +157,8 @@ namespace PKSim.Core
       {
          _result = sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
          {
-            Compound = _templateCompound,
+            SimulationCompound = _simulationCompound,
+            TemplateCompound = _templateCompound,
             ParameterPaths = new[] { "Organism|Aspirin|NonExistent" },
             NewOverwriteParameterSetName = "Set"
          });

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -107,14 +107,19 @@ namespace PKSim.Core
    public class When_committing_parameters_to_an_existing_overwrite_parameter_set : concern_for_CommitSimulationParametersTask
    {
       private ICommand _result;
-      private OverwriteParameterSet _existingSet;
+      private OverwriteParameterSet _simulationExistingSet;
+      private OverwriteParameterSet _templateExistingSet;
 
       protected override void Context()
       {
          base.Context();
-         _existingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId" };
-         _existingSet.Add(new ParameterValue { Path = "Organism|Aspirin|OldParam".ToObjectPath(), Value = 1.0 });
-         _simulationCompound.AddOverwriteParameterSet(_existingSet);
+         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
+         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|OldParam".ToObjectPath(), Value = 1.0 });
+         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
+
+         _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
+         _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|OldParam".ToObjectPath(), Value = 1.0 });
+         _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
 
          _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
       }
@@ -126,7 +131,8 @@ namespace PKSim.Core
             SimulationCompound = _simulationCompound,
             TemplateCompound = _templateCompound,
             ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity" },
-            ExistingOverwriteParameterSet = _existingSet
+            ExistingSimulationOverwriteParameterSet = _simulationExistingSet,
+            ExistingTemplateOverwriteParameterSet = _templateExistingSet
          });
       }
 
@@ -137,9 +143,15 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_update_the_existing_set_with_new_parameter_value()
+      public void should_update_the_simulation_existing_set_with_new_parameter_value()
       {
-         _existingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
+         _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_update_the_template_existing_set_with_new_parameter_value()
+      {
+         _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
       }
    }
 

--- a/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
@@ -187,11 +187,14 @@ namespace PKSim.Presentation
    {
       private CompoundCommitInfo _result;
       private OverwriteParameterSet _existingSet;
+      private OverwriteParameterSet _templateExistingSet;
 
       protected override void Context()
       {
          base.Context();
          _existingSet = new OverwriteParameterSet { Name = "Existing" };
+         _templateExistingSet = new OverwriteParameterSet { Name = "Existing" };
+         _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
 
          var dto = new CompoundCommitDTO
          {
@@ -217,8 +220,14 @@ namespace PKSim.Presentation
       [Observation]
       public void should_reference_existing_set()
       {
-         _result.ExistingOverwriteParameterSet.ShouldBeEqualTo(_existingSet);
+         _result.ExistingSimulationOverwriteParameterSet.ShouldBeEqualTo(_existingSet);
          _result.NewOverwriteParameterSetName.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_resolve_existing_template_overwrite_parameter_set()
+      {
+         _result.ExistingTemplateOverwriteParameterSet.ShouldBeEqualTo(_templateExistingSet);
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
@@ -2,7 +2,9 @@ using System.Collections.Generic;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.DTO.Simulations;
@@ -15,20 +17,27 @@ namespace PKSim.Presentation
    {
       protected ICommitSimulationParametersView _view;
       protected ISimulationToCompoundCommitDTOMapper _mapper;
+      protected IBuildingBlockRepository _buildingBlockRepository;
       protected IndividualSimulation _simulation;
-      protected Compound _templateCompound;
+      protected Compound _simulationCompound;
       protected Compound _compound;
+      protected Compound _templateCompound;
 
       protected override void Context()
       {
          _view = A.Fake<ICommitSimulationParametersView>();
          _mapper = A.Fake<ISimulationToCompoundCommitDTOMapper>();
+         _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
 
-         _templateCompound = new Compound { Name = "Aspirin", Id = "TemplateId" };
+         _simulationCompound = new Compound { Name = "Aspirin", Id = "TemplateId" };
          _compound = new Compound { Name = "Aspirin", Id = "CompoundId" };
+         _templateCompound = new Compound { Name = "Aspirin", Id = "ProjectCompoundId" };
          _simulation = new IndividualSimulation { Id = "SimId" };
 
-         sut = new CommitSimulationParametersPresenter(_view, _mapper);
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("ProjectCompoundId", PKSimBuildingBlockType.Compound) { BuildingBlock = _compound });
+         A.CallTo(() => _buildingBlockRepository.ById<Compound>("ProjectCompoundId")).Returns(_templateCompound);
+
+         sut = new CommitSimulationParametersPresenter(_view, _mapper, _buildingBlockRepository);
       }
    }
 
@@ -42,7 +51,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _templateCompound,
+            TemplateCompound = _simulationCompound,
             CreateNew = true,
             NewSetName = "MySet",
             Parameters = new List<ParameterCommitDTO>
@@ -64,8 +73,14 @@ namespace PKSim.Presentation
       public void should_return_commit_info()
       {
          _result.ShouldNotBeNull();
-         _result.Compound.ShouldBeEqualTo(_templateCompound);
+         _result.SimulationCompound.ShouldBeEqualTo(_simulationCompound);
          _result.ParameterPaths.ShouldContain("Organism|Aspirin|Lipophilicity");
+      }
+
+      [Observation]
+      public void should_resolve_template_compound()
+      {
+         _result.TemplateCompound.ShouldBeEqualTo(_templateCompound);
       }
 
       [Observation]
@@ -85,7 +100,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _templateCompound,
+            TemplateCompound = _simulationCompound,
             Parameters = new List<ParameterCommitDTO>
             {
                new() { Path = "Organism|Aspirin|Lipophilicity", Value = 3.5 }
@@ -141,7 +156,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _templateCompound,
+            TemplateCompound = _simulationCompound,
             CreateNew = true,
             NewSetName = "Set",
             Parameters = new List<ParameterCommitDTO>
@@ -181,7 +196,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _templateCompound,
+            TemplateCompound = _simulationCompound,
             CreateNew = false,
             SelectedExistingSet = _existingSet,
             Parameters = new List<ParameterCommitDTO>

--- a/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/CommitSimulationParametersPresenterSpecs.cs
@@ -51,7 +51,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _simulationCompound,
+            Compound = _simulationCompound,
             CreateNew = true,
             NewSetName = "MySet",
             Parameters = new List<ParameterCommitDTO>
@@ -100,7 +100,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _simulationCompound,
+            Compound = _simulationCompound,
             Parameters = new List<ParameterCommitDTO>
             {
                new() { Path = "Organism|Aspirin|Lipophilicity", Value = 3.5 }
@@ -156,7 +156,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _simulationCompound,
+            Compound = _simulationCompound,
             CreateNew = true,
             NewSetName = "Set",
             Parameters = new List<ParameterCommitDTO>
@@ -196,7 +196,7 @@ namespace PKSim.Presentation
          var dto = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = _simulationCompound,
+            Compound = _simulationCompound,
             CreateNew = false,
             SelectedExistingSet = _existingSet,
             Parameters = new List<ParameterCommitDTO>

--- a/tests/PKSim.Tests/Presentation/CompoundCommitDTOSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/CompoundCommitDTOSpecs.cs
@@ -14,7 +14,7 @@ namespace PKSim.Presentation
          sut = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = new Compound { Name = "Aspirin" },
+            Compound = new Compound { Name = "Aspirin" },
             AvailableExistingSets = new List<OverwriteParameterSet>
             {
                new() { Name = "ExistingSet1" },
@@ -128,7 +128,7 @@ namespace PKSim.Presentation
          sut = new CompoundCommitDTO
          {
             CompoundName = "Aspirin",
-            TemplateCompound = new Compound { Name = "Aspirin" },
+            Compound = new Compound { Name = "Aspirin" },
             AvailableExistingSets = new List<OverwriteParameterSet>(),
             CreateNew = true,
             NewSetName = "AnyName",

--- a/tests/PKSim.Tests/Presentation/SimulationToCompoundCommitDTOMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationToCompoundCommitDTOMapperSpecs.cs
@@ -92,7 +92,7 @@ namespace PKSim.Presentation
       [Observation]
       public void should_resolve_the_template_compound()
       {
-         _result.TemplateCompound.ShouldBeEqualTo(_templateCompound);
+         _result.Compound.ShouldBeEqualTo(_templateCompound);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #3505 Commit Overwrite Parameter Set does not add to the compound in the project

# Description
We just want a duplicate command that adds to the project compound at the same time as the simulation compound is updated.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused directives and adjusted file formatting.

* **Refactor**
  * Refactored parameter commit logic to distinctly handle simulation and template compounds, improving consistency in how parameter overwrite sets are applied across both compound types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->