### PR TITLE
Fixes #3512 createExpressionProfileBB should accept phenotype argument

### DIFF
--- a/src/PKSim.R/Exchange/BuildingBlockCreator.cs
+++ b/src/PKSim.R/Exchange/BuildingBlockCreator.cs
@@ -34,25 +34,25 @@ public static class BuildingBlockCreator
       return serializer.Serialize(mapper.MapFrom(buildingBlock));
    }
 
-   public static string CreateExpressionProfile(string category, string moleculeName, string speciesName)
+   public static string CreateExpressionProfile(string category, string moleculeName, string speciesName, string phenotype)
    {
       Api.InitializeOnce();
       var (serializer, mapper) = Api.ResolveTasks<IPKMLPersistor, IExpressionProfileToExpressionProfileBuildingBlockMapper>();
       ExpressionProfile buildingBlock;
 
       if (string.Equals(category, TransportProtein))
-         buildingBlock = createExpressionProfile<IndividualTransporter>(category, moleculeName, speciesName);
+         buildingBlock = createExpressionProfile<IndividualTransporter>(moleculeName, speciesName, phenotype);
       else if (string.Equals(category, ProteinBindingPartner))
-         buildingBlock = createExpressionProfile<IndividualOtherProtein>(category, moleculeName, speciesName);
+         buildingBlock = createExpressionProfile<IndividualOtherProtein>(moleculeName, speciesName, phenotype);
       else if (string.Equals(category, MetabolizingEnzyme))
-         buildingBlock = createExpressionProfile<IndividualEnzyme>(category, moleculeName, speciesName);
+         buildingBlock = createExpressionProfile<IndividualEnzyme>(moleculeName, speciesName, phenotype);
       else
          throw new ArgumentException(PKSimConstants.Error.InvalidProteinCategory(category));
 
       return serializer.Serialize(mapper.MapFrom(buildingBlock));
    }
 
-   private static ExpressionProfile createExpressionProfile<T>(string category, string moleculeName, string speciesName) where T : IndividualMolecule
+   private static ExpressionProfile createExpressionProfile<T>(string moleculeName, string speciesName, string phenotype) where T : IndividualMolecule
    {
       var (expressionProfileFactory, moleculeParameterTask, speciesRepository) = Api.ResolveTasks<IExpressionProfileFactory, IMoleculeParameterTask, ISpeciesRepository>();
 
@@ -61,7 +61,7 @@ public static class BuildingBlockCreator
          throw new ArgumentException(PKSimConstants.Error.CouldNotFindValidSpecies(speciesName));
 
       var expressionProfile = expressionProfileFactory.Create<T>(species, moleculeName);
-      expressionProfile.Category = category;
+      expressionProfile.Category = phenotype;
 
       moleculeParameterTask.SetDefaultFor(expressionProfile);
 

--- a/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.R.Tests/BuildingBlockCreatorSpecs.cs
@@ -59,7 +59,7 @@ internal class CreateExchangeMetabolizingEnzyme : ContextForStaticIntegration
 
    protected override void Because()
    {
-      _result = BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", CoreConstants.Species.HUMAN);
+      _result = BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", CoreConstants.Species.HUMAN, "Healthy");
    }
 
    [Observation]
@@ -79,7 +79,7 @@ internal class CreateExchangeExpressionProfileWithInvalidSpecies : ContextForSta
       {
          try
          {
-            BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", "InvalidSpecies");
+            BuildingBlockCreator.CreateExpressionProfile(MetabolizingEnzyme, "CYP3A4", "InvalidSpecies", "Healthy");
          }
          catch (Exception e)
          {
@@ -97,7 +97,7 @@ internal class CreateExchangeTransportProtein : ContextForStaticIntegration
 
    protected override void Because()
    {
-      _result = BuildingBlockCreator.CreateExpressionProfile(TransportProtein, "CYP3A4", CoreConstants.Species.HUMAN);
+      _result = BuildingBlockCreator.CreateExpressionProfile(TransportProtein, "CYP3A4", CoreConstants.Species.HUMAN, "Healthy");
    }
 
    [Observation]
@@ -112,7 +112,7 @@ internal class CreateExchangeTransportProtein : ContextForStaticIntegration
 
       protected override void Because()
       {
-         _result = BuildingBlockCreator.CreateExpressionProfile(ProteinBindingPartner, "CYP3A4", CoreConstants.Species.HUMAN);
+         _result = BuildingBlockCreator.CreateExpressionProfile(ProteinBindingPartner, "CYP3A4", CoreConstants.Species.HUMAN, "Healthy");
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #3512 createExpressionProfileBB should accept phenotype argument

# Description
We were using category to indicate the category of of the protein and the phenotype. Now they are separate parameters

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):