### PR TITLE
Edit/delete parameter values within OverwriteParameterSet

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -264,6 +264,18 @@ namespace PKSim.Assets
             return RemoveEntityFromContainer(ObjectTypes.ParameterGroupAlternative, alternativeName, ObjectTypes.ParameterGroup, groupName);
          }
 
+         public static string UpdateOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
+            $"Update {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
+         public static string UpdateParameterValueInOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
+            $"Update value of '{parameterPath}' in {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
+         public static string RemoveParameterValueFromOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
+            $"Remove '{parameterPath}' from {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
+         public static string AddParameterValueToOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
+            $"Add '{parameterPath}' to {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
          public static string AddEntityToContainer(string entityType, string entityName, string containerType, string containerName)
          {
             var lowerEntityType = string.IsNullOrEmpty(entityType) ? entityType : entityType.ToLower();

--- a/src/PKSim.Core/Commands/AddOverwriteParameterSetToCompoundCommand.cs
+++ b/src/PKSim.Core/Commands/AddOverwriteParameterSetToCompoundCommand.cs
@@ -1,5 +1,6 @@
 using OSPSuite.Core.Commands.Core;
 using PKSim.Assets;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core.Commands
@@ -23,6 +24,7 @@ namespace PKSim.Core.Commands
          base.PerformExecuteWith(context);
          _buildingBlock.AddOverwriteParameterSet(_overwriteParameterSet);
          context.Register(_overwriteParameterSet);
+         context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
       }
 
       protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)

--- a/src/PKSim.Core/Commands/BuildingBlockStructureChangeCommand.cs
+++ b/src/PKSim.Core/Commands/BuildingBlockStructureChangeCommand.cs
@@ -1,3 +1,5 @@
+using PKSim.Core.Model;
+
 namespace PKSim.Core.Commands
 {
    public interface IBuildingBlockStructureChangeCommand : IBuildingBlockChangeCommand
@@ -6,6 +8,14 @@ namespace PKSim.Core.Commands
 
    public abstract class BuildingBlockStructureChangeCommand : BuildingBlockChangeCommand, IBuildingBlockStructureChangeCommand
    {
+   }
+
+   public abstract class BuildingBlockStructureChangeCommand<T> : BuildingBlockChangeCommand<T>, IBuildingBlockStructureChangeCommand
+      where T : class, IPKSimBuildingBlock
+   {
+      protected BuildingBlockStructureChangeCommand(T buildingBlock) : base(buildingBlock)
+      {
+      }
    }
 
    public abstract class BuildingBlockIrreversibleStructureChangeCommand : PKSimCommand, IBuildingBlockStructureChangeCommand

--- a/src/PKSim.Core/Commands/RemoveOverwriteParameterSetFromCompoundCommand.cs
+++ b/src/PKSim.Core/Commands/RemoveOverwriteParameterSetFromCompoundCommand.cs
@@ -1,7 +1,6 @@
-using System.Linq;
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Core.Domain;
 using PKSim.Assets;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core.Commands
@@ -24,6 +23,7 @@ namespace PKSim.Core.Commands
       {
          base.PerformExecuteWith(context);
          _buildingBlock.RemoveOverwriteParameterSet(_overwriteParameterSet);
+         context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
       }
 
       protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)

--- a/src/PKSim.Core/Commands/RemoveParameterValueFromOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/RemoveParameterValueFromOverwriteSetCommand.cs
@@ -6,7 +6,7 @@ using PKSim.Core.Model;
 
 namespace PKSim.Core.Commands;
 
