### PR TITLE
Fixes #3436 Delete OverwriteParameterSet from compound

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -443,6 +443,17 @@ namespace PKSim.Assets
          public const string CannotDeleteSchema = "At least one schema needs to be defined.";
          public const string CannotDeleteDefaultParameterAlternative = "The default parameter alternative cannot be deleted.";
          public const string CannotDeleteParameterAlternative = "At least one alternative needs to be defined.";
+
+         public static string CannotDeleteOverwriteParameterSetUsedInSimulations(string overwriteParameterSetName, string compoundName, IReadOnlyList<string> simulationNameList) => 
+            $"{ObjectTypes.OverwriteParameterSet} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}' is used by{nameListFrom(simulationNameList)}and cannot be deleted.";
+
+         private static string nameListFrom(IReadOnlyList<string> simulationNameList)
+         {
+            return simulationNameList.Count > 1 ?
+               $"\n\n{string.Join("\n", simulationNameList.Select(n => $"- {n}"))}\n\n" :
+               $" {simulationNameList.ToString("", "'")} ";
+         }
+
          public static string CouldNotFindAdvancedParameterContainerForParameter(string parameterName) => $"Could not find advanced parameter container for parameter '{parameterName}'.";
          public static string CouldNotFindAdvancedParameterInContainerForParameter(string containerName, string parameterName) => $"Could not find advanced parameter in container '{containerName}' for parameter '{parameterName}'.";
          public static string CompoundProcessParameterMappingNotAvailable(string process, string parameter) => $"No compound process parameter mapping found for process='{process}' and parameter ='{parameter}'.";

--- a/src/PKSim.Core/Model/CannotDeleteOverwriteParameterSetException.cs
+++ b/src/PKSim.Core/Model/CannotDeleteOverwriteParameterSetException.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PKSim.Assets;
+
+namespace PKSim.Core.Model;
+
+public class CannotDeleteOverwriteParameterSetException : PKSimException
+{
+   public CannotDeleteOverwriteParameterSetException(string overwriteParameterSetName, string compoundName, IReadOnlyList<string> simulationNames)
+      : base(PKSimConstants.Error.CannotDeleteOverwriteParameterSetUsedInSimulations(overwriteParameterSetName, compoundName, simulationNames))
+   {
+   }
+}

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -5,7 +5,6 @@ using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 
 namespace PKSim.Core.Services;
 
@@ -31,16 +30,16 @@ public interface IOverwriteParameterSetTask
 public class OverwriteParameterSetTask : IOverwriteParameterSetTask
 {
    private readonly IExecutionContext _executionContext;
-   private readonly IBuildingBlockRepository _buildingBlockRepository;
+   private readonly IBuildingBlockInProjectManager _buildingBlockInProjectManager;
    private readonly ILazyLoadTask _lazyLoadTask;
 
    public OverwriteParameterSetTask(
-      IExecutionContext executionContext, 
-      IBuildingBlockRepository buildingBlockRepository, 
+      IExecutionContext executionContext,
+      IBuildingBlockInProjectManager buildingBlockInProjectManager,
       ILazyLoadTask lazyLoadTask)
    {
       _executionContext = executionContext;
-      _buildingBlockRepository = buildingBlockRepository;
+      _buildingBlockInProjectManager = buildingBlockInProjectManager;
       _lazyLoadTask = lazyLoadTask;
    }
 
@@ -83,9 +82,9 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
    
    private IReadOnlyList<Simulation> simulationsUsing(OverwriteParameterSet overwriteParameterSet, Compound compound)
    {
-      var simulations = _buildingBlockRepository.All<Simulation>();
-      simulations.Each(_lazyLoadTask.Load);
-      return simulations
+      var buildingBlocksUsingCompound = _buildingBlockInProjectManager.SimulationsUsing(compound);
+      buildingBlocksUsingCompound.Each(_lazyLoadTask.Load);
+      return buildingBlocksUsingCompound
          .Where(simulation => simulation.OverwriteParameterSetSelections.Selections.Any(x =>
             string.Equals(x.CompoundName, compound.Name) &&
             string.Equals(x.OverwriteParameterSet?.Name, overwriteParameterSet.Name)))

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
 
 namespace PKSim.Core.Services;
 
@@ -20,15 +24,24 @@ public interface IOverwriteParameterSetTask
    ICommand RemoveParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath);
 
    ICommand SetIsDefault(OverwriteParameterSet overwriteParameterSet, Compound compound, bool isDefault);
+
+   ICommand RemoveSet(OverwriteParameterSet overwriteParameterSet, Compound compound);
 }
 
 public class OverwriteParameterSetTask : IOverwriteParameterSetTask
 {
    private readonly IExecutionContext _executionContext;
+   private readonly IBuildingBlockRepository _buildingBlockRepository;
+   private readonly ILazyLoadTask _lazyLoadTask;
 
-   public OverwriteParameterSetTask(IExecutionContext executionContext)
+   public OverwriteParameterSetTask(
+      IExecutionContext executionContext, 
+      IBuildingBlockRepository buildingBlockRepository, 
+      ILazyLoadTask lazyLoadTask)
    {
       _executionContext = executionContext;
+      _buildingBlockRepository = buildingBlockRepository;
+      _lazyLoadTask = lazyLoadTask;
    }
 
    public ICommand UpdateParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, double newValue)
