### PR TITLE
Fixes #3433 OverwriteParameterSet selection in simulation configuration

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1466,7 +1466,7 @@ namespace PKSim.Assets
          public static readonly string ProcessInCompound = "Process in compound";
          public static readonly string AlternativeInCompound = "Alternative in compound";
          public static readonly string ParameterAlternatives = "Parameter Alternatives";
-         public static readonly string OverwriteParameterSetInCompound = "Overwrite Parameter Set in compound";
+         public static readonly string OverwriteParameterSetInCompound = "Overwrite parameter set in compound";
          public static readonly string OverwriteParameterSetSelection = "Overwrite Parameter Set";
          public static readonly string PlasmaClearanceInCompound = "Plasma clearance process in compound";
          public static readonly string CreatingSimulation = "Creating...";

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -267,6 +267,12 @@ namespace PKSim.Assets
          public static string UpdateOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
             $"Update {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
+         public static string SetDefaultOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
+            $"Set {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' as default in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
+         public static string ClearDefaultOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
+            $"Clear default flag from {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
          public static string UpdateParameterValueInOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
             $"Update value of '{parameterPath}' in {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
@@ -1460,6 +1466,8 @@ namespace PKSim.Assets
          public static readonly string ProcessInCompound = "Process in compound";
          public static readonly string AlternativeInCompound = "Alternative in compound";
          public static readonly string ParameterAlternatives = "Parameter Alternatives";
+         public static readonly string OverwriteParameterSetInCompound = "Overwrite Parameter Set in compound";
+         public static readonly string OverwriteParameterSetSelection = "Overwrite Parameter Set";
          public static readonly string PlasmaClearanceInCompound = "Plasma clearance process in compound";
          public static readonly string CreatingSimulation = "Creating...";
          public static readonly string Molecule = "Molecule";

--- a/src/PKSim.Core/Commands/ClearDefaultOverwriteParameterSetCommand.cs
+++ b/src/PKSim.Core/Commands/ClearDefaultOverwriteParameterSetCommand.cs
@@ -1,0 +1,45 @@
+using OSPSuite.Core.Commands.Core;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class ClearDefaultOverwriteParameterSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+
+   public ClearDefaultOverwriteParameterSetCommand(OverwriteParameterSet overwriteParameterSet, Compound compound)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+      Description = PKSimConstants.Command.ClearDefaultOverwriteParameterSetInCompound(overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+      _overwriteParameterSet.IsDefault = false;
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+   {
+      return new SetDefaultOverwriteParameterSetCommand(_overwriteParameterSet, _buildingBlock).AsInverseFor(this);
+   }
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+}

--- a/src/PKSim.Core/Commands/SetDefaultOverwriteParameterSetCommand.cs
+++ b/src/PKSim.Core/Commands/SetDefaultOverwriteParameterSetCommand.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class SetDefaultOverwriteParameterSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private string _previousDefaultId;
+   private OverwriteParameterSet _previousDefault;
+
+   public SetDefaultOverwriteParameterSetCommand(OverwriteParameterSet overwriteParameterSet, Compound compound)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+      Description = PKSimConstants.Command.SetDefaultOverwriteParameterSetInCompound(overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+
+      _previousDefault = _buildingBlock.OverwriteParameterSets.FirstOrDefault(x => x.IsDefault && !ReferenceEquals(x, _overwriteParameterSet));
+      _previousDefaultId = _previousDefault?.Id;
+
+      _buildingBlock.OverwriteParameterSets.Each(x => x.IsDefault = false);
+      _overwriteParameterSet.IsDefault = true;
+
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+   {
+      if (_previousDefault != null)
+         return new SetDefaultOverwriteParameterSetCommand(_previousDefault, _buildingBlock).AsInverseFor(this);
+
+      return new ClearDefaultOverwriteParameterSetCommand(_overwriteParameterSet, _buildingBlock).AsInverseFor(this);
+   }
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+      _previousDefault = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+      if (_previousDefaultId != null)
+         _previousDefault = context.Get<OverwriteParameterSet>(_previousDefaultId);
+   }
+}

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -8,16 +8,18 @@ namespace PKSim.Core.Services;
 public interface IOverwriteParameterSetTask
 {
    /// <summary>
-   ///    Updates the value of a parameter (identified by path) in an <see cref="OverwriteParameterSet"/>.
+   ///    Updates the value of a parameter (identified by path) in an <see cref="OverwriteParameterSet" />.
    ///    Returns an empty command if the parameter is not in the set or the value is unchanged.
    /// </summary>
    ICommand UpdateParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, double newValue);
 
    /// <summary>
-   ///    Removes a parameter (identified by path) from an <see cref="OverwriteParameterSet"/>.
+   ///    Removes a parameter (identified by path) from an <see cref="OverwriteParameterSet" />.
    ///    Returns an empty command if the parameter is not in the set.
    /// </summary>
    ICommand RemoveParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath);
+
+   ICommand SetIsDefault(OverwriteParameterSet overwriteParameterSet, Compound compound, bool isDefault);
 }
 
 public class OverwriteParameterSetTask : IOverwriteParameterSetTask
@@ -44,5 +46,16 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
          return new PKSimEmptyCommand();
 
       return new RemoveParameterValueFromOverwriteSetCommand(overwriteParameterSet, compound, parameterPath).Run(_executionContext);
+   }
+
+   public ICommand SetIsDefault(OverwriteParameterSet overwriteParameterSet, Compound compound, bool isDefault)
+   {
+      if (overwriteParameterSet.IsDefault == isDefault)
+         return new PKSimEmptyCommand();
+
+      if (isDefault)
+         return new SetDefaultOverwriteParameterSetCommand(overwriteParameterSet, compound).Run(_executionContext);
+
+      return new ClearDefaultOverwriteParameterSetCommand(overwriteParameterSet, compound).Run(_executionContext);
    }
 }

--- a/src/PKSim.Presentation/DTO/Simulations/SimulationCompoundOverwriteParameterSetSelectionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/SimulationCompoundOverwriteParameterSetSelectionDTO.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PKSim.Assets;
 using PKSim.Core.Model;
 
 namespace PKSim.Presentation.DTO.Simulations;
@@ -7,6 +8,7 @@ public class SimulationCompoundOverwriteParameterSetSelectionDTO
 {
    public IReadOnlyList<OverwriteParameterSet> AllOverwriteParameterSets { get; }
    public OverwriteParameterSet SelectedOverwriteParameterSet { get; set; }
+   public string Label => PKSimConstants.UI.OverwriteParameterSetInCompound;
 
    public SimulationCompoundOverwriteParameterSetSelectionDTO(IReadOnlyList<OverwriteParameterSet> allOverwriteParameterSets, OverwriteParameterSet selectedOverwriteParameterSet)
    {

--- a/src/PKSim.Presentation/DTO/Simulations/SimulationCompoundOverwriteParameterSetSelectionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/SimulationCompoundOverwriteParameterSetSelectionDTO.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using PKSim.Core.Model;
+
+namespace PKSim.Presentation.DTO.Simulations;
+
+public class SimulationCompoundOverwriteParameterSetSelectionDTO
+{
+   public IReadOnlyList<OverwriteParameterSet> AllOverwriteParameterSets { get; }
+   public OverwriteParameterSet SelectedOverwriteParameterSet { get; set; }
+
+   public SimulationCompoundOverwriteParameterSetSelectionDTO(IReadOnlyList<OverwriteParameterSet> allOverwriteParameterSets, OverwriteParameterSet selectedOverwriteParameterSet)
+   {
+      AllOverwriteParameterSets = allOverwriteParameterSets;
+      SelectedOverwriteParameterSet = selectedOverwriteParameterSet;
+   }
+}

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -14,6 +14,7 @@ public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, ILis
 {
    void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValue);
    void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
+   void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault);
 }
 
 public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwriteParameterSetsView, IOverwriteParameterSetsPresenter>, IOverwriteParameterSetsPresenter