-public class RemoveParameterValueFromOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+public class RemoveParameterValueFromOverwriteSetCommand : BuildingBlockStructureChangeCommand<Compound>
 {
    private readonly string _overwriteParameterSetId;
    private OverwriteParameterSet _overwriteParameterSet;
@@ -54,7 +54,7 @@ public class RemoveParameterValueFromOverwriteSetCommand : BuildingBlockChangeCo
    ///    Not public: new parameter values are only added to an <see cref="OverwriteParameterSet" />
    ///    via commit from a simulation, never directly from the compound tab.
    /// </summary>
-   private class AddParameterValueToOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+   private class AddParameterValueToOverwriteSetCommand : BuildingBlockStructureChangeCommand<Compound>
    {
       private readonly string _overwriteParameterSetId;
       private OverwriteParameterSet _overwriteParameterSet;

--- a/src/PKSim.Core/Commands/RemoveParameterValueFromOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/RemoveParameterValueFromOverwriteSetCommand.cs
@@ -1,0 +1,95 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class RemoveParameterValueFromOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private readonly string _parameterPath;
+   private ParameterValue _removedParameterValue;
+
+   public RemoveParameterValueFromOverwriteSetCommand(
+      OverwriteParameterSet overwriteParameterSet,
+      Compound compound,
+      string parameterPath)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      _parameterPath = parameterPath;
+      CommandType = PKSimConstants.Command.CommandTypeDelete;
+      Description = PKSimConstants.Command.RemoveParameterValueFromOverwriteParameterSet(parameterPath, overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+      _removedParameterValue = _overwriteParameterSet.ParameterValueByPath(_parameterPath);
+      _overwriteParameterSet.RemoveByPath(_parameterPath);
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+      new AddParameterValueToOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _removedParameterValue).AsInverseFor(this);
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+
+   /// <summary>
+   ///    Internal inverse of <see cref="RemoveParameterValueFromOverwriteSetCommand" />.
+   ///    Not public: new parameter values are only added to an <see cref="OverwriteParameterSet" />
+   ///    via commit from a simulation, never directly from the compound tab.
+   /// </summary>
+   private class AddParameterValueToOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+   {
+      private readonly string _overwriteParameterSetId;
+      private OverwriteParameterSet _overwriteParameterSet;
+      private readonly ParameterValue _parameterValue;
+
+      public AddParameterValueToOverwriteSetCommand(OverwriteParameterSet overwriteParameterSet, Compound compound, ParameterValue parameterValue)
+         : base(compound)
+      {
+         _overwriteParameterSet = overwriteParameterSet;
+         _overwriteParameterSetId = overwriteParameterSet.Id;
+         _parameterValue = parameterValue;
+         CommandType = PKSimConstants.Command.CommandTypeAdd;
+         Description = PKSimConstants.Command.AddParameterValueToOverwriteParameterSet(parameterValue.Path.PathAsString, overwriteParameterSet.Name, compound.Name);
+      }
+
+      protected override void PerformExecuteWith(IExecutionContext context)
+      {
+         base.PerformExecuteWith(context);
+         _overwriteParameterSet.Add(_parameterValue);
+         context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+      }
+
+      protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+         new RemoveParameterValueFromOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _parameterValue.Path.PathAsString).AsInverseFor(this);
+
+      protected override void ClearReferences()
+      {
+         base.ClearReferences();
+         _overwriteParameterSet = null;
+      }
+
+      public override void RestoreExecutionData(IExecutionContext context)
+      {
+         base.RestoreExecutionData(context);
+         _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+      }
+   }
+}

--- a/src/PKSim.Core/Commands/UpdateOverwriteParameterSetCommand.cs
+++ b/src/PKSim.Core/Commands/UpdateOverwriteParameterSetCommand.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core.Commands
 {
    /// <summary>
-   ///    Updates an existing <see cref="OverwriteParameterSet"/> by adding/replacing parameter values
+   ///    Updates an existing <see cref="OverwriteParameterSet" /> by adding/replacing parameter values
    ///    and removing paths that were reset by the user. Stores the previous state for undo.
    /// </summary>
    public class UpdateOverwriteParameterSetCommand : BuildingBlockChangeCommand<Compound>
@@ -33,7 +33,7 @@ namespace PKSim.Core.Commands
          _newParameterValues = newParameterValues.ToList();
          _pathsToRemove = pathsToRemove.ToList();
          CommandType = PKSimConstants.Command.CommandTypeEdit;
-         Description = $"Update {PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}' in {PKSimConstants.ObjectTypes.Compound} '{compound.Name}'";
+         Description = PKSimConstants.Command.UpdateOverwriteParameterSetInCompound(overwriteParameterSet.Name, compound.Name);
       }
 
       protected override void PerformExecuteWith(IExecutionContext context)
@@ -48,6 +48,8 @@ namespace PKSim.Core.Commands
 
          //Add or replace parameter values
          _newParameterValues.Each(pv => _overwriteParameterSet.Add(pv));
+
+         context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
       }
 
       protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)

--- a/src/PKSim.Core/Commands/UpdateParameterValueInOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/UpdateParameterValueInOverwriteSetCommand.cs
@@ -1,0 +1,56 @@
+using OSPSuite.Core.Commands.Core;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class UpdateParameterValueInOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private readonly string _parameterPath;
+   private readonly double _newValue;
+   private double? _oldValue;
+
+   public UpdateParameterValueInOverwriteSetCommand(
+      OverwriteParameterSet overwriteParameterSet,
+      Compound compound,
+      string parameterPath,
+      double newValue)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      _parameterPath = parameterPath;
+      _newValue = newValue;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+      Description = PKSimConstants.Command.UpdateParameterValueInOverwriteParameterSet(parameterPath, overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+      var parameterValue = _overwriteParameterSet.ParameterValueByPath(_parameterPath);
+      _oldValue = parameterValue.Value;
+      parameterValue.Value = _newValue;
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+   {
+      return new UpdateParameterValueInOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _parameterPath, _oldValue.GetValueOrDefault()).AsInverseFor(this);
+   }
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+}

--- a/src/PKSim.Core/Events/CompoundEvents.cs
+++ b/src/PKSim.Core/Events/CompoundEvents.cs
@@ -7,20 +7,20 @@ namespace PKSim.Core.Events
       Compound Compound { get; }
    }
 