@@ -57,5 +70,25 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
          return new SetDefaultOverwriteParameterSetCommand(overwriteParameterSet, compound).Run(_executionContext);
 
       return new ClearDefaultOverwriteParameterSetCommand(overwriteParameterSet, compound).Run(_executionContext);
+   }
+
+   public ICommand RemoveSet(OverwriteParameterSet overwriteParameterSet, Compound compound)
+   {
+      var blockingSimulations = simulationsUsing(overwriteParameterSet, compound);
+      if (blockingSimulations.Any())
+         throw new CannotDeleteOverwriteParameterSetException(overwriteParameterSet.Name, compound.Name, blockingSimulations.Select(x => x.Name).ToList());
+
+      return new RemoveOverwriteParameterSetFromCompoundCommand(overwriteParameterSet, compound).Run(_executionContext);
+   }
+   
+   private IReadOnlyList<Simulation> simulationsUsing(OverwriteParameterSet overwriteParameterSet, Compound compound)
+   {
+      var simulations = _buildingBlockRepository.All<Simulation>();
+      simulations.Each(_lazyLoadTask.Load);
+      return simulations
+         .Where(simulation => simulation.OverwriteParameterSetSelections.Selections.Any(x =>
+            string.Equals(x.CompoundName, compound.Name) &&
+            string.Equals(x.OverwriteParameterSet?.Name, overwriteParameterSet.Name)))
+         .ToList();
    }
 }

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -1,6 +1,8 @@
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -15,22 +17,26 @@ public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, ILis
    void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValue);
    void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
    void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault);
+   void RemoveSet(OverwriteParameterSetDTO setDTO);
 }
 
 public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwriteParameterSetsView, IOverwriteParameterSetsPresenter>, IOverwriteParameterSetsPresenter
 {
    private readonly IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
    private readonly IOverwriteParameterSetTask _overwriteParameterSetTask;
+   private readonly IDialogCreator _dialogCreator;
    private Compound _compound;
 
    public OverwriteParameterSetsPresenter(
       IOverwriteParameterSetsView view,
       IOverwriteParameterSetToOverwriteParameterSetDTOMapper mapper,
-      IOverwriteParameterSetTask overwriteParameterSetTask)
+      IOverwriteParameterSetTask overwriteParameterSetTask,
+      IDialogCreator dialogCreator)
       : base(view)
    {
       _mapper = mapper;
       _overwriteParameterSetTask = overwriteParameterSetTask;
+      _dialogCreator = dialogCreator;
    }
 
    public void EditCompound(Compound compound)
@@ -47,6 +53,15 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
 
    public void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault) =>
       AddCommand(_overwriteParameterSetTask.SetIsDefault(setDTO.OverwriteParameterSet, _compound, isDefault));