@@ -43,6 +44,9 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
 
    public void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO) =>
       AddCommand(_overwriteParameterSetTask.RemoveParameterValue(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString));
+
+   public void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault) =>
+      AddCommand(_overwriteParameterSetTask.SetIsDefault(setDTO.OverwriteParameterSet, _compound, isDefault));
 
    public void Handle(OverwriteParameterSetChangedEvent eventToHandle)
    {

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundConfigurationPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundConfigurationPresenter.cs
@@ -13,30 +13,36 @@ namespace PKSim.Presentation.Presenters.Simulations
    {
       private readonly ISimulationCompoundParameterAlternativesSelectionPresenter _alternativesSelectionPresenter;
       private readonly ISimulationCompoundCalculationMethodSelectionPresenter _calculationMethodSelectionPresenter;
+      private readonly ISimulationCompoundOverwriteParameterSetSelectionPresenter _overwriteParameterSetSelectionPresenter;
 
       public SimulationCompoundConfigurationPresenter(
          ISimulationCompoundConfigurationView view,
          ISimulationCompoundParameterAlternativesSelectionPresenter alternativesSelectionPresenter,
-         ISimulationCompoundCalculationMethodSelectionPresenter calculationMethodSelectionPresenter)
+         ISimulationCompoundCalculationMethodSelectionPresenter calculationMethodSelectionPresenter,
+         ISimulationCompoundOverwriteParameterSetSelectionPresenter overwriteParameterSetSelectionPresenter)
          : base(view)
       {
          _alternativesSelectionPresenter = alternativesSelectionPresenter;
          _calculationMethodSelectionPresenter = calculationMethodSelectionPresenter;
-         AddSubPresenters(_alternativesSelectionPresenter, _calculationMethodSelectionPresenter);
+         _overwriteParameterSetSelectionPresenter = overwriteParameterSetSelectionPresenter;
+         AddSubPresenters(_alternativesSelectionPresenter, _calculationMethodSelectionPresenter, _overwriteParameterSetSelectionPresenter);
          view.AddCalculationMethodsView(_calculationMethodSelectionPresenter.View);
          view.AddParameterAlternativesView(_alternativesSelectionPresenter.View);
+         view.AddOverwriteParameterSetSelectionView(_overwriteParameterSetSelectionPresenter.View);
       }
 
       public void SaveConfiguration()
       {
          _alternativesSelectionPresenter.SaveConfiguration();
          _calculationMethodSelectionPresenter.SaveConfiguration();
+         _overwriteParameterSetSelectionPresenter.SaveConfiguration();
       }
 
       public void EditSimulation(Simulation simulation, Compound compound)
       {
          _alternativesSelectionPresenter.EditSimulation(simulation, compound);
          _calculationMethodSelectionPresenter.EditSimulation(simulation, compound);
+         _overwriteParameterSetSelectionPresenter.EditSimulation(simulation, compound);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundOverwriteParameterSetSelectionPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundOverwriteParameterSetSelectionPresenter.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Presentation.Presenters;
+using PKSim.Assets;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation.Presenters.Simulations
+{
+   public interface ISimulationCompoundOverwriteParameterSetSelectionPresenter : IEditSimulationCompoundPresenter, IPresenter<ISimulationCompoundOverwriteParameterSetSelectionView>
+   {
+   }
+
+   public class SimulationCompoundOverwriteParameterSetSelectionPresenter : AbstractSubPresenter<ISimulationCompoundOverwriteParameterSetSelectionView, ISimulationCompoundOverwriteParameterSetSelectionPresenter>,
+      ISimulationCompoundOverwriteParameterSetSelectionPresenter
+   {
+      private readonly ILazyLoadTask _lazyLoadTask;
+      private readonly OverwriteParameterSet _noOverwriteParameterSet;
+      private Simulation _simulation;
+      private Compound _compound;
+      private SimulationCompoundOverwriteParameterSetSelectionDTO _dto;
+
+      public SimulationCompoundOverwriteParameterSetSelectionPresenter(
+         ISimulationCompoundOverwriteParameterSetSelectionView view,
+         ILazyLoadTask lazyLoadTask) : base(view)
+      {
+         _lazyLoadTask = lazyLoadTask;
+         _noOverwriteParameterSet = new OverwriteParameterSet { Name = PKSimConstants.UI.None };
+      }
+
+      public void EditSimulation(Simulation simulation, Compound compound)
+      {
+         _simulation = simulation;
+         _compound = compound;
+         _lazyLoadTask.Load(_compound);
+
+         var availableSets = new List<OverwriteParameterSet> { _noOverwriteParameterSet };
+         availableSets.AddRange(_compound.OverwriteParameterSets);
+
+         var selected = currentSelectionFor(simulation, compound);
+         _dto = new SimulationCompoundOverwriteParameterSetSelectionDTO(availableSets, selected);
+         _view.BindTo(_dto);
+      }
+
+      public void SaveConfiguration()
+      {
+         if (_dto == null) return;
+
+         if (isNoSelection(_dto.SelectedOverwriteParameterSet))
+            _simulation.RemoveOverwriteParameterSetSelection(_compound.Name);
+         else
+            _simulation.AddOverwriteParameterSetSelection(_compound.Name, _dto.SelectedOverwriteParameterSet);
+      }
+
+      private OverwriteParameterSet currentSelectionFor(Simulation simulation, Compound compound)
+      {
+         var existing = simulation.OverwriteParameterSetSelections.SelectedSetFor(compound.Name);
+         if (existing != null)
+            return existing;
+
+         var defaultSet = compound.OverwriteParameterSets.FirstOrDefault(x => x.IsDefault);
+         return defaultSet ?? _noOverwriteParameterSet;
+      }
+
+      private bool isNoSelection(OverwriteParameterSet overwriteParameterSet) =>
+         overwriteParameterSet == null || ReferenceEquals(overwriteParameterSet, _noOverwriteParameterSet);
+   }
+}

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundConfigurationView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundConfigurationView.cs
@@ -1,5 +1,5 @@
-using PKSim.Presentation.Presenters.Simulations;
 using OSPSuite.Presentation.Views;
+using PKSim.Presentation.Presenters.Simulations;
 
 namespace PKSim.Presentation.Views.Simulations
 {
@@ -7,5 +7,6 @@ namespace PKSim.Presentation.Views.Simulations
    {
       void AddParameterAlternativesView(IResizableView view);
       void AddCalculationMethodsView(IResizableView view);
+      void AddOverwriteParameterSetSelectionView(IResizableView view);
    }
 }

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundOverwriteParameterSetSelectionView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundOverwriteParameterSetSelectionView.cs
@@ -1,0 +1,10 @@
+using OSPSuite.Presentation.Views;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+
+namespace PKSim.Presentation.Views.Simulations;
+
+public interface ISimulationCompoundOverwriteParameterSetSelectionView : IView<ISimulationCompoundOverwriteParameterSetSelectionPresenter>, IResizableView
+{
+   void BindTo(SimulationCompoundOverwriteParameterSetSelectionDTO dto);
+}

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -7,6 +7,7 @@ using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.RepositoryItems;
 using PKSim.Assets;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.Presenters.Compounds;
@@ -21,6 +22,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    private readonly GridViewBinder<OverwriteParameterSetDTO> _gridViewBinderSets;
    private readonly GridViewBinder<OverwriteParameterValueDTO> _gridViewBinderParameterValues;
    private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRemoveButtonRepository();
+   private readonly UxRepositoryItemCheckEdit _isDefaultRepository;
 
    public OverwriteParameterSetsView()
    {
@@ -36,9 +38,12 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
          BindingMode = BindingMode.OneWay
       };
 
+      _isDefaultRepository = new UxRepositoryItemCheckEdit(gridViewSets);
+
       gridViewSets.OptionsSelection.EnableAppearanceFocusedCell = false;
       gridViewParameterValues.OptionsSelection.EnableAppearanceFocusedCell = false;
       gridViewParameterValues.EditorShowMode = EditorShowMode.MouseDown;
+      gridViewSets.EditorShowMode = EditorShowMode.MouseDown;
 
       gridViewSets.FocusedRowChanged += (o, e) => OnEvent(selectedSetChanged);
    }
@@ -56,7 +61,9 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
       _gridViewBinderSets.Bind(x => x.IsDefault)
          .WithCaption(PKSimConstants.UI.IsDefault)
-         .AsReadOnly();
+         .WithRepository(_ => _isDefaultRepository)
+         .WithFixedWidth(EMBEDDED_CHECK_BOX_WIDTH)
+         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetIsDefault(dto, e.NewValue)));
 
       _gridViewBinderSets.Bind(x => x.Species)
          .WithCaption(PKSimConstants.UI.Species)

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundConfigurationView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundConfigurationView.cs
@@ -39,6 +39,12 @@ namespace PKSim.UI.Views.Simulations
          AddViewTo(layoutMainGroup, layoutSimulationCompound, view);
       }
 