-   public class AddCompoundParameterGroupAlternativeEvent : AddEntityEvent<PKSim.Core.Model.ParameterAlternative, PKSim.Core.Model.ParameterAlternativeGroup>
+   public class AddCompoundParameterGroupAlternativeEvent : AddEntityEvent<ParameterAlternative, ParameterAlternativeGroup>
    {
    }
 
-   public class RemoveCompoundParameterGroupAlternativeEvent : RemoveEntityEvent<PKSim.Core.Model.ParameterAlternative, PKSim.Core.Model.ParameterAlternativeGroup>
+   public class RemoveCompoundParameterGroupAlternativeEvent : RemoveEntityEvent<ParameterAlternative, ParameterAlternativeGroup>
    {
    }
 
-   public class RemoveCompoundProcessEvent : RemoveEntityEvent<PKSim.Core.Model.CompoundProcess, Compound>, ICompoundEvent
+   public class RemoveCompoundProcessEvent : RemoveEntityEvent<CompoundProcess, Compound>, ICompoundEvent
    {
       public Compound Compound => Container;
    }
 
-   public class AddCompoundProcessEvent : AddEntityEvent<PKSim.Core.Model.CompoundProcess, Compound>, ICompoundEvent
+   public class AddCompoundProcessEvent : AddEntityEvent<CompoundProcess, Compound>, ICompoundEvent
    {
       public Compound Compound => Container;
    }
@@ -32,6 +32,18 @@ namespace PKSim.Core.Events
       public MoleculeRenamedInCompound(Compound compound)
       {
          Compound = compound;
+      }
+   }
+
+   public class OverwriteParameterSetChangedEvent : ICompoundEvent
+   {
+      public Compound Compound { get; }
+      public OverwriteParameterSet OverwriteParameterSet { get; }
+
+      public OverwriteParameterSetChangedEvent(Compound compound, OverwriteParameterSet overwriteParameterSet)
+      {
+         Compound = compound;
+         OverwriteParameterSet = overwriteParameterSet;
       }
    }
 }

--- a/src/PKSim.Core/Model/Compound.cs
+++ b/src/PKSim.Core/Model/Compound.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
+using OSPSuite.Utility.Visitor;
 
 namespace PKSim.Core.Model
 {
@@ -135,6 +136,12 @@ namespace PKSim.Core.Model
          CalculationMethodCache.UpdatePropertiesFrom(sourceCompound.CalculationMethodCache, cloneManager);
          _overwriteParameterSets.Clear();
          sourceCompound.OverwriteParameterSets.Each(x => AddOverwriteParameterSet(cloneManager.Clone(x)));
+      }
+
+      public override void AcceptVisitor(IVisitor visitor)
+      {
+         base.AcceptVisitor(visitor);
+         OverwriteParameterSets.Each(x => x.AcceptVisitor(visitor));
       }
    }
 }

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -1,0 +1,48 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain.Services;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Services;
+
+public interface IOverwriteParameterSetTask
+{
+   /// <summary>
+   ///    Updates the value of a parameter (identified by path) in an <see cref="OverwriteParameterSet"/>.
+   ///    Returns an empty command if the parameter is not in the set or the value is unchanged.
+   /// </summary>
+   ICommand UpdateParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, double newValue);
+
+   /// <summary>
+   ///    Removes a parameter (identified by path) from an <see cref="OverwriteParameterSet"/>.
+   ///    Returns an empty command if the parameter is not in the set.
+   /// </summary>
+   ICommand RemoveParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath);
+}
+
+public class OverwriteParameterSetTask : IOverwriteParameterSetTask
+{
+   private readonly IExecutionContext _executionContext;
+
+   public OverwriteParameterSetTask(IExecutionContext executionContext)
+   {
+      _executionContext = executionContext;
+   }
+
+   public ICommand UpdateParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, double newValue)
+   {
+      var existing = overwriteParameterSet.ParameterValueByPath(parameterPath);
+      if (existing == null || ValueComparer.AreValuesEqual(existing.Value.GetValueOrDefault(), newValue))
+         return new PKSimEmptyCommand();
+
+      return new UpdateParameterValueInOverwriteSetCommand(overwriteParameterSet, compound, parameterPath, newValue).Run(_executionContext);
+   }
+
+   public ICommand RemoveParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath)
+   {
+      if (overwriteParameterSet.ParameterValueByPath(parameterPath) == null)
+         return new PKSimEmptyCommand();
+
+      return new RemoveParameterValueFromOverwriteSetCommand(overwriteParameterSet, compound, parameterPath).Run(_executionContext);
+   }
+}