+
+   public void RemoveSet(OverwriteParameterSetDTO setDTO)
+   {
+      var viewResult = _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteObjectOfType(PKSimConstants.ObjectTypes.OverwriteParameterSet, setDTO.Name));
+      if (viewResult == ViewResult.No)
+         return;
+
+      AddCommand(_overwriteParameterSetTask.RemoveSet(setDTO.OverwriteParameterSet, _compound));
+   }
 
    public void Handle(OverwriteParameterSetChangedEvent eventToHandle)
    {

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -22,6 +22,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    private readonly GridViewBinder<OverwriteParameterSetDTO> _gridViewBinderSets;
    private readonly GridViewBinder<OverwriteParameterValueDTO> _gridViewBinderParameterValues;
    private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRemoveButtonRepository();
+   private readonly RepositoryItemButtonEdit _removeSetButtonRepository = new UxRemoveButtonRepository();
    private readonly UxRepositoryItemCheckEdit _isDefaultRepository;
 
    public OverwriteParameterSetsView()
@@ -72,6 +73,14 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       _gridViewBinderSets.Bind(x => x.DiseaseState)
          .WithCaption(PKSimConstants.UI.DiseaseState)
          .AsReadOnly();
+
+      _gridViewBinderSets.AddUnboundColumn()
+         .WithCaption(Captions.EmptyColumn)
+         .WithFixedWidth(EMBEDDED_BUTTON_WIDTH)
+         .WithShowButton(ShowButtonModeEnum.ShowAlways)
+         .WithRepository(_ => _removeSetButtonRepository);
+
+      _removeSetButtonRepository.ButtonClick += (_, _) => OnEvent(() => _presenter.RemoveSet(_gridViewBinderSets.FocusedElement));
 
       _gridViewBinderParameterValues.Bind(x => x.Path)
          .WithCaption(Captions.Diff.ObjectPath)

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -7,12 +8,15 @@ using OSPSuite.Core.Domain.Builder;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
+using IBuildingBlockRepository = PKSim.Core.Repositories.IBuildingBlockRepository;
 
 namespace PKSim.Core;
 
 public abstract class concern_for_OverwriteParameterSetTask : ContextSpecification<OverwriteParameterSetTask>
 {
    protected IExecutionContext _executionContext;
+   protected IBuildingBlockRepository _buildingBlockRepository;
+   protected ILazyLoadTask _lazyLoadTask;
    protected Compound _compound;
    protected OverwriteParameterSet _overwriteParameterSet;
    protected const string _path = "Organism|Aspirin|Lipophilicity";
@@ -20,6 +24,10 @@ public abstract class concern_for_OverwriteParameterSetTask : ContextSpecificati
    protected override void Context()
    {
       _executionContext = A.Fake<IExecutionContext>();
+      _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
+      _lazyLoadTask = A.Fake<ILazyLoadTask>();
+      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation>());
+
       _compound = new Compound { Name = "Aspirin", Id = "CompId" };
       _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
       _overwriteParameterSet.Add(new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 });
@@ -29,7 +37,7 @@ public abstract class concern_for_OverwriteParameterSetTask : ContextSpecificati
       A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
       A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
 
-      sut = new OverwriteParameterSetTask(_executionContext);
+      sut = new OverwriteParameterSetTask(_executionContext, _buildingBlockRepository, _lazyLoadTask);
    }
 }
 