+      public void AddOverwriteParameterSetSelectionView(IResizableView view)
+      {
+         _subViews.Add(view);
+         AddViewTo(layoutMainGroup, layoutSimulationCompound, view);
+      }
+
       protected override void AdjustLayoutItemSize(LayoutControlItem layoutControlItem, LayoutControl layoutControl, IResizableView view, int height)
       {
          base.AdjustLayoutItemSize(layoutControlItem, layoutControl, view, height);

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.Designer.cs
@@ -1,0 +1,110 @@
+namespace PKSim.UI.Views.Simulations
+{
+   partial class SimulationCompoundOverwriteParameterSetSelectionView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _screenBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.cbOverwriteParameterSet = new OSPSuite.UI.Controls.UxComboBoxEdit();
+         this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutItemOverwriteParameterSet = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.cbOverwriteParameterSet.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemOverwriteParameterSet)).BeginInit();
+         this.SuspendLayout();
+         //
+         // layoutControl
+         //
+         this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.cbOverwriteParameterSet);
+         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl.Name = "layoutControl";
+         this.layoutControl.OptionsView.UseSkinIndents = false;
+         this.layoutControl.Root = this.layoutControlGroup;
+         this.layoutControl.Size = new System.Drawing.Size(419, 32);
+         this.layoutControl.TabIndex = 0;
+         this.layoutControl.Text = "layoutControl";
+         //
+         // cbOverwriteParameterSet
+         //
+         this.cbOverwriteParameterSet.Location = new System.Drawing.Point(120, 4);
+         this.cbOverwriteParameterSet.Name = "cbOverwriteParameterSet";
+         this.cbOverwriteParameterSet.Properties.AllowMouseWheel = false;
+         this.cbOverwriteParameterSet.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cbOverwriteParameterSet.Size = new System.Drawing.Size(295, 24);
+         this.cbOverwriteParameterSet.StyleController = this.layoutControl;
+         this.cbOverwriteParameterSet.TabIndex = 0;
+         //
+         // layoutControlGroup
+         //
+         this.layoutControlGroup.GroupBordersVisible = false;
+         this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemOverwriteParameterSet});
+         this.layoutControlGroup.Name = "Root";
+         this.layoutControlGroup.OptionsItemText.TextToControlDistance = 5;
+         this.layoutControlGroup.Size = new System.Drawing.Size(419, 32);
+         this.layoutControlGroup.TextVisible = false;
+         //
+         // layoutItemOverwriteParameterSet
+         //
+         this.layoutItemOverwriteParameterSet.Control = this.cbOverwriteParameterSet;
+         this.layoutItemOverwriteParameterSet.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemOverwriteParameterSet.Name = "layoutItemOverwriteParameterSet";
+         this.layoutItemOverwriteParameterSet.Size = new System.Drawing.Size(419, 32);
+         this.layoutItemOverwriteParameterSet.TextSize = new System.Drawing.Size(114, 16);
+         //
+         // SimulationCompoundOverwriteParameterSetSelectionView
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.layoutControl);
+         this.Name = "SimulationCompoundOverwriteParameterSetSelectionView";
+         this.Size = new System.Drawing.Size(419, 32);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.cbOverwriteParameterSet.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemOverwriteParameterSet)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private OSPSuite.UI.Controls.UxComboBoxEdit cbOverwriteParameterSet;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemOverwriteParameterSet;
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.Designer.cs
@@ -17,7 +17,7 @@ namespace PKSim.UI.Views.Simulations
          {
             components.Dispose();
          }
-         _screenBinder.Dispose();
+         _gridViewBinder.Dispose();
          base.Dispose(disposing);
       }
 
