### PR TITLE
Fixes #3438 Metadata (Species, Disease State) support for OverwriteParameterSet

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -282,6 +282,9 @@ namespace PKSim.Assets
          public static string AddParameterValueToOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
             $"Add '{parameterPath}' to {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
+         public static string SetExtendedPropertyOnOverwriteParameterSet(string propertyName, string overwriteParameterSetName, string compoundName) =>
+            $"Set '{propertyName}' on {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
          public static string AddEntityToContainer(string entityType, string entityName, string containerType, string containerName)
          {
             var lowerEntityType = string.IsNullOrEmpty(entityType) ? entityType : entityType.ToLower();
@@ -1719,6 +1722,7 @@ namespace PKSim.Assets
          public static readonly string DissociationConstants = "Dissociation Constants";
          public static readonly string AdvancedParameterTabCaption = "Advanced Parameters";
          public static readonly string OverwriteParameterSetsTabCaption = "Overwrite Parameter Sets";
+         public static readonly string Metadata = "Metadata";
          public static readonly string CompoundParameterInSimulationSimple = BasicPharmacochemistry;
          public static readonly string CompoundParameterInSimulationAdvanced = AdvancedParameterTabCaption;
          public static readonly string ADME = "ADME";

--- a/src/PKSim.Core/Commands/SetExtendedPropertyOnOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/SetExtendedPropertyOnOverwriteSetCommand.cs
@@ -1,5 +1,4 @@
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Core.Domain;
 using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
@@ -33,21 +32,9 @@ public class SetExtendedPropertyOnOverwriteSetCommand : BuildingBlockChangeComma
    {
       base.PerformExecuteWith(context);
 
-      _oldValue = currentValue();
+      _oldValue = _overwriteParameterSet.GetExtendedProperty(_propertyName);
 
-      if (string.IsNullOrEmpty(_newValue))
-      {
-         if (_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
-            _overwriteParameterSet.ExtendedProperties.Remove(_propertyName);
-      }
-      else if (_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
-      {
-         _overwriteParameterSet.ExtendedProperties[_propertyName].ValueAsObject = _newValue;
-      }
-      else
-      {
-         _overwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = _propertyName, Value = _newValue });
-      }
+      _overwriteParameterSet.SetExtendedProperty(_propertyName, _newValue);
 
       context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
    }
@@ -65,13 +52,5 @@ public class SetExtendedPropertyOnOverwriteSetCommand : BuildingBlockChangeComma
    {
       base.RestoreExecutionData(context);
       _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
-   }
-
-   private string currentValue()
-   {
-      if (!_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
-         return string.Empty;
-
-      return _overwriteParameterSet.ExtendedProperties[_propertyName].ValueAsObject?.ToString() ?? string.Empty;
    }
 }

--- a/src/PKSim.Core/Commands/SetExtendedPropertyOnOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/SetExtendedPropertyOnOverwriteSetCommand.cs
@@ -1,0 +1,77 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class SetExtendedPropertyOnOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private readonly string _propertyName;
+   private readonly string _newValue;
+   private string _oldValue;
+
+   public SetExtendedPropertyOnOverwriteSetCommand(
+      OverwriteParameterSet overwriteParameterSet,
+      Compound compound,
+      string propertyName,
+      string newValue)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      _propertyName = propertyName;
+      _newValue = newValue ?? string.Empty;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+      Description = PKSimConstants.Command.SetExtendedPropertyOnOverwriteParameterSet(propertyName, overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+
+      _oldValue = currentValue();
+
+      if (string.IsNullOrEmpty(_newValue))
+      {
+         if (_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
+            _overwriteParameterSet.ExtendedProperties.Remove(_propertyName);
+      }
+      else if (_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
+      {
+         _overwriteParameterSet.ExtendedProperties[_propertyName].ValueAsObject = _newValue;
+      }
+      else
+      {
+         _overwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = _propertyName, Value = _newValue });
+      }
+
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+      new SetExtendedPropertyOnOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _propertyName, _oldValue).AsInverseFor(this);
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+
+   private string currentValue()
+   {
+      if (!_overwriteParameterSet.ExtendedProperties.Contains(_propertyName))
+         return string.Empty;
+
+      return _overwriteParameterSet.ExtendedProperties[_propertyName].ValueAsObject?.ToString() ?? string.Empty;
+   }
+}

--- a/src/PKSim.Core/Model/OverwriteParameterSet.cs
+++ b/src/PKSim.Core/Model/OverwriteParameterSet.cs
@@ -31,6 +31,49 @@ namespace PKSim.Core.Model
             Remove(existing);
       }
 
+      /// <summary>
+      /// Sets the value of a specified extended property. If the property already exists, its value is updated.
+      /// If the new value is <c>null</c> or empty, the property is removed.
+      /// </summary>
+      /// <param name="propertyName">
+      /// The name of the property to set or remove.
+      /// </param>
+      /// <param name="newValue">
+      /// The new value to assign to the property. If <c>null</c> or empty, the property will be removed.
+      /// </param>
+      public void SetExtendedProperty(string propertyName, string newValue)
+      {
+         if (string.IsNullOrEmpty(newValue))
+         {
+            if (ExtendedProperties.Contains(propertyName))
+               ExtendedProperties.Remove(propertyName);
+         }
+         else if (ExtendedProperties.Contains(propertyName))
+         {
+            ExtendedProperties[propertyName].ValueAsObject = newValue;
+         }
+         else
+         {
+            ExtendedProperties.Add(new ExtendedProperty<string> { Name = propertyName, Value = newValue });
+         }
+      }
+
+      /// <summary>
+      /// Retrieves the value of a specified extended property.
+      /// </summary>
+      /// <param name="propertyName">
+      /// The name of the property whose value is to be retrieved.
+      /// </param>
+      /// <returns>
+      /// The value of the specified property as a string. If the property does not exist, an empty string is returned.
+      /// </returns>
+      public string GetExtendedProperty(string propertyName)
+      {
+         return ExtendedProperties.Contains(propertyName)
+            ? ExtendedProperties[propertyName].ValueAsObject?.ToString() ?? string.Empty
+            : string.Empty;
+      }
+
       public ParameterValue ParameterValueByPath(string parameterPath) =>
          _parameterValues[parameterPath.ToObjectPath()];
 

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -89,9 +89,7 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
    public ICommand SetExtendedProperty(OverwriteParameterSet overwriteParameterSet, Compound compound, string propertyName, string newValue)
    {
       newValue ??= string.Empty;
-      var currentValue = overwriteParameterSet.ExtendedProperties.Contains(propertyName)
-         ? overwriteParameterSet.ExtendedProperties[propertyName].ValueAsObject?.ToString() ?? string.Empty
-         : string.Empty;
+      var currentValue = overwriteParameterSet.GetExtendedProperty(propertyName);
 
       if (string.Equals(newValue, currentValue))
          return new PKSimEmptyCommand();

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -25,6 +25,12 @@ public interface IOverwriteParameterSetTask
    ICommand SetIsDefault(OverwriteParameterSet overwriteParameterSet, Compound compound, bool isDefault);
 
    ICommand RemoveSet(OverwriteParameterSet overwriteParameterSet, Compound compound);
+
+   /// <summary>
+   ///    Sets the value of a metadata property (stored in <see cref="OverwriteParameterSet.ExtendedProperties" />)
+   ///    on an <see cref="OverwriteParameterSet" />
+   /// </summary>
+   ICommand SetExtendedProperty(OverwriteParameterSet overwriteParameterSet, Compound compound, string propertyName, string newValue);
 }
 
 public class OverwriteParameterSetTask : IOverwriteParameterSetTask
