### PR TITLE
Fixes #3520 Clone Individual and ExpressionProfile building blocks in SnapshotExchange

### DIFF
--- a/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
+++ b/src/PKSim.Assets.Images/PKSim.Assets.Images.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -49,8 +49,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -57,9 +57,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/PKSim.Core/Mappers/ExpressionProfileToExpressionProfileBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/ExpressionProfileToExpressionProfileBuildingBlockMapper.cs
@@ -31,8 +31,9 @@ namespace PKSim.Core.Mappers
          IFormulaFactory formulaFactory,
          IInitialConditionsCreator initialConditionsCreator,
          IMoleculeBuilderFactory moleculeBuilderFactory,
-         ICloner cloner) :
-         base(objectBaseFactory, entityPathResolver, applicationConfiguration, lazyLoadTask, formulaFactory, cloner)
+         ICloner cloner, 
+         IObjectIdResetter objectIdResetter) :
+         base(objectBaseFactory, entityPathResolver, applicationConfiguration, lazyLoadTask, formulaFactory, cloner, objectIdResetter)
       {
          _initialConditionsCreator = initialConditionsCreator;
          _moleculeBuilderFactory = moleculeBuilderFactory;

--- a/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
@@ -41,7 +41,8 @@ namespace PKSim.Core.Mappers
          IParameterQuery parameterQuery,
          IIndividualParametersSameFormulaOrValueForAllSpeciesRepository sameFormulaOrValueForAllSpeciesRepository,
          ICloner cloner,
-         IDimensionRepository dimensionRepository) : base(objectBaseFactory, entityPathResolver, applicationConfiguration, lazyLoadTask, formulaFactory, cloner)
+         IDimensionRepository dimensionRepository, 
+         IObjectIdResetter objectIdResetter) : base(objectBaseFactory, entityPathResolver, applicationConfiguration, lazyLoadTask, formulaFactory, cloner, objectIdResetter)
       {
          _representationInfoRepository = representationInfoRepository;
          _calculationMethodCategoryRepository = calculationMethodCategoryRepository;

--- a/src/PKSim.Core/Mappers/PathAndValueBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/PathAndValueBuildingBlockMapper.cs
@@ -37,6 +37,7 @@ namespace PKSim.Core.Mappers
       private readonly ILazyLoadTask _lazyLoadTask;
       protected readonly IFormulaFactory _formulaFactory;
       private readonly ICloner _cloner;
+      private readonly IObjectIdResetter _objectIdResetter;
 
       protected PathAndValueBuildingBlockMapper(
          IObjectBaseFactory objectBaseFactory,
@@ -44,7 +45,8 @@ namespace PKSim.Core.Mappers
          IApplicationConfiguration applicationConfiguration,
          ILazyLoadTask lazyLoadTask,
          IFormulaFactory formulaFactory,
-         ICloner cloner)
+         ICloner cloner,
+         IObjectIdResetter objectIdResetter)
       {
          _objectBaseFactory = objectBaseFactory;
          _entityPathResolver = entityPathResolver;
@@ -52,6 +54,7 @@ namespace PKSim.Core.Mappers
          _lazyLoadTask = lazyLoadTask;
          _formulaFactory = formulaFactory;
          _cloner = cloner;
+         _objectIdResetter = objectIdResetter;
       }
 
       protected TBuildingBlock CreateBaseObject(TPKSimBuildingBlock pkSimBuildingBlock)
@@ -99,6 +102,7 @@ namespace PKSim.Core.Mappers
                {
                   var templateFormula = retrieveTemplateFormulaFromCache(parameter, pkSimBuildingBlock, formulaCache);
                   builderParameter.Formula = templateFormula;
+                  _objectIdResetter.ResetIdFor(builderParameter.Formula);
                }
 
                // Only set the value of the parameter using a formula if it was indeed set