@@ -29,82 +29,36 @@ namespace PKSim.UI.Views.Simulations
       /// </summary>
       private void InitializeComponent()
       {
-         this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
-         this.cbOverwriteParameterSet = new OSPSuite.UI.Controls.UxComboBoxEdit();
-         this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
-         this.layoutItemOverwriteParameterSet = new DevExpress.XtraLayout.LayoutControlItem();
-         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
-         this.layoutControl.SuspendLayout();
-         ((System.ComponentModel.ISupportInitialize)(this.cbOverwriteParameterSet.Properties)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemOverwriteParameterSet)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          this.SuspendLayout();
          //
          // layoutControl
          //
-         this.layoutControl.AllowCustomization = false;
-         this.layoutControl.Controls.Add(this.cbOverwriteParameterSet);
-         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
-         this.layoutControl.Location = new System.Drawing.Point(0, 0);
-         this.layoutControl.Name = "layoutControl";
-         this.layoutControl.OptionsView.UseSkinIndents = false;
-         this.layoutControl.Root = this.layoutControlGroup;
-         this.layoutControl.Size = new System.Drawing.Size(419, 32);
-         this.layoutControl.TabIndex = 0;
-         this.layoutControl.Text = "layoutControl";
+         this.layoutControl.Size = new System.Drawing.Size(407, 64);
          //
-         // cbOverwriteParameterSet
+         // layoutItemGrid
          //
-         this.cbOverwriteParameterSet.Location = new System.Drawing.Point(120, 4);
-         this.cbOverwriteParameterSet.Name = "cbOverwriteParameterSet";
-         this.cbOverwriteParameterSet.Properties.AllowMouseWheel = false;
-         this.cbOverwriteParameterSet.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
-            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbOverwriteParameterSet.Size = new System.Drawing.Size(295, 24);
-         this.cbOverwriteParameterSet.StyleController = this.layoutControl;
-         this.cbOverwriteParameterSet.TabIndex = 0;
-         //
-         // layoutControlGroup
-         //
-         this.layoutControlGroup.GroupBordersVisible = false;
-         this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.layoutItemOverwriteParameterSet});
-         this.layoutControlGroup.Name = "Root";
-         this.layoutControlGroup.OptionsItemText.TextToControlDistance = 5;
-         this.layoutControlGroup.Size = new System.Drawing.Size(419, 32);
-         this.layoutControlGroup.TextVisible = false;
-         //
-         // layoutItemOverwriteParameterSet
-         //
-         this.layoutItemOverwriteParameterSet.Control = this.cbOverwriteParameterSet;
-         this.layoutItemOverwriteParameterSet.Location = new System.Drawing.Point(0, 0);
-         this.layoutItemOverwriteParameterSet.Name = "layoutItemOverwriteParameterSet";
-         this.layoutItemOverwriteParameterSet.Size = new System.Drawing.Size(419, 32);
-         this.layoutItemOverwriteParameterSet.TextSize = new System.Drawing.Size(114, 16);
+         this.layoutItemGrid.MaxSize = new System.Drawing.Size(0, 64);
+         this.layoutItemGrid.MinSize = new System.Drawing.Size(1, 64);
+         this.layoutItemGrid.Size = new System.Drawing.Size(407, 64);
+         this.layoutItemGrid.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
          //
          // SimulationCompoundOverwriteParameterSetSelectionView
          //
-         this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-         this.Controls.Add(this.layoutControl);
          this.Name = "SimulationCompoundOverwriteParameterSetSelectionView";
-         this.Size = new System.Drawing.Size(419, 32);
-         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         this.Size = new System.Drawing.Size(407, 64);
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
-         this.layoutControl.ResumeLayout(false);
-         ((System.ComponentModel.ISupportInitialize)(this.cbOverwriteParameterSet.Properties)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemOverwriteParameterSet)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          this.ResumeLayout(false);
 
       }
 
       #endregion
 