@@ -79,7 +85,20 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
 
       return new RemoveOverwriteParameterSetFromCompoundCommand(overwriteParameterSet, compound).Run(_executionContext);
    }
-   
+
+   public ICommand SetExtendedProperty(OverwriteParameterSet overwriteParameterSet, Compound compound, string propertyName, string newValue)
+   {
+      newValue ??= string.Empty;
+      var currentValue = overwriteParameterSet.ExtendedProperties.Contains(propertyName)
+         ? overwriteParameterSet.ExtendedProperties[propertyName].ValueAsObject?.ToString() ?? string.Empty
+         : string.Empty;
+
+      if (string.Equals(newValue, currentValue))
+         return new PKSimEmptyCommand();
+
+      return new SetExtendedPropertyOnOverwriteSetCommand(overwriteParameterSet, compound, propertyName, newValue).Run(_executionContext);
+   }
+
    private IReadOnlyList<Simulation> simulationsUsing(OverwriteParameterSet overwriteParameterSet, Compound compound)
    {
       var buildingBlocksUsingCompound = _buildingBlockInProjectManager.SimulationsUsing(compound);

--- a/src/PKSim.Presentation/DTO/Compounds/ExtendedPropertyOptionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/ExtendedPropertyOptionDTO.cs
@@ -1,6 +1,8 @@
+using OSPSuite.Core.Domain;
+
 namespace PKSim.Presentation.DTO.Compounds;
 
-public class ExtendedPropertyOptionDTO
+public class ExtendedPropertyOptionDTO : IWithName
 {
    public ExtendedPropertyOptionDTO(string name, string displayName = null, string icon = null)
    {
@@ -9,7 +11,7 @@ public class ExtendedPropertyOptionDTO
       Icon = icon;
    }
 
-   public string Name { get; }
+   public string Name { get; set; }
    public string DisplayName { get; }
    public string Icon { get; }
 }

--- a/src/PKSim.Presentation/DTO/Compounds/ExtendedPropertyOptionDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/ExtendedPropertyOptionDTO.cs
@@ -1,0 +1,15 @@
+namespace PKSim.Presentation.DTO.Compounds;
+
+public class ExtendedPropertyOptionDTO
+{
+   public ExtendedPropertyOptionDTO(string name, string displayName = null, string icon = null)
+   {
+      Name = name;
+      DisplayName = displayName ?? name;
+      Icon = icon;
+   }
+
+   public string Name { get; }
+   public string DisplayName { get; }
+   public string Icon { get; }
+}

--- a/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterSetDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterSetDTO.cs
@@ -18,16 +18,7 @@ public class OverwriteParameterSetDTO
    public OverwriteParameterSet OverwriteParameterSet { get; }
    public string Name => OverwriteParameterSet.Name;
    public bool IsDefault => OverwriteParameterSet.IsDefault;
-   public string Species => extendedPropertyValue(PKSimConstants.UI.Species);
-   public string DiseaseState => extendedPropertyValue(PKSimConstants.UI.DiseaseState);
+   public string Species => OverwriteParameterSet.GetExtendedProperty(PKSimConstants.ObjectTypes.Species);
+   public string DiseaseState => OverwriteParameterSet.GetExtendedProperty(PKSimConstants.ObjectTypes.DiseaseState);
    public IReadOnlyList<OverwriteParameterValueDTO> ParameterValues { get; }
-
-   private string extendedPropertyValue(string propertyName)
-   {
-      if (!OverwriteParameterSet.ExtendedProperties.Contains(propertyName))
-         return string.Empty;
-
-      var property = OverwriteParameterSet.ExtendedProperties[propertyName];
-      return property.ValueAsObject?.ToString() ?? string.Empty;
-   }
 }

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Events;
@@ -5,6 +7,7 @@ using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.DTO.Mappers;
@@ -18,6 +21,9 @@ public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, ILis
    void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
    void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault);
    void RemoveSet(OverwriteParameterSetDTO setDTO);
+   void SetExtendedProperty(OverwriteParameterSetDTO setDTO, string propertyName, string newValue);
+   IReadOnlyList<ExtendedPropertyOptionDTO> AllSpecies();
+   IReadOnlyList<ExtendedPropertyOptionDTO> AllDiseaseStates();
 }
 
 public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwriteParameterSetsView, IOverwriteParameterSetsPresenter>, IOverwriteParameterSetsPresenter
@@ -25,19 +31,31 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
    private readonly IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
    private readonly IOverwriteParameterSetTask _overwriteParameterSetTask;
    private readonly IDialogCreator _dialogCreator;
+   private readonly ISpeciesRepository _speciesRepository;
+   private readonly IDiseaseStateRepository _diseaseStateRepository;
    private Compound _compound;
 
    public OverwriteParameterSetsPresenter(
       IOverwriteParameterSetsView view,
       IOverwriteParameterSetToOverwriteParameterSetDTOMapper mapper,
       IOverwriteParameterSetTask overwriteParameterSetTask,
-      IDialogCreator dialogCreator)
+      IDialogCreator dialogCreator,
+      ISpeciesRepository speciesRepository,
+      IDiseaseStateRepository diseaseStateRepository)
       : base(view)
    {
       _mapper = mapper;
       _overwriteParameterSetTask = overwriteParameterSetTask;
       _dialogCreator = dialogCreator;
+      _speciesRepository = speciesRepository;
+      _diseaseStateRepository = diseaseStateRepository;
    }
+
+   public IReadOnlyList<ExtendedPropertyOptionDTO> AllSpecies() =>
+      _speciesRepository.All().Select(species => new ExtendedPropertyOptionDTO(species.Name, species.DisplayName, species.Icon)).ToList();
+
+   public IReadOnlyList<ExtendedPropertyOptionDTO> AllDiseaseStates() =>
+      _diseaseStateRepository.All().Select(diseaseState => new ExtendedPropertyOptionDTO(diseaseState.Name, diseaseState.DisplayName)).ToList();
 
    public void EditCompound(Compound compound)
    {
@@ -53,6 +71,9 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
 
    public void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault) =>
       AddCommand(_overwriteParameterSetTask.SetIsDefault(setDTO.OverwriteParameterSet, _compound, isDefault));