@@ -242,5 +250,114 @@ public class When_clearing_the_default_flag_on_a_set_that_is_not_default : conce
    public void should_return_an_empty_command()
    {
       _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_removing_an_overwrite_parameter_set_not_used_in_any_simulation : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.RemoveSet(_overwriteParameterSet, _compound);
+   }
+
+   [Observation]
+   public void should_remove_the_set_from_the_compound()
+   {
+      _compound.OverwriteParameterSets.ShouldNotContain(_overwriteParameterSet);
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_removing_an_overwrite_parameter_set_used_by_a_simulation : concern_for_OverwriteParameterSetTask
+{
+   private IndividualSimulation _simulation;
+
+   protected override void Context()
+   {
+      base.Context();
+      _simulation = new IndividualSimulation { Name = "Sim1" };
+      // Simulations hold clones of compounds, so the selection points to a clone of the set with a different id.
+      var clonedSet = new OverwriteParameterSet { Name = _overwriteParameterSet.Name, Id = "ClonedSetId" };
+      _simulation.OverwriteParameterSetSelections.SetSelectionForCompound(_compound.Name, clonedSet);
+      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _simulation });
+   }
+
+   [Observation]
+   public void should_throw_a_cannot_delete_exception_and_leave_the_set_on_the_compound()
+   {
+      The.Action(() => sut.RemoveSet(_overwriteParameterSet, _compound)).ShouldThrowAn<CannotDeleteOverwriteParameterSetException>();
+      _compound.OverwriteParameterSets.ShouldContain(_overwriteParameterSet);
+   }
+
+   [Observation]
+   public void should_lazy_load_the_simulation_before_inspecting_its_selections()
+   {
+      The.Action(() => sut.RemoveSet(_overwriteParameterSet, _compound)).ShouldThrowAn<CannotDeleteOverwriteParameterSetException>();
+      A.CallTo(() => _lazyLoadTask.Load<Simulation>(_simulation)).MustHaveHappened();
+   }
+}
+
+public class When_removing_an_overwrite_parameter_set_used_only_by_a_set_with_the_same_name_in_another_compound : concern_for_OverwriteParameterSetTask
+{
+   private IndividualSimulation _simulation;
+   private ICommand _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _simulation = new IndividualSimulation { Name = "Sim1" };
+      // Selection is for a different compound that happens to have a same-named set — must NOT block deletion.
+      var otherCompoundSet = new OverwriteParameterSet { Name = _overwriteParameterSet.Name, Id = "OtherCompoundSetId" };
+      _simulation.OverwriteParameterSetSelections.SetSelectionForCompound("OtherCompound", otherCompoundSet);
+      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _simulation });
+   }
+
+   protected override void Because()
+   {
+      _result = sut.RemoveSet(_overwriteParameterSet, _compound);
+   }
+
+   [Observation]
+   public void should_remove_the_set_from_the_compound()
+   {
+      _compound.OverwriteParameterSets.ShouldNotContain(_overwriteParameterSet);
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_removing_an_overwrite_parameter_set_with_multiple_simulations_in_the_project : concern_for_OverwriteParameterSetTask
+{
+   private IndividualSimulation _userSimulation;
+   private IndividualSimulation _otherSimulation;
+
+   protected override void Context()
+   {
+      base.Context();
+      _userSimulation = new IndividualSimulation { Name = "User" };
+      // Use a clone of the set (different id, same name) to mirror how UsedBuildingBlock holds compounds.
+      var clonedSet = new OverwriteParameterSet { Name = _overwriteParameterSet.Name, Id = "ClonedSetId" };
+      _userSimulation.OverwriteParameterSetSelections.SetSelectionForCompound(_compound.Name, clonedSet);
+
+      _otherSimulation = new IndividualSimulation { Name = "Other" };
+
+      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _userSimulation, _otherSimulation });
+   }
+
+   [Observation]
+   public void should_throw_a_cannot_delete_exception()
+   {
+      The.Action(() => sut.RemoveSet(_overwriteParameterSet, _compound)).ShouldThrowAn<CannotDeleteOverwriteParameterSetException>();
    }
 }

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -5,17 +5,15 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
-using IBuildingBlockRepository = PKSim.Core.Repositories.IBuildingBlockRepository;
 
 namespace PKSim.Core;
 
 public abstract class concern_for_OverwriteParameterSetTask : ContextSpecification<OverwriteParameterSetTask>
 {
    protected IExecutionContext _executionContext;
-   protected IBuildingBlockRepository _buildingBlockRepository;
+   protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
    protected ILazyLoadTask _lazyLoadTask;
    protected Compound _compound;
    protected OverwriteParameterSet _overwriteParameterSet;
@@ -24,9 +22,9 @@ public abstract class concern_for_OverwriteParameterSetTask : ContextSpecificati
    protected override void Context()
    {
       _executionContext = A.Fake<IExecutionContext>();
-      _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
+      _buildingBlockInProjectManager = A.Fake<IBuildingBlockInProjectManager>();
       _lazyLoadTask = A.Fake<ILazyLoadTask>();
-      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation>());
+      A.CallTo(() => _buildingBlockInProjectManager.SimulationsUsing(A<IPKSimBuildingBlock>._)).Returns(new List<Simulation>());
 
       _compound = new Compound { Name = "Aspirin", Id = "CompId" };
       _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
@@ -37,7 +35,7 @@ public abstract class concern_for_OverwriteParameterSetTask : ContextSpecificati
       A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
       A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
 
-      sut = new OverwriteParameterSetTask(_executionContext, _buildingBlockRepository, _lazyLoadTask);
+      sut = new OverwriteParameterSetTask(_executionContext, _buildingBlockInProjectManager, _lazyLoadTask);
    }
 }
 
@@ -286,7 +284,7 @@ public class When_removing_an_overwrite_parameter_set_used_by_a_simulation : con
       // Simulations hold clones of compounds, so the selection points to a clone of the set with a different id.
       var clonedSet = new OverwriteParameterSet { Name = _overwriteParameterSet.Name, Id = "ClonedSetId" };
       _simulation.OverwriteParameterSetSelections.SetSelectionForCompound(_compound.Name, clonedSet);
-      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _simulation });
+      A.CallTo(() => _buildingBlockInProjectManager.SimulationsUsing(_compound)).Returns(new List<Simulation> { _simulation });
    }
 
    [Observation]