-      private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
-      private OSPSuite.UI.Controls.UxComboBoxEdit cbOverwriteParameterSet;
-      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
-      private DevExpress.XtraLayout.LayoutControlItem layoutItemOverwriteParameterSet;
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
@@ -1,0 +1,56 @@
+using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.Presentation.Extensions;
+using OSPSuite.UI.Controls;
+using PKSim.Assets;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Views.Simulations;
+using static OSPSuite.UI.UIConstants.Size;
+
+namespace PKSim.UI.Views.Simulations
+{
+   public partial class SimulationCompoundOverwriteParameterSetSelectionView : BaseResizableUserControl, ISimulationCompoundOverwriteParameterSetSelectionView
+   {
+      private ISimulationCompoundOverwriteParameterSetSelectionPresenter _presenter;
+      private readonly ScreenBinder<SimulationCompoundOverwriteParameterSetSelectionDTO> _screenBinder;
+
+      private readonly int OPTIMAL_HEIGHT = ScaleForScreenDPI(35);
+
+      public SimulationCompoundOverwriteParameterSetSelectionView()
+      {
+         InitializeComponent();
+         _screenBinder = new ScreenBinder<SimulationCompoundOverwriteParameterSetSelectionDTO>();
+      }
+
+      public void AttachPresenter(ISimulationCompoundOverwriteParameterSetSelectionPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public void BindTo(SimulationCompoundOverwriteParameterSetSelectionDTO dto)
+      {
+         _screenBinder.BindToSource(dto);
+         cbOverwriteParameterSet.Enabled = dto.AllOverwriteParameterSets.Count > 1;
+      }
+
+      public override void InitializeBinding()
+      {
+         _screenBinder.Bind(x => x.SelectedOverwriteParameterSet)
+            .To(cbOverwriteParameterSet)
+            .WithValues(x => x.AllOverwriteParameterSets)
+            .AndDisplays(x => x?.Name ?? PKSimConstants.UI.None);
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         Caption = PKSimConstants.UI.OverwriteParameterSetSelection;
+         layoutItemOverwriteParameterSet.Text = PKSimConstants.UI.OverwriteParameterSetInCompound.FormatForLabel();
+      }
+
+      public override int OptimalHeight => OPTIMAL_HEIGHT;
+
+      public override bool HasError => _screenBinder.HasError;
+   }
+}

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
@@ -1,7 +1,7 @@
 using DevExpress.Utils;
 using DevExpress.XtraEditors;
-using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraGrid.Views.Base;
+using DevExpress.XtraGrid.Views.Grid;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.UI.Controls;
@@ -19,16 +19,15 @@ namespace PKSim.UI.Views.Simulations
    {
       private readonly GridViewBinder<SimulationCompoundOverwriteParameterSetSelectionDTO> _gridViewBinder;
       private readonly UxRepositoryItemComboBox _repositoryForOverwriteParameterSets;
-      private readonly RepositoryItemTextEdit _repositoryItemDisabled;
 
       public SimulationCompoundOverwriteParameterSetSelectionView()
       {
          InitializeComponent();
          _repositoryForOverwriteParameterSets = new UxRepositoryItemComboBox(gridView);
-         _repositoryItemDisabled = new RepositoryItemTextEdit { Enabled = false, ReadOnly = true };
          _gridViewBinder = new GridViewBinder<SimulationCompoundOverwriteParameterSetSelectionDTO>(gridView);
          gridView.HorzScrollVisibility = ScrollVisibility.Never;
          gridView.ShowColumnHeaders = false;
+         gridView.RowStyle += rowStyle;
          layoutControl.AutoScroll = false;
          _repositoryForOverwriteParameterSets.AllowDropDownWhenReadOnly = DefaultBoolean.False;
       }
@@ -51,27 +50,25 @@ namespace PKSim.UI.Views.Simulations
             .AsReadOnly();
 
          _gridViewBinder.AutoBind(x => x.SelectedOverwriteParameterSet)
-            .WithRepository(repositoryForOverwriteParameterSet)
+            .WithRepository(_ => _repositoryForOverwriteParameterSets)
             .WithEditorConfiguration(configureOverwriteParameterSets)
             .WithShowButton(ShowButtonModeEnum.ShowAlways);
       }
 
       public override bool HasError => _gridViewBinder.HasError;
 
-      private RepositoryItem repositoryForOverwriteParameterSet(SimulationCompoundOverwriteParameterSetSelectionDTO dto)
-      {
-         if (dto.AllOverwriteParameterSets.Count > 1)
-            return _repositoryForOverwriteParameterSets;
-
-         return _repositoryItemDisabled;
-      }
-
       private void configureOverwriteParameterSets(BaseEdit activeEditor, SimulationCompoundOverwriteParameterSetSelectionDTO dto)
       {
-         if (dto.AllOverwriteParameterSets.Count > 1)
-            activeEditor.FillComboBoxEditorWith(dto.AllOverwriteParameterSets);
-         else
-            activeEditor.Enabled = false;
+         activeEditor.FillComboBoxEditorWith(dto.AllOverwriteParameterSets);
+         activeEditor.Enabled = dto.AllOverwriteParameterSets.Count > 1;
+      }
+
+      private void rowStyle(object sender, RowStyleEventArgs e)
+      {
+         var dto = _gridViewBinder.ElementAt(e.RowHandle);
+         if (dto == null) return;
+
+         gridView.AdjustAppearance(e, dto.AllOverwriteParameterSets.Count > 1);
       }
 
       public override void InitializeResources()

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.cs
@@ -1,56 +1,83 @@
-using OSPSuite.DataBinding;
+using DevExpress.Utils;
+using DevExpress.XtraEditors;
+using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
 using OSPSuite.DataBinding.DevExpress;
-using OSPSuite.Presentation.Extensions;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
+using OSPSuite.UI.RepositoryItems;
+using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Presentation.DTO.Simulations;
 using PKSim.Presentation.Presenters.Simulations;
 using PKSim.Presentation.Views.Simulations;
-using static OSPSuite.UI.UIConstants.Size;
 
 namespace PKSim.UI.Views.Simulations
 {
-   public partial class SimulationCompoundOverwriteParameterSetSelectionView : BaseResizableUserControl, ISimulationCompoundOverwriteParameterSetSelectionView
+   public partial class SimulationCompoundOverwriteParameterSetSelectionView : BaseGridViewOnlyUserControl, ISimulationCompoundOverwriteParameterSetSelectionView
    {
-      private ISimulationCompoundOverwriteParameterSetSelectionPresenter _presenter;
-      private readonly ScreenBinder<SimulationCompoundOverwriteParameterSetSelectionDTO> _screenBinder;
-
-      private readonly int OPTIMAL_HEIGHT = ScaleForScreenDPI(35);
+      private readonly GridViewBinder<SimulationCompoundOverwriteParameterSetSelectionDTO> _gridViewBinder;
+      private readonly UxRepositoryItemComboBox _repositoryForOverwriteParameterSets;
+      private readonly RepositoryItemTextEdit _repositoryItemDisabled;
 
       public SimulationCompoundOverwriteParameterSetSelectionView()
       {
          InitializeComponent();
-         _screenBinder = new ScreenBinder<SimulationCompoundOverwriteParameterSetSelectionDTO>();
+         _repositoryForOverwriteParameterSets = new UxRepositoryItemComboBox(gridView);
+         _repositoryItemDisabled = new RepositoryItemTextEdit { Enabled = false, ReadOnly = true };
+         _gridViewBinder = new GridViewBinder<SimulationCompoundOverwriteParameterSetSelectionDTO>(gridView);
+         gridView.HorzScrollVisibility = ScrollVisibility.Never;
+         gridView.ShowColumnHeaders = false;
+         layoutControl.AutoScroll = false;
+         _repositoryForOverwriteParameterSets.AllowDropDownWhenReadOnly = DefaultBoolean.False;
       }
 
       public void AttachPresenter(ISimulationCompoundOverwriteParameterSetSelectionPresenter presenter)
       {
-         _presenter = presenter;
       }
 
       public void BindTo(SimulationCompoundOverwriteParameterSetSelectionDTO dto)
       {
-         _screenBinder.BindToSource(dto);
-         cbOverwriteParameterSet.Enabled = dto.AllOverwriteParameterSets.Count > 1;
+         _gridViewBinder.BindToSource(new[] { dto }.ToBindingList());
+         gridView.RefreshData();
       }
 
       public override void InitializeBinding()
       {
-         _screenBinder.Bind(x => x.SelectedOverwriteParameterSet)
-            .To(cbOverwriteParameterSet)
-            .WithValues(x => x.AllOverwriteParameterSets)
-            .AndDisplays(x => x?.Name ?? PKSimConstants.UI.None);
+         _gridViewBinder.ValidationMode = ValidationMode.LeavingRow;
+
+         _gridViewBinder.Bind(x => x.Label)
+            .AsReadOnly();
+
+         _gridViewBinder.AutoBind(x => x.SelectedOverwriteParameterSet)
+            .WithRepository(repositoryForOverwriteParameterSet)
+            .WithEditorConfiguration(configureOverwriteParameterSets)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways);
+      }
+
+      public override bool HasError => _gridViewBinder.HasError;
+
+      private RepositoryItem repositoryForOverwriteParameterSet(SimulationCompoundOverwriteParameterSetSelectionDTO dto)
+      {
+         if (dto.AllOverwriteParameterSets.Count > 1)
+            return _repositoryForOverwriteParameterSets;
+
+         return _repositoryItemDisabled;
+      }
+
+      private void configureOverwriteParameterSets(BaseEdit activeEditor, SimulationCompoundOverwriteParameterSetSelectionDTO dto)
+      {
+         if (dto.AllOverwriteParameterSets.Count > 1)
+            activeEditor.FillComboBoxEditorWith(dto.AllOverwriteParameterSets);
+         else
+            activeEditor.Enabled = false;
       }
 
       public override void InitializeResources()
       {
          base.InitializeResources();
          Caption = PKSimConstants.UI.OverwriteParameterSetSelection;
-         layoutItemOverwriteParameterSet.Text = PKSimConstants.UI.OverwriteParameterSetInCompound.FormatForLabel();
       }
-
-      public override int OptimalHeight => OPTIMAL_HEIGHT;
-
-      public override bool HasError => _screenBinder.HasError;
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.resx
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundOverwriteParameterSetSelectionView.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -124,3 +124,123 @@ public class When_removing_a_parameter_value_for_a_path_not_in_the_set : concern
       _result.IsEmpty().ShouldBeTrue();
    }
 }