--- a/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterSetDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterSetDTO.cs
@@ -7,28 +7,27 @@ namespace PKSim.Presentation.DTO.Compounds;
 
 public class OverwriteParameterSetDTO
 {
-   private readonly OverwriteParameterSet _overwriteParameterSet;
-
    public OverwriteParameterSetDTO(OverwriteParameterSet overwriteParameterSet)
    {
-      _overwriteParameterSet = overwriteParameterSet;
-      ParameterValues = _overwriteParameterSet.ParameterValues
+      OverwriteParameterSet = overwriteParameterSet;
+      ParameterValues = overwriteParameterSet.ParameterValues
          .Select(parameterValue => new OverwriteParameterValueDTO(parameterValue))
          .ToList();
    }
 
-   public string Name => _overwriteParameterSet.Name;
-   public bool IsDefault => _overwriteParameterSet.IsDefault;
+   public OverwriteParameterSet OverwriteParameterSet { get; }
+   public string Name => OverwriteParameterSet.Name;
+   public bool IsDefault => OverwriteParameterSet.IsDefault;
    public string Species => extendedPropertyValue(PKSimConstants.UI.Species);
    public string DiseaseState => extendedPropertyValue(PKSimConstants.UI.DiseaseState);
    public IReadOnlyList<OverwriteParameterValueDTO> ParameterValues { get; }
 
    private string extendedPropertyValue(string propertyName)
    {
-      if (!_overwriteParameterSet.ExtendedProperties.Contains(propertyName))
+      if (!OverwriteParameterSet.ExtendedProperties.Contains(propertyName))
          return string.Empty;
 
-      var property = _overwriteParameterSet.ExtendedProperties[propertyName];
+      var property = OverwriteParameterSet.ExtendedProperties[propertyName];
       return property.ValueAsObject?.ToString() ?? string.Empty;
    }
 }

--- a/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterValueDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterValueDTO.cs
@@ -4,15 +4,15 @@ namespace PKSim.Presentation.DTO.Compounds;
 
 public class OverwriteParameterValueDTO
 {
-   private readonly ParameterValue _parameterValue;
-
    public OverwriteParameterValueDTO(ParameterValue parameterValue)
    {
-      _parameterValue = parameterValue;
+      ParameterValue = parameterValue;
    }
 
-   public string Path => _parameterValue.Path.ToString();
-   public double? Value => _parameterValue.Value;
-   public string Unit => _parameterValue.DisplayUnit.Name;
-   public string ValueOrigin => _parameterValue.ValueOrigin.Display;
+   public ParameterValue ParameterValue { get; }
+
+   public string Path => ParameterValue.Path.ToString();
+   public double? Value => ParameterValue.Value;
+   public string Unit => ParameterValue.DisplayUnit.Name;
+   public string ValueOrigin => ParameterValue.ValueOrigin.Display;
 }

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -1,28 +1,56 @@
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.Views.Compounds;
 
 namespace PKSim.Presentation.Presenters.Compounds;
 
-public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter
+public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, IListener<OverwriteParameterSetChangedEvent>
 {
+   void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValue);
+   void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
 }
 
 public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwriteParameterSetsView, IOverwriteParameterSetsPresenter>, IOverwriteParameterSetsPresenter
 {
    private readonly IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
+   private readonly IOverwriteParameterSetTask _overwriteParameterSetTask;
+   private Compound _compound;
 
-   public OverwriteParameterSetsPresenter(IOverwriteParameterSetsView view, IOverwriteParameterSetToOverwriteParameterSetDTOMapper mapper)
+   public OverwriteParameterSetsPresenter(
+      IOverwriteParameterSetsView view,
+      IOverwriteParameterSetToOverwriteParameterSetDTOMapper mapper,
+      IOverwriteParameterSetTask overwriteParameterSetTask)
       : base(view)
    {
       _mapper = mapper;
+      _overwriteParameterSetTask = overwriteParameterSetTask;
    }
 
    public void EditCompound(Compound compound)
    {
-      View.BindTo(compound.OverwriteParameterSets
-         .MapAllUsing(_mapper));
+      _compound = compound;
+      rebindView();
    }
+
+   public void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValue) =>
+      AddCommand(_overwriteParameterSetTask.UpdateParameterValue(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString, newValue));
+
+   public void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO) =>
+      AddCommand(_overwriteParameterSetTask.RemoveParameterValue(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString));
+
+   public void Handle(OverwriteParameterSetChangedEvent eventToHandle)
+   {
+      if (!Equals(eventToHandle.Compound, _compound))
+         return;
+
+      rebindView();
+   }
+
+   private void rebindView() => View.BindTo(_compound.OverwriteParameterSets.MapAllUsing(_mapper));
 }

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
@@ -88,12 +88,8 @@ namespace PKSim.UI.Views.Compounds
          //
          // gridViewSets
          //
-         this.gridViewSets.AllowsFiltering = true;
-         this.gridViewSets.EnableColumnContextMenu = true;
          this.gridViewSets.GridControl = this.gridSets;
          this.gridViewSets.Name = "gridViewSets";
-         this.gridViewSets.OptionsBehavior.Editable = false;
-         this.gridViewSets.OptionsSelection.EnableAppearanceFocusedRow = true;
          //
          // gridParameterValues
          //
@@ -107,11 +103,8 @@ namespace PKSim.UI.Views.Compounds
          //
          // gridViewParameterValues
          //