+
+   public void SetExtendedProperty(OverwriteParameterSetDTO setDTO, string propertyName, string newValue) =>
+      AddCommand(_overwriteParameterSetTask.SetExtendedProperty(setDTO.OverwriteParameterSet, _compound, propertyName, newValue));
 
    public void RemoveSet(OverwriteParameterSetDTO setDTO)
    {

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
@@ -24,6 +25,8 @@ public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, ILis
    void SetExtendedProperty(OverwriteParameterSetDTO setDTO, string propertyName, string newValue);
    IReadOnlyList<ExtendedPropertyOptionDTO> AllSpecies();
    IReadOnlyList<ExtendedPropertyOptionDTO> AllDiseaseStates();
+   IReadOnlyList<string> MetadataPropertyNamesFor(OverwriteParameterSetDTO selectedSet);
+   ExtendedPropertyOptionDTO ExtendedPropertyDTOFor(string extendedPropertyName);
 }
 
 public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwriteParameterSetsView, IOverwriteParameterSetsPresenter>, IOverwriteParameterSetsPresenter
@@ -31,9 +34,11 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
    private readonly IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
    private readonly IOverwriteParameterSetTask _overwriteParameterSetTask;
    private readonly IDialogCreator _dialogCreator;
-   private readonly ISpeciesRepository _speciesRepository;
-   private readonly IDiseaseStateRepository _diseaseStateRepository;
    private Compound _compound;
+   private readonly Cache<string, ExtendedPropertyOptionDTO> _allSpecies = new(getKey:x => x.Name);
+   private readonly Cache<string, ExtendedPropertyOptionDTO> _allDiseaseStates = new(getKey: x => x.Name);
+   private readonly ExtendedPropertyOptionDTO _emptySpecies = new(string.Empty, string.Empty);
+   private readonly ExtendedPropertyOptionDTO _emptyDiseaseState = new(string.Empty, string.Empty);
 
    public OverwriteParameterSetsPresenter(
       IOverwriteParameterSetsView view,
@@ -47,15 +52,37 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
       _mapper = mapper;
       _overwriteParameterSetTask = overwriteParameterSetTask;
       _dialogCreator = dialogCreator;
-      _speciesRepository = speciesRepository;
-      _diseaseStateRepository = diseaseStateRepository;
+      _allSpecies.Add(_emptySpecies);
+      _allDiseaseStates.Add(_emptyDiseaseState);
+      _allDiseaseStates.AddRange(diseaseStateRepository.All().Select(diseaseState => new ExtendedPropertyOptionDTO(diseaseState.Name, diseaseState.DisplayName)));
+      _allSpecies.AddRange(speciesRepository.All().Select(species => new ExtendedPropertyOptionDTO(species.Name, species.DisplayName, species.Icon)));
    }
 
-   public IReadOnlyList<ExtendedPropertyOptionDTO> AllSpecies() =>
-      _speciesRepository.All().Select(species => new ExtendedPropertyOptionDTO(species.Name, species.DisplayName, species.Icon)).ToList();
+   public IReadOnlyList<ExtendedPropertyOptionDTO> AllSpecies() => _allSpecies.ToList();
 
-   public IReadOnlyList<ExtendedPropertyOptionDTO> AllDiseaseStates() =>
-      _diseaseStateRepository.All().Select(diseaseState => new ExtendedPropertyOptionDTO(diseaseState.Name, diseaseState.DisplayName)).ToList();
+   public IReadOnlyList<ExtendedPropertyOptionDTO> AllDiseaseStates() => _allDiseaseStates.ToList();
+
+   public IReadOnlyList<string> MetadataPropertyNamesFor(OverwriteParameterSetDTO selectedSet)
+   {
+      var defaultPropertyNames = new List<string> { PKSimConstants.UI.Species, PKSimConstants.UI.DiseaseState };
+      if (selectedSet == null)
+         return defaultPropertyNames;
+
+      var existingNames = selectedSet.OverwriteParameterSet.ExtendedProperties.All.Select(x => x.Name);
+
+      // preserve this order (adding existing names to defaults). That ensures that Species and Disease State
+      // are always created in this order and before any other extended properties
+      defaultPropertyNames.AddRange(existingNames);
+      return defaultPropertyNames.Distinct().ToList();
+   }
+
+   public ExtendedPropertyOptionDTO ExtendedPropertyDTOFor(string extendedPropertyName)
+   {
+      if(_allDiseaseStates.Contains(extendedPropertyName))
+         return _allDiseaseStates[extendedPropertyName];
+
+      return _allSpecies[extendedPropertyName];
+   }
 
    public void EditCompound(Compound compound)
    {

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
@@ -17,6 +17,7 @@ namespace PKSim.UI.Views.Compounds
          {
             components.Dispose();
          }
+         disposeMetadataGroup();
          _gridViewBinderSets?.Dispose();
          _gridViewBinderParameterValues?.Dispose();
          base.Dispose(disposing);
@@ -34,10 +35,14 @@ namespace PKSim.UI.Views.Compounds
          this.splitContainerControl = new DevExpress.XtraEditors.SplitContainerControl();
          this.gridSets = new OSPSuite.UI.Controls.UxGridControl();
          this.gridViewSets = new PKSim.UI.Views.Core.UxGridView();
+         this.rightPanelLayoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
          this.gridParameterValues = new OSPSuite.UI.Controls.UxGridControl();
          this.gridViewParameterValues = new PKSim.UI.Views.Core.UxGridView();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+         this.rightPanelLayoutGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.parameterValuesGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutControlItemParameterValues = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
@@ -45,10 +50,15 @@ namespace PKSim.UI.Views.Compounds
          this.splitContainerControl.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.gridSets)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridViewSets)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.rightPanelLayoutControl)).BeginInit();
+         this.rightPanelLayoutControl.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.gridParameterValues)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridViewParameterValues)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.rightPanelLayoutGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.parameterValuesGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemParameterValues)).BeginInit();
          this.SuspendLayout();
          //
          // layoutControl
@@ -69,10 +79,10 @@ namespace PKSim.UI.Views.Compounds
          this.splitContainerControl.Name = "splitContainerControl";
          this.splitContainerControl.Panel1.Controls.Add(this.gridSets);
          this.splitContainerControl.Panel1.Text = "Panel1";
-         this.splitContainerControl.Panel2.Controls.Add(this.gridParameterValues);
+         this.splitContainerControl.Panel2.Controls.Add(this.rightPanelLayoutControl);
          this.splitContainerControl.Panel2.Text = "Panel2";
          this.splitContainerControl.Size = new System.Drawing.Size(676, 426);
-         this.splitContainerControl.SplitterPosition = 300;
+         this.splitContainerControl.SplitterPosition = 400;
          this.splitContainerControl.TabIndex = 0;
          this.splitContainerControl.Text = "splitContainerControl";
          //