+
+public abstract class concern_for_OverwriteParameterSetTask_setting_default : concern_for_OverwriteParameterSetTask
+{
+   protected OverwriteParameterSet _otherSet;
+   protected OverwriteParameterSet _previousDefault;
+
+   protected override void Context()
+   {
+      base.Context();
+      _previousDefault = new OverwriteParameterSet { Name = "PreviousDefault", Id = "PreviousDefaultId", IsDefault = true };
+      _otherSet = new OverwriteParameterSet { Name = "Other", Id = "OtherId" };
+      _compound.AddOverwriteParameterSet(_previousDefault);
+      _compound.AddOverwriteParameterSet(_otherSet);
+
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_previousDefault.Id)).Returns(_previousDefault);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_otherSet.Id)).Returns(_otherSet);
+   }
+}
+
+public class When_setting_a_set_as_default_through_the_task : concern_for_OverwriteParameterSetTask_setting_default
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetIsDefault(_otherSet, _compound, true);
+   }
+
+   [Observation]
+   public void should_set_is_default_on_the_target_set()
+   {
+      _otherSet.IsDefault.ShouldBeTrue();
+   }
+
+   [Observation]
+   public void should_clear_is_default_on_the_previously_default_set()
+   {
+      _previousDefault.IsDefault.ShouldBeFalse();
+   }
+
+   [Observation]
+   public void should_leave_the_originally_added_set_unchanged()
+   {
+      _overwriteParameterSet.IsDefault.ShouldBeFalse();
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_clearing_the_default_flag_through_the_task : concern_for_OverwriteParameterSetTask_setting_default
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetIsDefault(_previousDefault, _compound, false);
+   }
+
+   [Observation]
+   public void should_clear_is_default_on_the_target_set()
+   {
+      _previousDefault.IsDefault.ShouldBeFalse();
+   }
+
+   [Observation]
+   public void should_leave_other_sets_unchanged()
+   {
+      _otherSet.IsDefault.ShouldBeFalse();
+      _overwriteParameterSet.IsDefault.ShouldBeFalse();
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_setting_a_set_as_default_that_is_already_default : concern_for_OverwriteParameterSetTask_setting_default
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetIsDefault(_previousDefault, _compound, true);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+
+   [Observation]
+   public void should_leave_state_unchanged()
+   {
+      _previousDefault.IsDefault.ShouldBeTrue();
+      _otherSet.IsDefault.ShouldBeFalse();
+   }
+}
+
+public class When_clearing_the_default_flag_on_a_set_that_is_not_default : concern_for_OverwriteParameterSetTask_setting_default
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetIsDefault(_otherSet, _compound, false);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}

--- a/tests/PKSim.Tests/Core/SetDefaultOverwriteParameterSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/SetDefaultOverwriteParameterSetCommandSpecs.cs
@@ -1,0 +1,181 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Commands;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_SetDefaultOverwriteParameterSetCommand : ContextSpecification<SetDefaultOverwriteParameterSetCommand>
+   {
+      protected Compound _compound;
+      protected OverwriteParameterSet _previousDefault;
+      protected OverwriteParameterSet _newDefault;
+      protected OverwriteParameterSet _otherSet;
+      protected IExecutionContext _executionContext;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _previousDefault = new OverwriteParameterSet { Name = "PreviousDefault", Id = "PreviousId", IsDefault = true };
+         _newDefault = new OverwriteParameterSet { Name = "NewDefault", Id = "NewId" };
+         _otherSet = new OverwriteParameterSet { Name = "Other", Id = "OtherId" };
+         _compound.AddOverwriteParameterSet(_previousDefault);
+         _compound.AddOverwriteParameterSet(_newDefault);
+         _compound.AddOverwriteParameterSet(_otherSet);
+
+         A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_previousDefault.Id)).Returns(_previousDefault);
+         A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_newDefault.Id)).Returns(_newDefault);
+         A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_otherSet.Id)).Returns(_otherSet);
+
+         sut = new SetDefaultOverwriteParameterSetCommand(_newDefault, _compound);
+      }
+   }
+
+   public class When_executing_the_set_default_command_with_a_previous_default : concern_for_SetDefaultOverwriteParameterSetCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(_executionContext);
+      }
+
+      [Observation]
+      public void should_set_is_default_on_the_target_set()
+      {
+         _newDefault.IsDefault.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_clear_is_default_on_the_previously_default_set()
+      {
+         _previousDefault.IsDefault.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_leave_the_other_non_default_set_unchanged()
+      {
+         _otherSet.IsDefault.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_publish_an_overwrite_parameter_set_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _newDefault))).MustHaveHappened();
+      }
+   }
+
+   public class When_undoing_the_set_default_command_with_a_previous_default : concern_for_SetDefaultOverwriteParameterSetCommand
+   {
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_restore_the_previously_default_set()
+      {
+         _previousDefault.IsDefault.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_clear_the_new_default()
+      {
+         _newDefault.IsDefault.ShouldBeFalse();
+      }
+   }
+
+   public abstract class concern_for_SetDefaultOverwriteParameterSetCommand_with_no_previous_default : ContextSpecification<SetDefaultOverwriteParameterSetCommand>
+   {
+      protected Compound _compound;
+      protected OverwriteParameterSet _newDefault;
+      protected IExecutionContext _executionContext;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _newDefault = new OverwriteParameterSet { Name = "NewDefault", Id = "NewId" };
+         _compound.AddOverwriteParameterSet(_newDefault);
+
+         A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_newDefault.Id)).Returns(_newDefault);
+
+         sut = new SetDefaultOverwriteParameterSetCommand(_newDefault, _compound);
+      }
+   }
+
+   public class When_undoing_the_set_default_command_with_no_previous_default : concern_for_SetDefaultOverwriteParameterSetCommand_with_no_previous_default
+   {
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_clear_is_default_on_the_target_set()
+      {
+         _newDefault.IsDefault.ShouldBeFalse();
+      }
+   }
+
+   public abstract class concern_for_ClearDefaultOverwriteParameterSetCommand : ContextSpecification<ClearDefaultOverwriteParameterSetCommand>
+   {
+      protected Compound _compound;
+      protected OverwriteParameterSet _defaultSet;
+      protected IExecutionContext _executionContext;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _defaultSet = new OverwriteParameterSet { Name = "DefaultSet", Id = "DefaultId", IsDefault = true };
+         _compound.AddOverwriteParameterSet(_defaultSet);
+
+         A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+         A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_defaultSet.Id)).Returns(_defaultSet);
+
+         sut = new ClearDefaultOverwriteParameterSetCommand(_defaultSet, _compound);
+      }
+   }
+
+   public class When_executing_the_clear_default_command : concern_for_ClearDefaultOverwriteParameterSetCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(_executionContext);
+      }
+
+      [Observation]
+      public void should_clear_is_default_on_the_target_set()
+      {
+         _defaultSet.IsDefault.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_publish_an_overwrite_parameter_set_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _defaultSet))).MustHaveHappened();
+      }
+   }
+
+   public class When_undoing_the_clear_default_command : concern_for_ClearDefaultOverwriteParameterSetCommand
+   {
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_restore_is_default_on_the_target_set()
+      {
+         _defaultSet.IsDefault.ShouldBeTrue();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -144,6 +144,52 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_setting_is_default_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _task.SetIsDefault(_overwriteParameterSet, _compound, true)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.SetIsDefault(_setDTO, true);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.SetIsDefault(_overwriteParameterSet, _compound, true)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_clearing_is_default_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _task.SetIsDefault(_overwriteParameterSet, _compound, false)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.SetIsDefault(_setDTO, false);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.SetIsDefault(_overwriteParameterSet, _compound, false)).MustHaveHappenedOnceExactly();
+      }
+   }
+
    public class When_handling_an_overwrite_parameter_set_changed_event_for_the_edited_compound : concern_for_OverwriteParameterSetsPresenter_editing
    {
       protected override void Because()

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundConfigurationPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundConfigurationPresenterSpecs.cs
@@ -11,13 +11,15 @@ namespace PKSim.Presentation
       protected ISimulationCompoundConfigurationView _view;
       protected ISimulationCompoundParameterAlternativesSelectionPresenter _alternativesSelectionPresenter;
       protected ISimulationCompoundCalculationMethodSelectionPresenter _calculationMethodSelectionPresenter;
+      protected ISimulationCompoundOverwriteParameterSetSelectionPresenter _overwriteParameterSetSelectionPresenter;
 
       protected override void Context()
       {
          _view = A.Fake<ISimulationCompoundConfigurationView>();
          _alternativesSelectionPresenter = A.Fake<ISimulationCompoundParameterAlternativesSelectionPresenter>();
          _calculationMethodSelectionPresenter = A.Fake<ISimulationCompoundCalculationMethodSelectionPresenter>();
-         sut = new SimulationCompoundConfigurationPresenter(_view, _alternativesSelectionPresenter, _calculationMethodSelectionPresenter);
+         _overwriteParameterSetSelectionPresenter = A.Fake<ISimulationCompoundOverwriteParameterSetSelectionPresenter>();
+         sut = new SimulationCompoundConfigurationPresenter(_view, _alternativesSelectionPresenter, _calculationMethodSelectionPresenter, _overwriteParameterSetSelectionPresenter);
       }
    }
 