-         this.gridViewParameterValues.AllowsFiltering = true;
-         this.gridViewParameterValues.EnableColumnContextMenu = true;
          this.gridViewParameterValues.GridControl = this.gridParameterValues;
          this.gridViewParameterValues.Name = "gridViewParameterValues";
-         this.gridViewParameterValues.OptionsBehavior.Editable = false;
          //
          // layoutControlGroup
          //

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using DevExpress.Utils;
+using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
 using OSPSuite.Assets;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
@@ -8,6 +11,7 @@ using PKSim.Assets;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.Presenters.Compounds;
 using PKSim.Presentation.Views.Compounds;
+using static OSPSuite.UI.UIConstants.Size;
 
 namespace PKSim.UI.Views.Compounds;
 
@@ -16,6 +20,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    private IOverwriteParameterSetsPresenter _presenter;
    private readonly GridViewBinder<OverwriteParameterSetDTO> _gridViewBinderSets;
    private readonly GridViewBinder<OverwriteParameterValueDTO> _gridViewBinderParameterValues;
+   private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRemoveButtonRepository();
 
    public OverwriteParameterSetsView()
    {
@@ -31,6 +36,10 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
          BindingMode = BindingMode.OneWay
       };
 
+      gridViewSets.OptionsSelection.EnableAppearanceFocusedCell = false;
+      gridViewParameterValues.OptionsSelection.EnableAppearanceFocusedCell = false;
+      gridViewParameterValues.EditorShowMode = EditorShowMode.MouseDown;
+
       gridViewSets.FocusedRowChanged += (o, e) => OnEvent(selectedSetChanged);
    }
 
@@ -42,28 +51,44 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    public override void InitializeBinding()
    {
       _gridViewBinderSets.Bind(x => x.Name)
-         .WithCaption(PKSimConstants.UI.Name);
+         .WithCaption(PKSimConstants.UI.Name)
+         .AsReadOnly();
 
       _gridViewBinderSets.Bind(x => x.IsDefault)
-         .WithCaption(PKSimConstants.UI.IsDefault);
+         .WithCaption(PKSimConstants.UI.IsDefault)
+         .AsReadOnly();
 
       _gridViewBinderSets.Bind(x => x.Species)
-         .WithCaption(PKSimConstants.UI.Species);
+         .WithCaption(PKSimConstants.UI.Species)
+         .AsReadOnly();
 
       _gridViewBinderSets.Bind(x => x.DiseaseState)
-         .WithCaption(PKSimConstants.UI.DiseaseState);
+         .WithCaption(PKSimConstants.UI.DiseaseState)
+         .AsReadOnly();
 
       _gridViewBinderParameterValues.Bind(x => x.Path)
-         .WithCaption(Captions.Diff.ObjectPath);
+         .WithCaption(Captions.Diff.ObjectPath)
+         .AsReadOnly();
 
       _gridViewBinderParameterValues.Bind(x => x.Value)
-         .WithCaption(Captions.Value);
+         .WithCaption(Captions.Value)
+         .WithOnValueUpdating((dto, e) => OnEvent(() => onParameterValueUpdating(dto, e.NewValue)));
 
       _gridViewBinderParameterValues.Bind(x => x.Unit)
-         .WithCaption(Captions.Unit);
+         .WithCaption(Captions.Unit)
+         .AsReadOnly();
 
       _gridViewBinderParameterValues.Bind(x => x.ValueOrigin)
-         .WithCaption(Captions.ValueOrigin);
+         .WithCaption(Captions.ValueOrigin)
+         .AsReadOnly();
+
+      _gridViewBinderParameterValues.AddUnboundColumn()
+         .WithCaption(Captions.EmptyColumn)
+         .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+         .WithShowButton(ShowButtonModeEnum.ShowAlways)
+         .WithRepository(_ => _removeButtonRepository);
+
+      _removeButtonRepository.ButtonClick += (_, _) => OnEvent(() => _presenter.RemoveParameterValue(_gridViewBinderSets.FocusedElement, _gridViewBinderParameterValues.FocusedElement));
    }
 
    public override void InitializeResources()
@@ -91,5 +116,18 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       }
 
       _gridViewBinderParameterValues.BindToSource(selectedSet.ParameterValues);
+   }
+
+   private void onParameterValueUpdating(OverwriteParameterValueDTO dto, double? newValue)
+   {
+      if (!newValue.HasValue)
+         return;
+
+      var selectedSet = _gridViewBinderSets.FocusedElement;
+      if (selectedSet == null)
+         return;
+
+      _presenter.UpdateParameterValue(selectedSet, dto, newValue.Value);
+      gridViewParameterValues.CloseEditor();
    }
 }