@@ -91,9 +101,20 @@ namespace PKSim.UI.Views.Compounds
          this.gridViewSets.GridControl = this.gridSets;
          this.gridViewSets.Name = "gridViewSets";
          //
+         // rightPanelLayoutControl
+         //
+         this.rightPanelLayoutControl.AllowCustomization = false;
+         this.rightPanelLayoutControl.Controls.Add(this.gridParameterValues);
+         this.rightPanelLayoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.rightPanelLayoutControl.Location = new System.Drawing.Point(0, 0);
+         this.rightPanelLayoutControl.Name = "rightPanelLayoutControl";
+         this.rightPanelLayoutControl.Root = this.rightPanelLayoutGroup;
+         this.rightPanelLayoutControl.Size = new System.Drawing.Size(371, 426);
+         this.rightPanelLayoutControl.TabIndex = 0;
+         this.rightPanelLayoutControl.Text = "rightPanelLayoutControl";
+         //
          // gridParameterValues
          //
-         this.gridParameterValues.Dock = System.Windows.Forms.DockStyle.Fill;
          this.gridParameterValues.Location = new System.Drawing.Point(0, 0);
          this.gridParameterValues.MainView = this.gridViewParameterValues;
          this.gridParameterValues.Name = "gridParameterValues";
@@ -127,6 +148,37 @@ namespace PKSim.UI.Views.Compounds
          this.layoutControlItem.TextToControlDistance = 0;
          this.layoutControlItem.TextVisible = false;
          //
+         // rightPanelLayoutGroup
+         //
+         this.rightPanelLayoutGroup.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.rightPanelLayoutGroup.GroupBordersVisible = false;
+         this.rightPanelLayoutGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.parameterValuesGroup});
+         this.rightPanelLayoutGroup.Location = new System.Drawing.Point(0, 0);
+         this.rightPanelLayoutGroup.Name = "rightPanelLayoutGroup";
+         this.rightPanelLayoutGroup.Size = new System.Drawing.Size(371, 426);
+         this.rightPanelLayoutGroup.TextVisible = false;
+         //
+         // parameterValuesGroup
+         //
+         this.parameterValuesGroup.GroupBordersVisible = false;
+         this.parameterValuesGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItemParameterValues});
+         this.parameterValuesGroup.Location = new System.Drawing.Point(0, 0);
+         this.parameterValuesGroup.Name = "parameterValuesGroup";
+         this.parameterValuesGroup.Size = new System.Drawing.Size(371, 426);
+         this.parameterValuesGroup.TextVisible = false;
+         //
+         // layoutControlItemParameterValues
+         //
+         this.layoutControlItemParameterValues.Control = this.gridParameterValues;
+         this.layoutControlItemParameterValues.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlItemParameterValues.Name = "layoutControlItemParameterValues";
+         this.layoutControlItemParameterValues.Size = new System.Drawing.Size(371, 426);
+         this.layoutControlItemParameterValues.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItemParameterValues.TextToControlDistance = 0;
+         this.layoutControlItemParameterValues.TextVisible = false;
+         //
          // OverwriteParameterSetsView
          //
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -141,10 +193,15 @@ namespace PKSim.UI.Views.Compounds
          this.splitContainerControl.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.gridSets)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridViewSets)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.rightPanelLayoutControl)).EndInit();
+         this.rightPanelLayoutControl.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.gridParameterValues)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridViewParameterValues)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.rightPanelLayoutGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.parameterValuesGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemParameterValues)).EndInit();
          this.ResumeLayout(false);
       }
 
@@ -154,9 +211,13 @@ namespace PKSim.UI.Views.Compounds
       private DevExpress.XtraEditors.SplitContainerControl splitContainerControl;
       private OSPSuite.UI.Controls.UxGridControl gridSets;
       private PKSim.UI.Views.Core.UxGridView gridViewSets;
+      private OSPSuite.UI.Controls.UxLayoutControl rightPanelLayoutControl;
       private OSPSuite.UI.Controls.UxGridControl gridParameterValues;
       private PKSim.UI.Views.Core.UxGridView gridViewParameterValues;
       private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem;
+      private DevExpress.XtraLayout.LayoutControlGroup rightPanelLayoutGroup;
+      private DevExpress.XtraLayout.LayoutControlGroup parameterValuesGroup;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemParameterValues;
    }
 }

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.Designer.cs
@@ -18,6 +18,7 @@ namespace PKSim.UI.Views.Compounds
             components.Dispose();
          }
          disposeMetadataGroup();
+         _metadataToolTipController?.Dispose();
          _gridViewBinderSets?.Dispose();
          _gridViewBinderParameterValues?.Dispose();
          base.Dispose(disposing);

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -179,11 +179,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       if (selectedSet == null)
          return string.Empty;
 
-      var extendedProperties = selectedSet.OverwriteParameterSet.ExtendedProperties;
-      if (!extendedProperties.Contains(propertyName))
-         return string.Empty;
-
-      return extendedProperties[propertyName].ValueAsObject?.ToString() ?? string.Empty;
+      return selectedSet.OverwriteParameterSet.GetExtendedProperty(propertyName);
    }
 
    private void addMetadataItem(OverwriteParameterSetDTO selectedSet, string propertyName, string value)

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -1,32 +1,52 @@
 using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using DevExpress.Utils;
+using DevExpress.XtraEditors;
+using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraGrid.Views.Base;
+using DevExpress.XtraLayout;
+using DevExpress.XtraLayout.Utils;
 using OSPSuite.Assets;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
 using OSPSuite.UI.RepositoryItems;
+using OSPSuite.UI.Services;
+using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.Presenters.Compounds;
 using PKSim.Presentation.Views.Compounds;