@@ -38,6 +40,12 @@ namespace PKSim.Presentation
       public void should_save_the_calculation_methods_selection()
       {
          A.CallTo(() => _calculationMethodSelectionPresenter.SaveConfiguration()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_save_the_overwrite_parameter_set_selection()
+      {
+         A.CallTo(() => _overwriteParameterSetSelectionPresenter.SaveConfiguration()).MustHaveHappened();
       }
    }
 
@@ -68,6 +76,12 @@ namespace PKSim.Presentation
       public void should_edit_the_calculation_methods_selection()
       {
          A.CallTo(() => _calculationMethodSelectionPresenter.EditSimulation(_simulation, _compound)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_edit_the_overwrite_parameter_set_selection()
+      {
+         A.CallTo(() => _overwriteParameterSetSelectionPresenter.EditSimulation(_simulation, _compound)).MustHaveHappened();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundOverwriteParameterSetSelectionPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundOverwriteParameterSetSelectionPresenterSpecs.cs
@@ -1,0 +1,200 @@
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Presentation.DTO.Simulations;
+using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Views.Simulations;
+
+namespace PKSim.Presentation;
+
+public abstract class concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter : ContextSpecification<ISimulationCompoundOverwriteParameterSetSelectionPresenter>
+{
+   protected ISimulationCompoundOverwriteParameterSetSelectionView _view;
+   protected ILazyLoadTask _lazyLoadTask;
+   protected Simulation _simulation;
+   protected Compound _compound;
+   protected OverwriteParameterSetSelections _selections;
+
+   protected override void Context()
+   {
+      _view = A.Fake<ISimulationCompoundOverwriteParameterSetSelectionView>();
+      _lazyLoadTask = A.Fake<ILazyLoadTask>();
+      _simulation = A.Fake<Simulation>();
+      _compound = new Compound { Name = "Aspirin" };
+      _selections = new OverwriteParameterSetSelections();
+      A.CallTo(() => _simulation.OverwriteParameterSetSelections).Returns(_selections);
+      A.CallTo(() => _simulation.CompoundNames).Returns(new[] { "Aspirin" });
+      sut = new SimulationCompoundOverwriteParameterSetSelectionPresenter(_view, _lazyLoadTask);
+   }
+}
+
+public class When_editing_a_simulation_with_a_compound_having_no_overwrite_parameter_sets : concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter
+{
+   private SimulationCompoundOverwriteParameterSetSelectionDTO _capturedDto;
+
+   protected override void Context()
+   {
+      base.Context();
+      A.CallTo(() => _view.BindTo(A<SimulationCompoundOverwriteParameterSetSelectionDTO>._))
+         .Invokes(call => _capturedDto = call.GetArgument<SimulationCompoundOverwriteParameterSetSelectionDTO>(0));
+   }
+
+   protected override void Because()
+   {
+      sut.EditSimulation(_simulation, _compound);
+   }
+
+   [Observation]
+   public void should_lazy_load_the_compound()
+   {
+      A.CallTo(() => _lazyLoadTask.Load(_compound)).MustHaveHappened();
+   }
+
+   [Observation]
+   public void should_provide_only_the_none_option()
+   {
+      _capturedDto.AllOverwriteParameterSets.Count.ShouldBeEqualTo(1);
+      _capturedDto.AllOverwriteParameterSets[0].Name.ShouldBeEqualTo(PKSimConstants.UI.None);
+   }
+
+   [Observation]
+   public void should_select_the_none_option_by_default()
+   {
+      _capturedDto.SelectedOverwriteParameterSet.Name.ShouldBeEqualTo(PKSimConstants.UI.None);
+   }
+}
+
+public class When_editing_a_simulation_with_a_compound_having_a_default_overwrite_parameter_set : concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter
+{
+   private SimulationCompoundOverwriteParameterSetSelectionDTO _capturedDto;
+   private OverwriteParameterSet _defaultSet;
+   private OverwriteParameterSet _otherSet;
+
+   protected override void Context()
+   {
+      base.Context();
+      _defaultSet = new OverwriteParameterSet { Name = "RenalImpairment", IsDefault = true };
+      _otherSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+      _compound.AddOverwriteParameterSet(_defaultSet);
+      _compound.AddOverwriteParameterSet(_otherSet);
+      A.CallTo(() => _view.BindTo(A<SimulationCompoundOverwriteParameterSetSelectionDTO>._))
+         .Invokes(call => _capturedDto = call.GetArgument<SimulationCompoundOverwriteParameterSetSelectionDTO>(0));
+   }
+
+   protected override void Because()
+   {
+      sut.EditSimulation(_simulation, _compound);
+   }
+
+   [Observation]
+   public void should_show_none_first_followed_by_all_overwrite_parameter_sets()
+   {
+      _capturedDto.AllOverwriteParameterSets.Count.ShouldBeEqualTo(3);
+      _capturedDto.AllOverwriteParameterSets[0].Name.ShouldBeEqualTo(PKSimConstants.UI.None);
+      _capturedDto.AllOverwriteParameterSets.Skip(1).ShouldContain(_defaultSet);
+      _capturedDto.AllOverwriteParameterSets.Skip(1).ShouldContain(_otherSet);
+   }
+
+   [Observation]
+   public void should_auto_select_the_default_overwrite_parameter_set()
+   {
+      _capturedDto.SelectedOverwriteParameterSet.ShouldBeEqualTo(_defaultSet);
+   }
+}
+
+public class When_editing_a_simulation_with_an_existing_selection_that_is_not_the_default : concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter
+{
+   private SimulationCompoundOverwriteParameterSetSelectionDTO _capturedDto;
+   private OverwriteParameterSet _defaultSet;
+   private OverwriteParameterSet _selectedSet;
+
+   protected override void Context()
+   {
+      base.Context();
+      _defaultSet = new OverwriteParameterSet { Name = "RenalImpairment", IsDefault = true };
+      _selectedSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+      _compound.AddOverwriteParameterSet(_defaultSet);
+      _compound.AddOverwriteParameterSet(_selectedSet);
+      _selections.SetSelectionForCompound("Aspirin", _selectedSet);
+      A.CallTo(() => _view.BindTo(A<SimulationCompoundOverwriteParameterSetSelectionDTO>._))
+         .Invokes(call => _capturedDto = call.GetArgument<SimulationCompoundOverwriteParameterSetSelectionDTO>(0));
+   }
+
+   protected override void Because()
+   {
+      sut.EditSimulation(_simulation, _compound);
+   }
+
+   [Observation]
+   public void should_use_the_existing_selection_rather_than_the_default()
+   {
+      _capturedDto.SelectedOverwriteParameterSet.ShouldBeEqualTo(_selectedSet);
+   }
+}
+
+public class When_saving_a_real_overwrite_parameter_set_selection : concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter
+{
+   private OverwriteParameterSet _userSelectedSet;
+   private SimulationCompoundOverwriteParameterSetSelectionDTO _capturedDto;
+
+   protected override void Context()
+   {
+      base.Context();
+      _userSelectedSet = new OverwriteParameterSet { Name = "HepaticImpairment" };
+      _compound.AddOverwriteParameterSet(_userSelectedSet);
+      A.CallTo(() => _view.BindTo(A<SimulationCompoundOverwriteParameterSetSelectionDTO>._))
+         .Invokes(call => _capturedDto = call.GetArgument<SimulationCompoundOverwriteParameterSetSelectionDTO>(0));
+      sut.EditSimulation(_simulation, _compound);
+      _capturedDto.SelectedOverwriteParameterSet = _userSelectedSet;
+   }
+
+   protected override void Because()
+   {
+      sut.SaveConfiguration();
+   }
+
+   [Observation]
+   public void should_add_the_selection_to_the_simulation()
+   {
+      A.CallTo(() => _simulation.AddOverwriteParameterSetSelection("Aspirin", _userSelectedSet)).MustHaveHappened();
+   }
+}
+
+public class When_saving_a_none_selection : concern_for_SimulationCompoundOverwriteParameterSetSelectionPresenter
+{
+   private OverwriteParameterSet _existingSet;
+   private SimulationCompoundOverwriteParameterSetSelectionDTO _capturedDto;
+
+   protected override void Context()
+   {
+      base.Context();
+      _existingSet = new OverwriteParameterSet { Name = "RenalImpairment", IsDefault = true };
+      _compound.AddOverwriteParameterSet(_existingSet);
+      A.CallTo(() => _view.BindTo(A<SimulationCompoundOverwriteParameterSetSelectionDTO>._))
+         .Invokes(call => _capturedDto = call.GetArgument<SimulationCompoundOverwriteParameterSetSelectionDTO>(0));
+      sut.EditSimulation(_simulation, _compound);
+      //user clears to "None"
+      _capturedDto.SelectedOverwriteParameterSet = _capturedDto.AllOverwriteParameterSets.First(x => x.Name == PKSimConstants.UI.None);
+   }
+
+   protected override void Because()
+   {
+      sut.SaveConfiguration();
+   }
+
+   [Observation]
+   public void should_remove_the_selection_from_the_simulation()
+   {
+      A.CallTo(() => _simulation.RemoveOverwriteParameterSetSelection("Aspirin")).MustHaveHappened();
+   }
+
+   [Observation]
+   public void should_not_add_a_selection_to_the_simulation()
+   {
+      A.CallTo(() => _simulation.AddOverwriteParameterSetSelection(A<string>._, A<OverwriteParameterSet>._)).MustNotHaveHappened();
+   }
+}


### PR DESCRIPTION
Fixes #3433

## Summary
- Adds an **OverwriteParameterSet dropdown** to the per-compound simulation configuration step. Options are "None" plus all sets defined on the compound; the compound's default set is auto-selected when present, and the user can switch or clear back to "None". Selection persists into `Simulation.OverwriteParameterSetSelections`.
- Enables the **IsDefault checkbox** in the compound's Overwrite Parameter Sets tab. Setting a set as default clears the flag on every other set in the compound (preserving the at-most-one-default invariant); clearing the flag affects only that set. Both directions are undo/redo-able.

## Implementation notes
- New `SimulationCompoundOverwriteParameterSetSelectionPresenter` / DTO / view, wired into `SimulationCompoundConfigurationPresenter` next to the existing parameter alternatives and calculation methods sub-presenters. View is a single `UxComboBoxEdit` bound via `ScreenBinder`.
- A presenter-owned sentinel `OverwriteParameterSet { Name = "None" }` represents the "None" option in the dropdown — on save, the sentinel maps to `RemoveOverwriteParameterSetSelection`; a real set maps to `AddOverwriteParameterSetSelection`.
- New `SetDefaultOverwriteParameterSetCommand` and `ClearDefaultOverwriteParameterSetCommand` (each with proper inverses for undo). `OverwriteParameterSetTask` exposes a single `SetIsDefault(set, compound, bool)` entry point that picks the right command and short-circuits when the flag already matches.

## Test plan
- [x] New unit tests: `SimulationCompoundOverwriteParameterSetSelectionPresenterSpecs` (auto-default, existing-selection wins, save/clear flow), `SetDefaultOverwriteParameterSetCommandSpecs` (forward + undo for both commands), `OverwriteParameterSetTaskSpecs` extended with set/clear/no-op cases, presenter specs extended for the IsDefault delegate.
- [x] All relevant tests pass (39 OverwriteParameterSet-related tests across Core, Task, and Presenter).
- [x] Manual UI verification in PK-Sim: dropdown appears in simulation creation wizard, default auto-selects, "None" option clears, IsDefault checkbox in compound tab toggles correctly with other sets unchecked.

Not sure if this should go in a gridview like others in this view. We won't have more than one row in this grid ever.
<img width="662" height="747" alt="image" src="https://github.com/user-attachments/assets/0e085911-2ded-4093-ae91-42daf525727e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Set and clear default overwrite parameter sets on compounds using an interactive checkbox
  * Dedicated UI controls for selecting and managing overwrite parameter sets in simulation configurations
  * Enhanced support for persisting per-compound overwrite parameter set selections

* **Tests**
  * Comprehensive test coverage for default overwrite parameter set management and selection workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->