--- a/tests/PKSim.Tests/Core/AddOverwriteParameterSetToCompoundCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/AddOverwriteParameterSetToCompoundCommandSpecs.cs
@@ -3,6 +3,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using PKSim.Core.Commands;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core
@@ -38,6 +39,12 @@ namespace PKSim.Core
       public void should_add_the_set_to_the_compound()
       {
          _compound.OverwriteParameterSets.ShouldContain(_overwriteParameterSet);
+      }
+
+      [Observation]
+      public void should_publish_an_overwrite_parameter_set_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
       }
    }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -1,0 +1,126 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+
+namespace PKSim.Core;
+
+public abstract class concern_for_OverwriteParameterSetTask : ContextSpecification<OverwriteParameterSetTask>
+{
+   protected IExecutionContext _executionContext;
+   protected Compound _compound;
+   protected OverwriteParameterSet _overwriteParameterSet;
+   protected const string _path = "Organism|Aspirin|Lipophilicity";
+
+   protected override void Context()
+   {
+      _executionContext = A.Fake<IExecutionContext>();
+      _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+      _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
+      _overwriteParameterSet.Add(new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 });
+      _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+      A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
+
+      sut = new OverwriteParameterSetTask(_executionContext);
+   }
+}
+
+public class When_updating_a_parameter_value_through_the_task : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.UpdateParameterValue(_overwriteParameterSet, _compound, _path, 9.0);
+   }
+
+   [Observation]
+   public void should_update_the_value_in_the_set()
+   {
+      _overwriteParameterSet.ParameterValueByPath(_path).Value.ShouldBeEqualTo(9.0);
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_updating_a_parameter_value_with_the_same_value : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.UpdateParameterValue(_overwriteParameterSet, _compound, _path, 1.0);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_updating_a_parameter_value_for_a_path_not_in_the_set : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.UpdateParameterValue(_overwriteParameterSet, _compound, "Organism|Aspirin|Permeability", 9.0);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_removing_a_parameter_value_through_the_task : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.RemoveParameterValue(_overwriteParameterSet, _compound, _path);
+   }
+
+   [Observation]
+   public void should_remove_the_parameter_from_the_set()
+   {
+      _overwriteParameterSet.ParameterValueByPath(_path).ShouldBeNull();
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_removing_a_parameter_value_for_a_path_not_in_the_set : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.RemoveParameterValue(_overwriteParameterSet, _compound, "Organism|Aspirin|Permeability");
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}

--- a/tests/PKSim.Tests/Core/RemoveOverwriteParameterSetFromCompoundCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/RemoveOverwriteParameterSetFromCompoundCommandSpecs.cs
@@ -3,6 +3,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using PKSim.Core.Commands;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core
@@ -39,6 +40,12 @@ namespace PKSim.Core
       public void should_remove_the_set_from_the_compound()
       {
          _compound.OverwriteParameterSets.ShouldNotContain(_overwriteParameterSet);
+      }
+
+      [Observation]
+      public void should_publish_an_overwrite_parameter_set_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
       }
    }
 

--- a/tests/PKSim.Tests/Core/RemoveParameterValueFromOverwriteSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/RemoveParameterValueFromOverwriteSetCommandSpecs.cs
@@ -1,0 +1,83 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Commands;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core;
+
+public abstract class concern_for_RemoveParameterValueFromOverwriteSetCommand : ContextSpecification<RemoveParameterValueFromOverwriteSetCommand>
+{
+   protected Compound _compound;
+   protected OverwriteParameterSet _overwriteParameterSet;
+   protected IExecutionContext _executionContext;
+   protected ParameterValue _existingPV;
+   protected const string _path = "Organism|Aspirin|Lipophilicity";
+
+   protected override void Context()
+   {
+      _executionContext = A.Fake<IExecutionContext>();
+      _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+      _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
+
+      _existingPV = new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 };
+      _overwriteParameterSet.Add(_existingPV);
+      _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+      A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
+   }
+}
+
+public class When_executing_the_remove_parameter_value_from_overwrite_set_command : concern_for_RemoveParameterValueFromOverwriteSetCommand
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut = new RemoveParameterValueFromOverwriteSetCommand(_overwriteParameterSet, _compound, _path);
+   }
+
+   protected override void Because()
+   {
+      sut.Execute(_executionContext);
+   }
+
+   [Observation]
+   public void should_remove_the_parameter_from_the_set()
+   {
+      _overwriteParameterSet.ParameterValueByPath(_path).ShouldBeNull();
+      _overwriteParameterSet.ParameterValues.Count.ShouldBeEqualTo(0);
+   }
+
+   [Observation]
+   public void should_publish_an_overwrite_parameter_set_changed_event()
+   {
+      A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
+   }
+}
+
+public class When_undoing_a_remove_parameter_value_from_overwrite_set_command : concern_for_RemoveParameterValueFromOverwriteSetCommand
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut = new RemoveParameterValueFromOverwriteSetCommand(_overwriteParameterSet, _compound, _path);
+   }
+
+   protected override void Because()
+   {
+      sut.ExecuteAndInvokeInverse(_executionContext);
+   }
+
+   [Observation]
+   public void should_restore_the_parameter_with_its_original_value()
+   {
+      var restored = _overwriteParameterSet.ParameterValueByPath(_path);
+      restored.ShouldNotBeNull();
+      restored.Value.ShouldBeEqualTo(1.0);
+   }
+}