+using PKSim.UI.Views.Core;
 using static OSPSuite.UI.UIConstants.Size;
 
 namespace PKSim.UI.Views.Compounds;
 
 public partial class OverwriteParameterSetsView : BaseUserControl, IOverwriteParameterSetsView
 {
+   private const int METADATA_EDITOR_WIDTH = 200;
+
    private IOverwriteParameterSetsPresenter _presenter;
+   private readonly IImageListRetriever _imageListRetriever;
    private readonly GridViewBinder<OverwriteParameterSetDTO> _gridViewBinderSets;
    private readonly GridViewBinder<OverwriteParameterValueDTO> _gridViewBinderParameterValues;
    private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRemoveButtonRepository();
    private readonly RepositoryItemButtonEdit _removeSetButtonRepository = new UxRemoveButtonRepository();
    private readonly UxRepositoryItemCheckEdit _isDefaultRepository;
+   private readonly UxRepositoryItemImageComboBox _speciesRepository;
+   private readonly UxRepositoryItemImageComboBox _diseaseStateRepository;
+   private readonly ToolTipController _metadataToolTipController = new();
+   private readonly List<BaseEdit> _metadataEditors = new();
+   private LayoutControlGroup _metadataGroup;
 
-   public OverwriteParameterSetsView()
+   public OverwriteParameterSetsView(IImageListRetriever imageListRetriever)
    {
+      _imageListRetriever = imageListRetriever;
       InitializeComponent();
 
       _gridViewBinderSets = new GridViewBinder<OverwriteParameterSetDTO>(gridViewSets)
@@ -40,6 +60,12 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       };
 
       _isDefaultRepository = new UxRepositoryItemCheckEdit(gridViewSets);
+      _speciesRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
+      _diseaseStateRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
+      
+      // Disease state options use DisplayName for UI but no icon. Clearing the image lists hides the icon column.
+      _diseaseStateRepository.SmallImages = null;
+      _diseaseStateRepository.LargeImages = null;
 
       gridViewSets.OptionsSelection.EnableAppearanceFocusedCell = false;
       gridViewParameterValues.OptionsSelection.EnableAppearanceFocusedCell = false;
@@ -68,11 +94,15 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
       _gridViewBinderSets.Bind(x => x.Species)
          .WithCaption(PKSimConstants.UI.Species)
-         .AsReadOnly();
+         .WithRepository(_ => configureSpeciesRepository())
+         .WithShowButton(ShowButtonModeEnum.ShowAlways)
+         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.UI.Species, e.NewValue)));
 
       _gridViewBinderSets.Bind(x => x.DiseaseState)
          .WithCaption(PKSimConstants.UI.DiseaseState)
-         .AsReadOnly();
+         .WithRepository(_ => configureDiseaseStateRepository())
+         .WithShowButton(ShowButtonModeEnum.ShowAlways)
+         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.UI.DiseaseState, e.NewValue)));
 
       _gridViewBinderSets.AddUnboundColumn()
          .WithCaption(Captions.EmptyColumn)
@@ -125,13 +155,132 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    private void bindToSelectedParameterValues()
    {
       var selectedSet = _gridViewBinderSets.FocusedElement;
-      if (selectedSet == null)
-      {
-         _gridViewBinderParameterValues.BindToSource([]);
-         return;
-      }
-
+      buildMetadataPanel(selectedSet);
       _gridViewBinderParameterValues.BindToSource(selectedSet.ParameterValues);
+   }
+
+   private void buildMetadataPanel(OverwriteParameterSetDTO selectedSet)
+   {
+      rightPanelLayoutControl.DoInBatch(() =>
+      {
+         disposeMetadataGroup();
+
+         _metadataGroup = rightPanelLayoutControl.AddGroup();
+         _metadataGroup.Text = PKSimConstants.UI.Metadata;
+         _metadataGroup.LayoutMode = LayoutMode.Flow;
+         _metadataGroup.Move(parameterValuesGroup, InsertType.Top);
+         _metadataGroup.Enabled = selectedSet != null;
+
+         metadataPropertyNamesFor(selectedSet).Each(x => addMetadataItem(selectedSet, x, valueOf(selectedSet, x)));
+      });
+   }
+
+   private static IEnumerable<string> metadataPropertyNamesFor(OverwriteParameterSetDTO selectedSet)
+   {
+      var defaultPropertyNames = new List<string> { PKSimConstants.UI.Species, PKSimConstants.UI.DiseaseState };
+      if (selectedSet == null)
+         return defaultPropertyNames;
+
+      var existingNames = selectedSet.OverwriteParameterSet.ExtendedProperties.All.Select(x => x.Name);
+
+      // preserve this order (adding existing names to defaults). That ensures that Species and Disease State
+      // are always created in this order and before any other extended properties
+      defaultPropertyNames.AddRange(existingNames);
+      return defaultPropertyNames.Distinct();
+   }
+
+   private static string valueOf(OverwriteParameterSetDTO selectedSet, string propertyName)
+   {
+      if (selectedSet == null)
+         return string.Empty;
+
+      var extendedProperties = selectedSet.OverwriteParameterSet.ExtendedProperties;
+      if (!extendedProperties.Contains(propertyName))
+         return string.Empty;
+
+      return extendedProperties[propertyName].ValueAsObject?.ToString() ?? string.Empty;
+   }
+
+   private void addMetadataItem(OverwriteParameterSetDTO selectedSet, string propertyName, string value)
+   {
+      var editor = createMetadataEditor(selectedSet, propertyName, value);
+      editor.Width = METADATA_EDITOR_WIDTH;
+      editor.MinimumSize = editor.MinimumSize with { Width = METADATA_EDITOR_WIDTH };
+      editor.MaximumSize = editor.MaximumSize with { Width = METADATA_EDITOR_WIDTH };
+
+      var item = rightPanelLayoutControl.AddItem();
+      item.Text = propertyName.FormatForLabel(checkCase: false);
+      item.Control = editor;
+      _metadataGroup.AddItem(item);
+   }
+
+   private BaseEdit createMetadataEditor(OverwriteParameterSetDTO selectedSet, string propertyName, string value)
+   {
+      var editor = createEditorFor(propertyName, value);
+      editor.ToolTipController = _metadataToolTipController;
+      editor.ToolTip = editor.Text;
+      editor.EditValueChanged += (_, _) =>
+      {
+         OnEvent(() => _presenter.SetExtendedProperty(selectedSet, propertyName, editor.EditValue.ToString()));
+         editor.ToolTip = editor.Text;
+      };
+
+      _metadataEditors.Add(editor);
+      return editor;
+   }
+
+   private BaseEdit createEditorFor(string propertyName, string value)
+   {
+      if (string.Equals(propertyName, PKSimConstants.UI.Species))
+         return createImageComboBoxEditor(_presenter.AllSpecies(), value, withIcons: true);
+
+      if (string.Equals(propertyName, PKSimConstants.UI.DiseaseState))
+         return createImageComboBoxEditor(_presenter.AllDiseaseStates(), value, withIcons: false);
+
+      return new TextEdit { Text = value };
+   }
+
+   private ImageComboBoxEdit createImageComboBoxEditor(IReadOnlyList<ExtendedPropertyOptionDTO> options, string value, bool withIcons)
+   {
+      var comboBox = new UxImageComboBoxEdit();
+      comboBox.Properties.TextEditStyle = TextEditStyles.DisableTextEditor;
+      if (withIcons)
+         comboBox.Properties.SmallImages = _imageListRetriever.AllImages16x16;
+
+      comboBox.Properties.Items.Add(new ImageComboBoxItem(string.Empty, string.Empty, -1));
+      foreach (var option in options)
+         comboBox.Properties.Items.Add(new ImageComboBoxItem(option.DisplayName, option.Name, withIcons ? _imageListRetriever.ImageIndex(option.Icon) : -1));
+
+      comboBox.EditValue = value ?? string.Empty;
+      return comboBox;
+   }
+
+   private void disposeMetadataGroup()
+   {
+      if (_metadataGroup == null)
+         return;
+
+      _metadataEditors.Each(x => x.Dispose());
+      _metadataEditors.Clear();
+      rightPanelLayoutControl.Remove(_metadataGroup);
+      _metadataGroup.Dispose();
+      _metadataGroup = null;
+   }
+
+   private RepositoryItem configureSpeciesRepository() =>
+      fillImageComboBoxRepository(_speciesRepository, _presenter.AllSpecies(), withIcons: true);
+
+   private RepositoryItem configureDiseaseStateRepository() =>
+      fillImageComboBoxRepository(_diseaseStateRepository, _presenter.AllDiseaseStates(), withIcons: false);
+
+   private RepositoryItem fillImageComboBoxRepository(UxRepositoryItemImageComboBox repository, IReadOnlyList<ExtendedPropertyOptionDTO> options, bool withIcons)
+   {
+      repository.Items.Clear();
+      repository.Items.Add(new ImageComboBoxItem(string.Empty, string.Empty, -1));
+      foreach (var option in options)
+         repository.Items.Add(new ImageComboBoxItem(option.DisplayName, option.Name, withIcons ? _imageListRetriever.ImageIndex(option.Icon) : -1));
+
+      return repository;
    }
 
    private void onParameterValueUpdating(OverwriteParameterValueDTO dto, double? newValue)

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -156,7 +156,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    {
       var selectedSet = _gridViewBinderSets.FocusedElement;
       buildMetadataPanel(selectedSet);
-      _gridViewBinderParameterValues.BindToSource(selectedSet.ParameterValues);
+      _gridViewBinderParameterValues.BindToSource(selectedSet?.ParameterValues ?? []);
    }
 
    private void buildMetadataPanel(OverwriteParameterSetDTO selectedSet)

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
 using DevExpress.Utils;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