--- a/src/PKSim.Core/Mappers/PathAndValueBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/PathAndValueBuildingBlockMapper.cs
@@ -102,7 +102,8 @@ namespace PKSim.Core.Mappers
                {
                   var templateFormula = retrieveTemplateFormulaFromCache(parameter, pkSimBuildingBlock, formulaCache);
                   builderParameter.Formula = templateFormula;
-                  _objectIdResetter.ResetIdFor(builderParameter.Formula);
+                  if (builderParameter.Formula != null)
+                     _objectIdResetter.ResetIdFor(builderParameter.Formula);
                }
 
                // Only set the value of the parameter using a formula if it was indeed set

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.102" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,14 +36,14 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.102" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.102" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Starter/SnapshotExchange.cs
+++ b/src/PKSim.Starter/SnapshotExchange.cs
@@ -13,8 +13,7 @@ public static class SnapshotExchange
    {
       var container = CLIApplicationStartup.Initialize();
       var mapper = container.Resolve<IIndividualSnapshotToIndividualBuildingBlockMapper>();
-      var cloner = container.Resolve<ICloner>();
-      var individualBuildingBlock = cloner.Clone(mapper.MapFrom(individualSnapshot));
+      var individualBuildingBlock = mapper.MapFrom(individualSnapshot);
       individualBuildingBlock.Snapshot = individualSnapshot;
       return serialize(individualBuildingBlock, container);
    }
@@ -23,8 +22,8 @@ public static class SnapshotExchange
    {
       var container = CLIApplicationStartup.Initialize();
       var mapper = container.Resolve<IExpressionProfileSnapshotToExpressionProfileBuildingBlockMapper>();
-      var cloner = container.Resolve<ICloner>();
-      var expressionProfileBuildingBlock = cloner.Clone(mapper.MapFrom(expressionProfileSnapshot));
+      
+      var expressionProfileBuildingBlock = mapper.MapFrom(expressionProfileSnapshot);
       expressionProfileBuildingBlock.Snapshot = expressionProfileSnapshot;
       return serialize(expressionProfileBuildingBlock, container);
    }

--- a/src/PKSim.Starter/SnapshotExchange.cs
+++ b/src/PKSim.Starter/SnapshotExchange.cs
@@ -1,7 +1,5 @@
-﻿using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Services;
+﻿using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Qualification;
-using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Serialization.Xml;
 using PKSim.CLI.Core.Services;
 using PKSim.Core.Services;
@@ -15,8 +13,8 @@ public static class SnapshotExchange
    {
       var container = CLIApplicationStartup.Initialize();
       var mapper = container.Resolve<IIndividualSnapshotToIndividualBuildingBlockMapper>();
-
-      var individualBuildingBlock = mapper.MapFrom(individualSnapshot);
+      var cloner = container.Resolve<ICloner>();
+      var individualBuildingBlock = cloner.Clone(mapper.MapFrom(individualSnapshot));
       individualBuildingBlock.Snapshot = individualSnapshot;
       return serialize(individualBuildingBlock, container);
    }
@@ -25,7 +23,8 @@ public static class SnapshotExchange
    {
       var container = CLIApplicationStartup.Initialize();
       var mapper = container.Resolve<IExpressionProfileSnapshotToExpressionProfileBuildingBlockMapper>();
-      var expressionProfileBuildingBlock = mapper.MapFrom(expressionProfileSnapshot);
+      var cloner = container.Resolve<ICloner>();
+      var expressionProfileBuildingBlock = cloner.Clone(mapper.MapFrom(expressionProfileSnapshot));
       expressionProfileBuildingBlock.Snapshot = expressionProfileSnapshot;
       return serialize(expressionProfileBuildingBlock, container);
    }
@@ -46,7 +45,7 @@ public static class SnapshotExchange
       var container = CLIApplicationStartup.Initialize();
       var projectSnapshotToSimulationTransferMapper = container.Resolve<IProjectSnapshotToModuleMapper>();
       var qualificationInputTask = container.Resolve<IQualificationInputTask>();
-      
+
       var (module, project) = projectSnapshotToSimulationTransferMapper.MapFrom(projectSnapshot);
       var objectIdResetter = container.Resolve<IObjectIdResetter>();
       objectIdResetter.ResetIdFor(module);

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,14 +46,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.4" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -73,14 +73,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.Tests/Core/ExpressionProfileToExpressionProfileBuildingBlockMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/ExpressionProfileToExpressionProfileBuildingBlockMapperSpecs.cs
@@ -30,6 +30,7 @@ namespace PKSim.Core
       protected IInitialConditionsCreator _initialConditionsCreator;
       protected IMoleculeBuilderFactory _moleculeBuilderFactory;
       protected ICloner _cloner;