--- a/tests/PKSim.Tests/Core/UpdateOverwriteParameterSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/UpdateOverwriteParameterSetCommandSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using PKSim.Core.Commands;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
 
 namespace PKSim.Core
@@ -60,6 +61,12 @@ namespace PKSim.Core
       public void should_keep_existing_values()
       {
          _overwriteParameterSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_publish_an_overwrite_parameter_set_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
       }
    }
 

--- a/tests/PKSim.Tests/Core/UpdateParameterValueInOverwriteSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/UpdateParameterValueInOverwriteSetCommandSpecs.cs
@@ -1,0 +1,80 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Commands;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core;
+
+public abstract class concern_for_UpdateParameterValueInOverwriteSetCommand : ContextSpecification<UpdateParameterValueInOverwriteSetCommand>
+{
+   protected Compound _compound;
+   protected OverwriteParameterSet _overwriteParameterSet;
+   protected IExecutionContext _executionContext;
+   protected ParameterValue _existingPV;
+   protected const string _path = "Organism|Aspirin|Lipophilicity";
+
+   protected override void Context()
+   {
+      _executionContext = A.Fake<IExecutionContext>();
+      _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+      _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
+
+      _existingPV = new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 };
+      _overwriteParameterSet.Add(_existingPV);
+      _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+      A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
+   }
+}
+
+public class When_executing_the_update_parameter_value_in_overwrite_set_command : concern_for_UpdateParameterValueInOverwriteSetCommand
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut = new UpdateParameterValueInOverwriteSetCommand(_overwriteParameterSet, _compound, _path, 7.5);
+   }
+
+   protected override void Because()
+   {
+      sut.Execute(_executionContext);
+   }
+
+   [Observation]
+   public void should_update_the_parameter_value_to_the_new_value()
+   {
+      _overwriteParameterSet.ParameterValueByPath(_path).Value.ShouldBeEqualTo(7.5);
+   }
+
+   [Observation]
+   public void should_publish_an_overwrite_parameter_set_changed_event()
+   {
+      A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
+   }
+}
+
+public class When_undoing_an_update_parameter_value_in_overwrite_set_command : concern_for_UpdateParameterValueInOverwriteSetCommand
+{
+   protected override void Context()
+   {
+      base.Context();
+      sut = new UpdateParameterValueInOverwriteSetCommand(_overwriteParameterSet, _compound, _path, 7.5);
+   }
+
+   protected override void Because()
+   {
+      sut.ExecuteAndInvokeInverse(_executionContext);
+   }
+
+   [Observation]
+   public void should_restore_the_previous_parameter_value()
+   {
+      _overwriteParameterSet.ParameterValueByPath(_path).Value.ShouldBeEqualTo(1.0);
+   }
+}

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -2,7 +2,13 @@ using System.Collections.Generic;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.Presenters.Compounds;
@@ -14,12 +20,15 @@ namespace PKSim.Presentation
    {
       protected IOverwriteParameterSetsView _view;
       protected IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
+      protected IOverwriteParameterSetTask _task;
 
       protected override void Context()
       {
          _view = A.Fake<IOverwriteParameterSetsView>();
          _mapper = A.Fake<IOverwriteParameterSetToOverwriteParameterSetDTOMapper>();
-         sut = new OverwriteParameterSetsPresenter(_view, _mapper);
+         _task = A.Fake<IOverwriteParameterSetTask>();
+         sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task);
+         sut.InitializeWith(A.Fake<ICommandCollector>());
       }
    }
 
@@ -61,6 +70,107 @@ namespace PKSim.Presentation
          _boundDTOs.ShouldNotBeNull();
          _boundDTOs.Count.ShouldBeEqualTo(1);
          _boundDTOs[0].ShouldBeEqualTo(_dto);