@@ -9,6 +7,7 @@ using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
@@ -62,7 +61,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       _isDefaultRepository = new UxRepositoryItemCheckEdit(gridViewSets);
       _speciesRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
       _diseaseStateRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
-      
+
       // Disease state options use DisplayName for UI but no icon. Clearing the image lists hides the icon column.
       _diseaseStateRepository.SmallImages = null;
       _diseaseStateRepository.LargeImages = null;
@@ -96,13 +95,13 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
          .WithCaption(PKSimConstants.UI.Species)
          .WithRepository(_ => configureSpeciesRepository())
          .WithShowButton(ShowButtonModeEnum.ShowAlways)
-         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.UI.Species, e.NewValue)));
+         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.ObjectTypes.Species, e.NewValue)));
 
       _gridViewBinderSets.Bind(x => x.DiseaseState)
          .WithCaption(PKSimConstants.UI.DiseaseState)
          .WithRepository(_ => configureDiseaseStateRepository())
          .WithShowButton(ShowButtonModeEnum.ShowAlways)
-         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.UI.DiseaseState, e.NewValue)));
+         .WithOnValueUpdating((dto, e) => OnEvent(() => _presenter.SetExtendedProperty(dto, PKSimConstants.ObjectTypes.DiseaseState, e.NewValue)));
 
       _gridViewBinderSets.AddUnboundColumn()
          .WithCaption(Captions.EmptyColumn)
@@ -171,22 +170,8 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
          _metadataGroup.Move(parameterValuesGroup, InsertType.Top);
          _metadataGroup.Enabled = selectedSet != null;
 
-         metadataPropertyNamesFor(selectedSet).Each(x => addMetadataItem(selectedSet, x, valueOf(selectedSet, x)));
+         _presenter.MetadataPropertyNamesFor(selectedSet).Each(x => addMetadataItem(selectedSet, x, valueOf(selectedSet, x)));
       });
-   }
-
-   private static IEnumerable<string> metadataPropertyNamesFor(OverwriteParameterSetDTO selectedSet)
-   {
-      var defaultPropertyNames = new List<string> { PKSimConstants.UI.Species, PKSimConstants.UI.DiseaseState };
-      if (selectedSet == null)
-         return defaultPropertyNames;
-
-      var existingNames = selectedSet.OverwriteParameterSet.ExtendedProperties.All.Select(x => x.Name);
-
-      // preserve this order (adding existing names to defaults). That ensures that Species and Disease State
-      // are always created in this order and before any other extended properties
-      defaultPropertyNames.AddRange(existingNames);
-      return defaultPropertyNames.Distinct();
    }
 
    private static string valueOf(OverwriteParameterSetDTO selectedSet, string propertyName)
@@ -247,12 +232,16 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       if (withIcons)
          comboBox.Properties.SmallImages = _imageListRetriever.AllImages16x16;
 
-      comboBox.Properties.Items.Add(new ImageComboBoxItem(string.Empty, string.Empty, -1));
-      foreach (var option in options)
-         comboBox.Properties.Items.Add(new ImageComboBoxItem(option.DisplayName, option.Name, withIcons ? _imageListRetriever.ImageIndex(option.Icon) : -1));
-
+      comboBox.FillImageComboBoxEditorWith(options.AllNames(), 
+         x => imageIndex(withIcons, x), 
+         x => _presenter.ExtendedPropertyDTOFor(x).DisplayName);
       comboBox.EditValue = value ?? string.Empty;
       return comboBox;
+   }
+
+   private int imageIndex(bool withIcons, string x)
+   {
+      return withIcons ? _imageListRetriever.ImageIndex(_presenter.ExtendedPropertyDTOFor(x).Icon) : -1;
    }
 
    private void disposeMetadataGroup()
@@ -275,11 +264,9 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
    private RepositoryItem fillImageComboBoxRepository(UxRepositoryItemImageComboBox repository, IReadOnlyList<ExtendedPropertyOptionDTO> options, bool withIcons)
    {
-      repository.Items.Clear();
-      repository.Items.Add(new ImageComboBoxItem(string.Empty, string.Empty, -1));
-      foreach (var option in options)
-         repository.Items.Add(new ImageComboBoxItem(option.DisplayName, option.Name, withIcons ? _imageListRetriever.ImageIndex(option.Icon) : -1));
-
+      repository.FillImageComboBoxRepositoryWith(options.AllNames(),
+         x => imageIndex(withIcons, x),
+         x => _presenter.ExtendedPropertyDTOFor(x).DisplayName);
       return repository;
    }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 
@@ -332,6 +333,129 @@ public class When_removing_an_overwrite_parameter_set_used_only_by_a_set_with_th
    public void should_return_a_non_empty_command()
    {
       _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_setting_an_extended_property_on_a_set_that_does_not_have_it : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, "Human");
