### PR TITLE
Fixes #3534 Do not export ontogeny factor parameters in Individual snapshot

### DIFF
--- a/src/PKSim.Core/Snapshots/Mappers/IndividualMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/IndividualMapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Utility.Extensions;
@@ -48,9 +49,11 @@ namespace PKSim.Core.Snapshots.Mappers
 
       private Task<LocalizedParameter[]> allParametersChangedByUserFrom(ModelIndividual individual)
       {
-         //Expression profile parameters are exported now in the expression profile building block
-         var changedParameters = individual.GetAllChildren<IParameter>(x => !x.IsExpressionProfile() && x.ShouldExportToSnapshot());
+         var changedParameters = individual.GetAllChildren<IParameter>(changedParameterFilter);
          return _parameterMapper.LocalizedParametersFrom(changedParameters);
+
+         //Expression profile parameters and ontogeny factors are exported now in the expression profile building block
+         bool changedParameterFilter(IParameter p) => !p.IsExpressionProfile() && !p.IsExpressionOrOntogenyFactor() && p.ShouldExportToSnapshot();
       }
 
       public override async Task<ModelIndividual> MapToModel(SnapshotIndividual individualSnapshot, SnapshotContext snapshotContext)

--- a/tests/PKSim.Tests/Core/IndividualMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/IndividualMapperSpecs.cs
@@ -35,6 +35,7 @@ namespace PKSim.Core
       public Model.ExpressionProfile _expressionProfile1;
       public Model.ExpressionProfile _expressionProfile2;
       protected IParameter _parameterKidneyRelExp;
+      protected IParameter _parameterKidneyOntogenyFactorTable;
       protected List<IParameter> _mappedParameters;
 
       protected override Task Context()
@@ -58,6 +59,10 @@ namespace PKSim.Core
          _parameterKidneyRelExp.DefaultValue = 10;
          kidney.Add(_parameterKidneyRelExp);
 
+         _parameterKidneyOntogenyFactorTable = DomainHelperForSpecs.ConstantParameterWithValue().WithName(CoreConstants.Parameters.ONTOGENY_FACTOR_TABLE);
+         _parameterKidneyOntogenyFactorTable.DefaultValue = 1;
+         kidney.Add(_parameterKidneyOntogenyFactorTable);
+
          _parameterLiver.ValueDiffersFromDefault().ShouldBeFalse();
          _parameterKidney.ValueDiffersFromDefault().ShouldBeFalse();
 
@@ -65,6 +70,9 @@ namespace PKSim.Core
          _parameterKidney.ValueDiffersFromDefault().ShouldBeTrue();
          _parameterKidneyRelExp.Value = 50;
          _parameterKidneyRelExp.ValueDiffersFromDefault().ShouldBeTrue();
+         _parameterKidneyOntogenyFactorTable.Value = 2;
+         _parameterKidneyOntogenyFactorTable.IsDefault = false;
+         _parameterKidneyOntogenyFactorTable.ValueDiffersFromDefault().ShouldBeTrue();
 
          _expressionProfile1 = DomainHelperForSpecs.CreateExpressionProfile<IndividualEnzyme>(moleculeName: "Enz");
          _expressionProfile2 = DomainHelperForSpecs.CreateExpressionProfile<IndividualTransporter>(moleculeName: "Trans");
@@ -103,6 +111,12 @@ namespace PKSim.Core
       {
          _mappedParameters.ShouldContain(_parameterKidney);
          _mappedParameters.ShouldNotContain(_parameterKidneyRelExp);
+      }
+
+      [Observation]
+      public void should_not_save_ontogeny_factor_table_parameters_as_they_belong_to_the_expression_profile_building_block()
+      {
+         _mappedParameters.ShouldNotContain(_parameterKidneyOntogenyFactorTable);
       }
 
       [Observation]


### PR DESCRIPTION
## Summary
- Fixes #3534 (and the warning side of #3530)
- The Individual snapshot mapper was including ontogeny factor and ontogeny factor table parameters (e.g. `CYP3A4|Ontogeny factor table`) in the exported `Parameters` list. On reload these warned `Snapshot parameter '...' was not found in '<Individual>'`, because the parameters only exist after the expression profile is added — so the Parameter mapping step (which runs before expression profiles are attached) cannot resolve them.
- The sibling `IndividualToIndividualBuildingBlockMapper` already excludes the same parameters with the comment *"Ontogeny factor are exported also in the expression profile"*. The snapshot mapper now does the same via `IsExpressionOrOntogenyFactor()`, so ontogeny factors are exported only via the expression profile snapshot.

## Test plan
- [x] `When_mapping_an_individual_to_snapshot` (550 tests in PKSim.Core mappers pass)
- [x] New regression observation: ontogeny factor table parameter on a kidney molecule container with `IsDefault=false` is **not** included in the snapshot's `Parameters`
- [ ] Manual: reproduce the steps from #3530 (load `Individual_Volumes_orig`, scale all volumes ×2, commit individual to BB, export snapshot, reload) and confirm no `Ontogeny factor ... was not found` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot export to properly exclude expression profile and ontogeny factor parameters when saving individual configurations.

* **Tests**
  * Added test coverage to verify ontogeny factor parameters are correctly excluded from snapshot exports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->