+      }
+   }
+
+   public abstract class concern_for_OverwriteParameterSetsPresenter_editing : concern_for_OverwriteParameterSetsPresenter
+   {
+      protected Compound _compound;
+      protected OverwriteParameterSet _overwriteParameterSet;
+      protected ParameterValue _parameterValue;
+      protected OverwriteParameterSetDTO _setDTO;
+      protected OverwriteParameterValueDTO _valueDTO;
+      protected const string _path = "Organism|Aspirin|Lipophilicity";
+
+      protected override void Context()
+      {
+         base.Context();
+         _compound = new Compound { Name = "Aspirin" };
+         _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet" };
+         _parameterValue = new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 };
+         _overwriteParameterSet.Add(_parameterValue);
+         _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+         _setDTO = new OverwriteParameterSetDTO(_overwriteParameterSet);
+         _valueDTO = new OverwriteParameterValueDTO(_parameterValue);
+
+         sut.EditCompound(_compound);
+      }
+   }
+
+   public class When_updating_a_parameter_value_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _task.UpdateParameterValue(_overwriteParameterSet, _compound, _path, 5.5)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateParameterValue(_setDTO, _valueDTO, 5.5);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.UpdateParameterValue(_overwriteParameterSet, _compound, _path, 5.5)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_removing_a_parameter_value_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _task.RemoveParameterValue(_overwriteParameterSet, _compound, _path)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveParameterValue(_setDTO, _valueDTO);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.RemoveParameterValue(_overwriteParameterSet, _compound, _path)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_handling_an_overwrite_parameter_set_changed_event_for_the_edited_compound : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      protected override void Because()
+      {
+         Fake.ClearRecordedCalls(_view);
+         sut.Handle(new OverwriteParameterSetChangedEvent(_compound, _overwriteParameterSet));
+      }
+
+      [Observation]
+      public void should_rebind_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<OverwriteParameterSetDTO>>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_handling_an_overwrite_parameter_set_changed_event_for_another_compound : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      protected override void Because()
+      {
+         Fake.ClearRecordedCalls(_view);
+         sut.Handle(new OverwriteParameterSetChangedEvent(new Compound { Name = "OtherCompound" }, _overwriteParameterSet));
+      }
+
+      [Observation]
+      public void should_not_rebind_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<OverwriteParameterSetDTO>>._)).MustNotHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #3435

## Summary

Inline editing of `Value` in the parameter grid and row deletion via an unbound button column — both routed through the command layer so they are registered in history and fully reversible. Undo/redo from the history view also refreshes the view via a new domain event.

## Changes

**Commands** (`PKSim.Core.Commands`)
- `UpdateParameterValueInOverwriteSetCommand` — mutates `ParameterValue.Value` in place, stores the old value, inverse restores it.
- `RemoveParameterValueFromOverwriteSetCommand` — captures the `ParameterValue`, then removes by path; inverse is a private nested `AddParameterValueToOverwriteSetCommand` (public add is intentionally not exposed from the compound tab).
- `AddOverwriteParameterSetToCompoundCommand`, `RemoveOverwriteParameterSetFromCompoundCommand`, `UpdateOverwriteParameterSetCommand` now all publish `OverwriteParameterSetChangedEvent` at the end of `PerformExecuteWith`.

**Events** (`PKSim.Core.Events`)
- New `OverwriteParameterSetChangedEvent(Compound, OverwriteParameterSet)` implements `ICompoundEvent`.

**Task layer** (`PKSim.Core.Services`)
- New `IOverwriteParameterSetTask` / `OverwriteParameterSetTask` — wraps command execution, returns `PKSimEmptyCommand` when the value is unchanged or the path is not in the set.

**Presenter** (`PKSim.Presentation`)
- `OverwriteParameterSetsPresenter` now implements `IListener<OverwriteParameterSetChangedEvent>`; `Handle` filters on `Equals(e.Compound, _compound)` and rebinds. The previous `OnStatusChanged` override is removed — undo/redo from the history view now refreshes correctly.
- Exposes `UpdateParameterValue` / `RemoveParameterValue` methods that delegate to the task.

**DTOs** (`PKSim.Presentation.DTO.Compounds`)
- `OverwriteParameterSetDTO` and `OverwriteParameterValueDTO` now expose their underlying domain objects so the presenter can build commands from the DTO rows.

**View** (`PKSim.UI.Views.Compounds`)
- Value column is inline-editable via `WithOnValueUpdating`; all other columns (Path/Unit/ValueOrigin, plus Name/IsDefault/Species/DiseaseState on the set-list grid) are `.AsReadOnly()`.
- Unbound delete column using `UxRemoveButtonRepository` — single-click row deletion via the command layer.
- Row-level selection (`EnableAppearanceFocusedCell = false`); first row auto-selected after every bind so a row is always selected.
- Read-only cells render with a darker appearance via `AdjustAppearance` in the `RowCellStyle` handler.

**PKSimConstants.Command**
- Added description helpers: `UpdateOverwriteParameterSetInCompound`, `UpdateParameterValueInOverwriteParameterSet`, `RemoveParameterValueFromOverwriteParameterSet`, `AddParameterValueToOverwriteParameterSet`.

**Other**
- New files use file-scoped namespaces.
- Compound.cs: `AcceptVisitor` override walks the `OverwriteParameterSets` collection.

## Test plan

- [x] Unit specs pass (40 targeted tests green)
- [x] Full suite previously green (5236 passed / 6 skipped)
- [x] Manual: edit a parameter value inline in the Overwrite Parameter Sets tab, undo/redo works
- [x] Manual: delete a parameter row via the delete button, undo/redo works
- [x] Manual: commit from a simulation to an existing set — the tab rebinds
- [x] Manual: undo/redo from the history view refreshes the tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline editing support for parameter values in overwrite parameter sets
  * Added remove button to delete parameter values from overwrite parameter sets
  * Overwrite parameter set changes now trigger real-time UI updates

* **Tests**
  * Comprehensive test coverage for parameter value operations and event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->