+   }
+
+   [Observation]
+   public void should_create_the_extended_property_with_the_new_value()
+   {
+      _overwriteParameterSet.ExtendedProperties.Contains(PKSimConstants.UI.Species).ShouldBeTrue();
+      _overwriteParameterSet.ExtendedProperties[PKSimConstants.UI.Species].ValueAsObject.ShouldBeEqualTo("Human");
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_setting_an_extended_property_on_a_set_that_already_has_it_with_a_different_value : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _overwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = PKSimConstants.UI.Species, Value = "Mouse" });
+   }
+
+   protected override void Because()
+   {
+      _result = sut.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, "Human");
+   }
+
+   [Observation]
+   public void should_update_the_value_of_the_existing_extended_property()
+   {
+      _overwriteParameterSet.ExtendedProperties[PKSimConstants.UI.Species].ValueAsObject.ShouldBeEqualTo("Human");
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_setting_an_extended_property_to_the_same_value_it_already_has : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _overwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = PKSimConstants.UI.Species, Value = "Human" });
+   }
+
+   protected override void Because()
+   {
+      _result = sut.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, "Human");
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_clearing_an_extended_property_with_an_empty_string : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _overwriteParameterSet.ExtendedProperties.Add(new ExtendedProperty<string> { Name = PKSimConstants.UI.Species, Value = "Human" });
+   }
+
+   protected override void Because()
+   {
+      _result = sut.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, string.Empty);
+   }
+
+   [Observation]
+   public void should_remove_the_extended_property_from_the_set()
+   {
+      _overwriteParameterSet.ExtendedProperties.Contains(PKSimConstants.UI.Species).ShouldBeFalse();
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_setting_an_absent_extended_property_to_an_empty_value : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, string.Empty);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+
+   [Observation]
+   public void should_not_add_the_extended_property_to_the_set()
+   {
+      _overwriteParameterSet.ExtendedProperties.Contains(PKSimConstants.UI.Species).ShouldBeFalse();
    }
 }
 

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -27,6 +27,10 @@ namespace PKSim.Presentation
       protected IDialogCreator _dialogCreator;
       protected ISpeciesRepository _speciesRepository;
       protected IDiseaseStateRepository _diseaseStateRepository;
+      protected DiseaseState _healthy;
+      protected DiseaseState _ckd;
+      protected Species _human;
+      protected Species _rat;
 
       protected override void Context()
       {
@@ -36,6 +40,15 @@ namespace PKSim.Presentation
          _dialogCreator = A.Fake<IDialogCreator>();
          _speciesRepository = A.Fake<ISpeciesRepository>();
          _diseaseStateRepository = A.Fake<IDiseaseStateRepository>();
+
+         _healthy = new DiseaseState { Name = "HEALTHY", DisplayName = "Healthy" };
+         _ckd = new DiseaseState { Name = "CKD", DisplayName = "Chronic Kidney Disease" };
+         A.CallTo(() => _diseaseStateRepository.All()).Returns(new[] { _healthy, _ckd });
+
+         _human = new Species { Name = "Human", DisplayName = "Human", Icon = "HumanIcon" };
+         _rat = new Species { Name = "Rat", DisplayName = "Rat", Icon = "RatIcon" };
+         A.CallTo(() => _speciesRepository.All()).Returns(new[] { _human, _rat });
+
          sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task, _dialogCreator, _speciesRepository, _diseaseStateRepository);
          sut.InitializeWith(A.Fake<ICommandCollector>());
       }