+      private IObjectIdResetter _objectIdResetter;
 
       protected override void Context()
       {
@@ -41,11 +42,12 @@ namespace PKSim.Core
          _initialConditionsCreator = A.Fake<IInitialConditionsCreator>();
          _moleculeBuilderFactory = A.Fake<IMoleculeBuilderFactory>();
          _cloner= A.Fake<ICloner>();
+         _objectIdResetter = A.Fake<IObjectIdResetter>();
 
          A.CallTo(() => _objectBaseFactory.Create<ExpressionProfileBuildingBlock>()).Returns(new ExpressionProfileBuildingBlock());
          A.CallTo(() => _objectBaseFactory.Create<ExpressionParameter>()).ReturnsLazily(() => new ExpressionParameter());
 
-         sut = new ExpressionProfileToExpressionProfileBuildingBlockMapper(_objectBaseFactory, _objectPathFactory, _applicationConfiguration, _lazyLoadTask, _formulaFactory, _initialConditionsCreator, _moleculeBuilderFactory, _cloner);
+         sut = new ExpressionProfileToExpressionProfileBuildingBlockMapper(_objectBaseFactory, _objectPathFactory, _applicationConfiguration, _lazyLoadTask, _formulaFactory, _initialConditionsCreator, _moleculeBuilderFactory, _cloner, _objectIdResetter);
       }
    }
 

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -18,8 +18,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -25,11 +25,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.102" />
 		<PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.101" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.102" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
## Summary
- Reset each template formula's id at assignment time inside `PathAndValueBuildingBlockMapper.MapFormulaOrValue` so every building-block instantiation gets unique formula ids, not the deterministic rate-key strings produced by `FormulaFactory`
- Wire `IObjectIdResetter` through `PathAndValueBuildingBlockMapper` and its concrete subclasses (`IndividualToIndividualBuildingBlockMapper`, `ExpressionProfileToExpressionProfileBuildingBlockMapper`)
- Bumps OSPSuite.Core to the version that adds `Input.PKSimModule` (companion field needed by MoBi's per-PKSimModule input remap)

## Problem
Template-derived formulas in PK-Sim carry rate-key-derived ids set by `FormulaFactory.createTableFormulaWithArgument`:

```csharp
var formula = _objectBaseFactory.Create<TableFormulaWithXArgument>()
   .WithId(rateKey)
   .WithName(rateKey.Rate);
```

`RateKey : CompositeKey` has an implicit `string` conversion that yields `"<CalculationMethod>.<Rate>"` — the Id is deterministic per calc-method/rate, not a GUID.

Two PK-Sim module snapshots materialised against the same calc-method database therefore produce formulas with identical ids (e.g. `Individual_AgeDependent.TableFormulaWithXArgument_OntogenyFactorAlbumin`). When MoBi adds both modules to the same project and calls `RegisterTask.Register`, `WithIdRepository.Register` throws `Id not unique`.

## Fix (revised after PR feedback)

Rather than cloning whole building blocks in `SnapshotExchange`, the fix was moved deeper into [`PathAndValueBuildingBlockMapper.MapFormulaOrValue`](./src/PKSim.Core/Mappers/PathAndValueBuildingBlockMapper.cs) — at the exact moment a template formula is attached to a builder parameter, reset its id:

```csharp
var templateFormula = retrieveTemplateFormulaFromCache(parameter, pkSimBuildingBlock, formulaCache);
builderParameter.Formula = templateFormula;
if (builderParameter.Formula != null)
   _objectIdResetter.ResetIdFor(builderParameter.Formula);
```

`IObjectIdResetter` is now injected through the abstract mapper's constructor; the two concrete subclasses (`IndividualToIndividualBuildingBlockMapper`, `ExpressionProfileToExpressionProfileBuildingBlockMapper`) forward it to `base(...)`. `SnapshotExchange` is unchanged relative to `V13`.

This makes the fix location-of-origin rather than location-of-use: every caller that goes through `MapFrom(...)` gets fresh formula ids, not just the reflective bridge invoked from MoBi. No extra clone overhead, and the isolation matches what the PKML import path already provides.

## Test plan
- [x] End-to-end Amikacin-Model MoBi qualification with a single `Walker 1979 Combined.json` carrying two `PKSimModules` (Volunteer 6 + Volunteer 9 sharing the same PK-Sim calc-method templates) — both modules load cleanly, inputs export per module, report renders compound + individual markdown for each, GOF plots and time profiles produced for both volunteers
- [x] `ExpressionProfileToExpressionProfileBuildingBlockMapperSpecs` updated for the new constructor signature
- [x] Existing PK-Sim qualification flow (single PKSim project) still passes
- [x] R-side `CreateIndividualBuildingBlock` / `CreateExpressionProfileBuildingBlock` callers still work

Fixes #3520