@@ -316,7 +314,7 @@ public class When_removing_an_overwrite_parameter_set_used_only_by_a_set_with_th
       // Selection is for a different compound that happens to have a same-named set — must NOT block deletion.
       var otherCompoundSet = new OverwriteParameterSet { Name = _overwriteParameterSet.Name, Id = "OtherCompoundSetId" };
       _simulation.OverwriteParameterSetSelections.SetSelectionForCompound("OtherCompound", otherCompoundSet);
-      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _simulation });
+      A.CallTo(() => _buildingBlockInProjectManager.SimulationsUsing(_compound)).Returns(new List<Simulation> { _simulation });
    }
 
    protected override void Because()
@@ -352,7 +350,7 @@ public class When_removing_an_overwrite_parameter_set_with_multiple_simulations_
 
       _otherSimulation = new IndividualSimulation { Name = "Other" };
 
-      A.CallTo(() => _buildingBlockRepository.All<Simulation>()).Returns(new List<Simulation> { _userSimulation, _otherSimulation });
+      A.CallTo(() => _buildingBlockInProjectManager.SimulationsUsing(_compound)).Returns(new List<Simulation> { _userSimulation, _otherSimulation });
    }
 
    [Observation]

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.Core.Commands;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -21,13 +22,15 @@ namespace PKSim.Presentation
       protected IOverwriteParameterSetsView _view;
       protected IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
       protected IOverwriteParameterSetTask _task;
+      protected IDialogCreator _dialogCreator;
 
       protected override void Context()
       {
          _view = A.Fake<IOverwriteParameterSetsView>();
          _mapper = A.Fake<IOverwriteParameterSetToOverwriteParameterSetDTOMapper>();
          _task = A.Fake<IOverwriteParameterSetTask>();
-         sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task);
+         _dialogCreator = A.Fake<IDialogCreator>();
+         sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task, _dialogCreator);
          sut.InitializeWith(A.Fake<ICommandCollector>());
       }
    }
@@ -217,6 +220,56 @@ namespace PKSim.Presentation
       public void should_not_rebind_the_view()
       {
          A.CallTo(() => _view.BindTo(A<IReadOnlyList<OverwriteParameterSetDTO>>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_removing_a_set_through_the_presenter_and_the_user_confirms : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.Yes);
+         A.CallTo(() => _task.RemoveSet(_overwriteParameterSet, _compound)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveSet(_setDTO);
+      }
+
+      [Observation]
+      public void should_ask_the_user_to_confirm()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.RemoveSet(_overwriteParameterSet, _compound)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_removing_a_set_through_the_presenter_and_the_user_cancels : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.No);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveSet(_setDTO);
+      }
+
+      [Observation]
+      public void should_not_delegate_to_the_task()
+      {
+         A.CallTo(() => _task.RemoveSet(A<OverwriteParameterSet>._, A<Compound>._)).MustNotHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Some of the intended functionality from here had already been implemented alongside previous commits - such as marking a set as default, so those changes don't appear here.

## Summary
- Adds a per-row delete button on the overwrite parameter sets grid in the compound editor.
- Blocks deletion (with a clear message listing the offending simulations) when any simulation has the set selected; otherwise prompts for confirmation and runs `RemoveOverwriteParameterSetFromCompoundCommand` (with full undo/redo via the existing inverse `Add…` command).
- Sets are matched by name within the compound — simulations hold cloned compounds (`UsedBuildingBlock.BuildingBlock = cloneManager.Clone(...)`), so id/reference equality misses; name + compound name is the durable identifier.
- Simulations are lazy-loaded before their `OverwriteParameterSetSelections` are inspected, since the property is empty until content is hydrated.

## Test plan
- [x] Open a compound with one or more overwrite parameter sets — each row has a delete button.
- [x] Click delete on a set that is **not** referenced by any simulation → confirmation dialog → set is removed.
- [x] Undo → set comes back; redo → set goes again.
- [x] Click delete on a set that **is** selected by a simulation (loaded or unloaded) → error dialog naming the blocking simulation(s); set remains.
- [x] When the message lists multiple simulations they appear as a `-` bullet list with blank lines around it; a single simulation appears inline in single quotes.
- [x] A same-named set in a different compound does **not** block deletion.

<img width="772" height="238" alt="image" src="https://github.com/user-attachments/assets/7b7fd025-9ba5-4e01-aa8c-633dbf03d6a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete overwrite parameter sets from the UI, with a confirmation prompt.
* **Bug Fixes / Safety**
  * Prevents deletion of parameter sets that are referenced by simulations and shows an informative error listing those simulations.
* **Tests**
  * Added coverage for delete scenarios, confirmations, and blocking behavior when referenced by simulations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->