@@ -202,16 +215,6 @@ namespace PKSim.Presentation
    public class When_listing_all_known_species_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
    {
       private IReadOnlyList<ExtendedPropertyOptionDTO> _result;
-      private Species _human;
-      private Species _rat;
-
-      protected override void Context()
-      {
-         base.Context();
-         _human = new Species { Name = "Human", DisplayName = "Human", Icon = "HumanIcon" };
-         _rat = new Species { Name = "Rat", DisplayName = "Rat", Icon = "RatIcon" };
-         A.CallTo(() => _speciesRepository.All()).Returns(new[] { _human, _rat });
-      }
 
       protected override void Because()
       {
@@ -219,9 +222,9 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_return_one_option_per_species()
+      public void should_return_one_option_per_species_plus_empty()
       {
-         _result.Count.ShouldBeEqualTo(2);
+         _result.Count.ShouldBeEqualTo(3);
       }
 
       [Observation]
@@ -237,16 +240,6 @@ namespace PKSim.Presentation
    public class When_listing_all_known_disease_states_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
    {
       private IReadOnlyList<ExtendedPropertyOptionDTO> _result;
-      private DiseaseState _healthy;
-      private DiseaseState _ckd;
-
-      protected override void Context()
-      {
-         base.Context();
-         _healthy = new DiseaseState { Name = "HEALTHY", DisplayName = "Healthy" };
-         _ckd = new DiseaseState { Name = "CKD", DisplayName = "Chronic Kidney Disease" };
-         A.CallTo(() => _diseaseStateRepository.All()).Returns(new[] { _healthy, _ckd });
-      }
 
       protected override void Because()
       {
@@ -254,9 +247,9 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_return_one_option_per_disease_state()
+      public void should_return_one_option_per_disease_state_plus_empty()
       {
-         _result.Count.ShouldBeEqualTo(2);
+         _result.Count.ShouldBeEqualTo(3);
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
-using OSPSuite.Core.Commands;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -201,7 +201,7 @@ namespace PKSim.Presentation
 
    public class When_listing_all_known_species_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
    {
-      private System.Collections.Generic.IReadOnlyList<ExtendedPropertyOptionDTO> _result;
+      private IReadOnlyList<ExtendedPropertyOptionDTO> _result;
       private Species _human;
       private Species _rat;
 
@@ -227,15 +227,16 @@ namespace PKSim.Presentation
       [Observation]
       public void should_use_the_species_name_as_the_canonical_name_and_the_species_display_name_for_display()
       {
-         _result[0].Name.ShouldBeEqualTo(_human.Name);
-         _result[0].DisplayName.ShouldBeEqualTo(_human.DisplayName);
-         _result[0].Icon.ShouldBeEqualTo(_human.Icon);
+         var humanOption = _result.FirstOrDefault(x => x.Name == _human.Name);
+         humanOption.ShouldNotBeNull();
+         humanOption.DisplayName.ShouldBeEqualTo(_human.DisplayName);
+         humanOption.Icon.ShouldBeEqualTo(_human.Icon);
       }
    }
 
    public class When_listing_all_known_disease_states_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
    {
-      private System.Collections.Generic.IReadOnlyList<ExtendedPropertyOptionDTO> _result;
+      private IReadOnlyList<ExtendedPropertyOptionDTO> _result;
       private DiseaseState _healthy;
       private DiseaseState _ckd;
 
@@ -261,14 +262,17 @@ namespace PKSim.Presentation
       [Observation]
       public void should_use_the_disease_state_name_as_the_canonical_name_and_the_disease_state_display_name_for_display()
       {
-         _result[1].Name.ShouldBeEqualTo(_ckd.Name);
-         _result[1].DisplayName.ShouldBeEqualTo(_ckd.DisplayName);
+         var ckdOption = _result.FirstOrDefault(x => x.Name == _ckd.Name);
+         ckdOption.ShouldNotBeNull();
+         ckdOption.DisplayName.ShouldBeEqualTo(_ckd.DisplayName);
       }
 
       [Observation]
       public void should_not_carry_an_icon_for_disease_states()
       {
-         _result[0].Icon.ShouldBeNull();
+         var healthyOption = _result.FirstOrDefault(x => x.Name == _healthy.Name);
+         healthyOption.ShouldNotBeNull();
+         healthyOption.Icon.ShouldBeNull();
       }
    }
 

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -7,8 +7,10 @@ using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Services;
+using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.DTO.Mappers;
@@ -23,6 +25,8 @@ namespace PKSim.Presentation
       protected IOverwriteParameterSetToOverwriteParameterSetDTOMapper _mapper;
       protected IOverwriteParameterSetTask _task;
       protected IDialogCreator _dialogCreator;
+      protected ISpeciesRepository _speciesRepository;
+      protected IDiseaseStateRepository _diseaseStateRepository;
 
       protected override void Context()
       {
@@ -30,7 +34,9 @@ namespace PKSim.Presentation
          _mapper = A.Fake<IOverwriteParameterSetToOverwriteParameterSetDTOMapper>();
          _task = A.Fake<IOverwriteParameterSetTask>();
          _dialogCreator = A.Fake<IDialogCreator>();
-         sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task, _dialogCreator);
+         _speciesRepository = A.Fake<ISpeciesRepository>();
+         _diseaseStateRepository = A.Fake<IDiseaseStateRepository>();
+         sut = new OverwriteParameterSetsPresenter(_view, _mapper, _task, _dialogCreator, _speciesRepository, _diseaseStateRepository);
          sut.InitializeWith(A.Fake<ICommandCollector>());
       }
    }
@@ -190,6 +196,116 @@ namespace PKSim.Presentation
       public void should_delegate_to_the_overwrite_parameter_set_task()
       {
          A.CallTo(() => _task.SetIsDefault(_overwriteParameterSet, _compound, false)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_listing_all_known_species_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
+   {
+      private System.Collections.Generic.IReadOnlyList<ExtendedPropertyOptionDTO> _result;
+      private Species _human;
+      private Species _rat;
+
+      protected override void Context()
+      {
+         base.Context();
+         _human = new Species { Name = "Human", DisplayName = "Human", Icon = "HumanIcon" };
+         _rat = new Species { Name = "Rat", DisplayName = "Rat", Icon = "RatIcon" };
+         A.CallTo(() => _speciesRepository.All()).Returns(new[] { _human, _rat });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.AllSpecies();
+      }
+
+      [Observation]
+      public void should_return_one_option_per_species()
+      {
+         _result.Count.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_use_the_species_name_as_the_canonical_name_and_the_species_display_name_for_display()
+      {
+         _result[0].Name.ShouldBeEqualTo(_human.Name);
+         _result[0].DisplayName.ShouldBeEqualTo(_human.DisplayName);
+         _result[0].Icon.ShouldBeEqualTo(_human.Icon);
+      }
+   }
+
+   public class When_listing_all_known_disease_states_through_the_presenter : concern_for_OverwriteParameterSetsPresenter
+   {
+      private System.Collections.Generic.IReadOnlyList<ExtendedPropertyOptionDTO> _result;
+      private DiseaseState _healthy;
+      private DiseaseState _ckd;
+
+      protected override void Context()
+      {
+         base.Context();
+         _healthy = new DiseaseState { Name = "HEALTHY", DisplayName = "Healthy" };
+         _ckd = new DiseaseState { Name = "CKD", DisplayName = "Chronic Kidney Disease" };
+         A.CallTo(() => _diseaseStateRepository.All()).Returns(new[] { _healthy, _ckd });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.AllDiseaseStates();
+      }
+
+      [Observation]
+      public void should_return_one_option_per_disease_state()
+      {
+         _result.Count.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_use_the_disease_state_name_as_the_canonical_name_and_the_disease_state_display_name_for_display()
+      {
+         _result[1].Name.ShouldBeEqualTo(_ckd.Name);
+         _result[1].DisplayName.ShouldBeEqualTo(_ckd.DisplayName);
+      }
+
+      [Observation]
+      public void should_not_carry_an_icon_for_disease_states()
+      {
+         _result[0].Icon.ShouldBeNull();
+      }
+   }
+
+   public class When_constructing_an_extended_property_option_with_only_a_name : ContextSpecification<ExtendedPropertyOptionDTO>
+   {
+      protected override void Because()
+      {
+         sut = new ExtendedPropertyOptionDTO("MyOption");
+      }
+
+      [Observation]
+      public void should_default_the_display_name_to_the_name()
+      {
+         sut.DisplayName.ShouldBeEqualTo(sut.Name);
+      }
+   }
+
+   public class When_setting_an_extended_property_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         A.CallTo(() => _task.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, "Human")).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.SetExtendedProperty(_setDTO, PKSimConstants.UI.Species, "Human");
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.SetExtendedProperty(_overwriteParameterSet, _compound, PKSimConstants.UI.Species, "Human")).MustHaveHappenedOnceExactly();
       }
    }
 


### PR DESCRIPTION
## Summary

- Store Species and Disease State on `OverwriteParameterSet` via `ExtendedProperties` (extensible to future metadata fields without schema changes)
- Editable in two places: as dropdown columns in the parameter-set list, and as comboboxes in a new right-panel metadata flow group that mirrors MoBi's `IndividualBuildingBlockView` pattern
- Allowed values come from `ISpeciesRepository` / `IDiseaseStateRepository`, surfaced via a single `ExtendedPropertyOptionDTO` (Name, DisplayName, optional Icon) so storage stays canonical and domain operations always see the Name. Species shows icons; disease state hides the glyph column
- Edits flow through `IOverwriteParameterSetTask.SetExtendedProperty` and produce `SetExtendedPropertyOnOverwriteSetCommand` for undo/redo, publishing `OverwriteParameterSetChangedEvent`
- Splitter widened in favor of the parameter-set list; metadata combo editors are fixed-width with a tooltip showing the full text when truncated

Fixes #3438

## Test plan

- [x] Add a parameter set, pick Species and Disease State from the grid dropdowns, save and reopen the project — values persist
- [x] Same flow but using the right-panel metadata combos
- [x] Undo/redo of metadata edits round-trips cleanly
- [x] Empty selection clears the property (`ExtendedProperties` no longer contains it)
- [x] Disease state combo has no icon column; species combo shows the species icon
- [x] Long Disease State display names show a hover tooltip when truncated in the 200px combo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added extended property management for overwrite parameter sets, allowing custom metadata assignment
  * Introduced image-based editors for species and disease state selection with visual icons
  * Added dynamic metadata editing panel for enhanced parameter set configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->