### PR TITLE
Fixes #3537 Make PKSim.R honestly net10.0 cross-platform

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/ApplicationStartup.cs
+++ b/src/PKSim.BatchTool/ApplicationStartup.cs
@@ -6,6 +6,7 @@ using OSPSuite.Utility.Container;
 using PKSim.CLI.Core;
 using PKSim.Core;
 using PKSim.Infrastructure;
+using PKSim.Presentation.Infrastructure;
 using PresenterRegister = PKSim.Presentation.PresenterRegister;
 
 namespace PKSim.BatchTool
@@ -25,8 +26,9 @@ namespace PKSim.BatchTool
             container.AddRegister(x => x.FromType<BatchRegister>());
             container.AddRegister(x => x.FromType<CLIRegister>());
 
-            InfrastructureRegister.LoadSerializers(container);
-            InfrastructureRegister.RegisterWorkspace(container);
+            InfrastructureRegister.RegisterSerializationDependencies(container);
+            PresentationSerializerInitializer.AddPresentationSerializers(container);
+            InfrastructureRegister.LoadDefaultEntities(container);
             UI.BootStrapping.ApplicationStartup.RegisterCommands(container);
             container.RegisterImplementationOf(new DefaultLookAndFeel().LookAndFeel);
          }

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/MinimalImplementations/CLISimulationChartsLoader.cs
+++ b/src/PKSim.CLI.Core/MinimalImplementations/CLISimulationChartsLoader.cs
@@ -7,6 +7,10 @@ namespace PKSim.CLI.Core.MinimalImplementations
    {
       public void LoadChartsFor(Simulation simulation)
       {
+         // Intentionally no-op in headless CLI/R: chart loading is a Presentation-side
+         // concern (the real impl injects IChartTask from PKSim.Presentation). LazyLoadTask
+         // injects ISimulationChartsLoader unconditionally, so this stub satisfies IoC
+         // without dragging Presentation into the cross-platform R/CLI graph.
       }
    }
 }

--- a/src/PKSim.CLI.Core/MinimalImplementations/CLISimulationChartsLoader.cs
+++ b/src/PKSim.CLI.Core/MinimalImplementations/CLISimulationChartsLoader.cs
@@ -1,0 +1,12 @@
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+
+namespace PKSim.CLI.Core.MinimalImplementations
+{
+   public class CLISimulationChartsLoader : ISimulationChartsLoader
+   {
+      public void LoadChartsFor(Simulation simulation)
+      {
+      }
+   }
+}

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.114" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.113" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/ApplicationStartup.cs
+++ b/src/PKSim.CLI/ApplicationStartup.cs
@@ -10,6 +10,9 @@ using PKSim.CLI.Core.MinimalImplementations;
 using PKSim.Core;
 using PKSim.Core.Services;
 using PKSim.Infrastructure;
+using PKSim.Infrastructure.Serialization;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
+using PKSim.Infrastructure.Services;
 using CoreRegister = PKSim.Core.CoreRegister;
 using ICoreUserSettings = PKSim.Core.ICoreUserSettings;
 
@@ -37,7 +40,9 @@ namespace PKSim.CLI
             container.AddRegister(x => x.FromType<InfrastructureRegister>());
             container.AddRegister(x => x.FromType<CLIRegister>());
 
-            InfrastructureRegister.LoadSerializers(container);
+            InfrastructureRegister.RegisterSerializationDependencies(container);
+            PKSim.Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(container);
+            InfrastructureRegister.LoadDefaultEntities(container);
          }
       }
 
@@ -48,6 +53,10 @@ namespace PKSim.CLI
          container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
          container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, CLIUserSettings>(LifeStyle.Singleton);
          container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
+         container.Register<IPKSimXmlSerializerRepository, CorePKSimXmlSerializerRepository>(LifeStyle.Singleton);
+         container.Register<IWorkspacePersistor, CoreWorkspacePersistor>(LifeStyle.Singleton);
+         container.Register<IObservedDataTask, CoreObservedDataTask>();
+         container.Register<ISimulationChartsLoader, CLISimulationChartsLoader>();
       }
    }
 }

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
@@ -61,6 +61,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PKSim.CLI.Core\PKSim.CLI.Core.csproj" />
     <ProjectReference Include="..\PKSim.Infrastructure\PKSim.Infrastructure.csproj" />
+    <ProjectReference Include="..\PKSim.Presentation\PKSim.Presentation.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.114" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.113" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/IProteinExpressionDataHelper.cs
+++ b/src/PKSim.Core/Services/IProteinExpressionDataHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using System.Data;
 
-namespace PKSim.Presentation.Presenters.ProteinExpression
+namespace PKSim.Core.Services
 {
    public enum JoinType
    {

--- a/src/PKSim.Core/StartOptions.cs
+++ b/src/PKSim.Core/StartOptions.cs
@@ -3,7 +3,7 @@ using OSPSuite.Core;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Utility;
 
-namespace PKSim.Presentation
+namespace PKSim.Core
 {
    public enum StartOptionMode
    {

--- a/src/PKSim.Infrastructure/InfrastructureRegister.cs
+++ b/src/PKSim.Infrastructure/InfrastructureRegister.cs
@@ -13,8 +13,6 @@ using OSPSuite.Infrastructure.Serialization;
 using OSPSuite.Infrastructure.Serialization.ORM.History;
 using OSPSuite.Infrastructure.Serialization.ORM.MetaData;
 using OSPSuite.Infrastructure.Serialization.Services;
-using OSPSuite.Presentation.Serialization.Extensions;
-using OSPSuite.Presentation.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Events;
@@ -35,8 +33,6 @@ using PKSim.Infrastructure.Serialization;
 using PKSim.Infrastructure.Serialization.Xml;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Infrastructure.Services;
-using PKSim.Presentation;
-using IWorkspace = PKSim.Presentation.IWorkspace;
 using StringSerializer = PKSim.Infrastructure.Serialization.StringSerializer;
 
 namespace PKSim.Infrastructure
@@ -113,7 +109,6 @@ namespace PKSim.Infrastructure
          container.Register<ISerializationManager, XmlSerializationManager>();
          container.Register<IStringSerializer, StringSerializer>();
          container.Register<IStringSerializer, CompressedStringSerializer>(CoreConstants.Serialization.Compressed);
-         container.Register<IPKSimXmlSerializerRepository, PKSimXmlSerializerRepository>(LifeStyle.Singleton);
 
          container.Register(typeof(IXmlReader<>), typeof(XmlReader<>));
          container.Register(typeof(IXmlWriter<>), typeof(XmlWriter<>));
@@ -131,7 +126,6 @@ namespace PKSim.Infrastructure
 
          //Load pkml serializers
          var ospSuiteXmlSerializerRepository = container.Resolve<IOSPSuiteXmlSerializerRepository>();
-         ospSuiteXmlSerializerRepository.AddPresentationSerializers();
          ospSuiteXmlSerializerRepository.PerformMapping();
          //then load pk parameters
          loadPKParameters(container);
@@ -155,11 +149,6 @@ namespace PKSim.Infrastructure
          pKParameterLoader.Load(pkParameterRepository, pkSimConfiguration.PKParametersFilePath);
       }
 
-      public static void RegisterWorkspace(IContainer container)
-      {
-         container.Register<IWorkspace, IWithWorkspaceLayout, ICoreWorkspace, OSPSuite.Core.IWorkspace, Workspace>(LifeStyle.Singleton);
-      }
-
       private void registerORMDependencies(IContainer container)
       {
          container.Register(typeof(IDataTableToMetaDataMapper<>), typeof(DataTableToMetaDataMapper<>));
@@ -175,10 +164,10 @@ namespace PKSim.Infrastructure
             scan.ExcludeNamespaceContainingType<SpeciesRepository>();
 
             //this type will be registered using another convention
-            scan.ExcludeNamespaceContainingType<IObjectConverter>();             //Converter
-            scan.ExcludeNamespaceContainingType<IReportBuilder>();               //report builder
-            scan.ExcludeNamespaceContainingType<IMarkdownBuilder>();             //Markdown builder
-            scan.ExcludeNamespaceContainingType<PKSimXmlSerializerRepository>(); //Serializer
+            scan.ExcludeNamespaceContainingType<IObjectConverter>(); //Converter
+            scan.ExcludeNamespaceContainingType<IReportBuilder>(); //report builder
+            scan.ExcludeNamespaceContainingType<IMarkdownBuilder>(); //Markdown builder
+            scan.ExcludeNamespaceContainingType<CorePKSimXmlSerializerRepository>(); //Serializer
 
             scan.ExcludeType<CommandMetaDataRepository>();
             scan.ExcludeType<DefaultIndividualRetriever>();
@@ -188,14 +177,15 @@ namespace PKSim.Infrastructure
             scan.ExcludeType<GeneExpressionQueries>();
             scan.ExcludeType<ModelDatabase>();
             scan.ExcludeType<VersionChecker>();
-            scan.ExcludeType<Workspace>();
             scan.ExcludeType<StringSerializer>();
             scan.ExcludeType<CompressedStringSerializer>();
 
             //already registered
-            scan.ExcludeType<PKSimXmlSerializerRepository>();
+            scan.ExcludeType<CorePKSimXmlSerializerRepository>();
             scan.ExcludeType<PKSimConfiguration>();
             scan.ExcludeType<SerializationContext>();
+            scan.ExcludeType<CoreWorkspacePersistor>();
+            scan.ExcludeType<CoreObservedDataTask>();
 
             scan.WithConvention<PKSimRegistrationConvention>();
          });

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -36,14 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.113" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
   </ItemGroup>
@@ -51,7 +50,6 @@
   <ItemGroup>
     <ProjectReference Include="..\PKSim.Assets\PKSim.Assets.csproj" />
     <ProjectReference Include="..\PKSim.Core\PKSim.Core.csproj" />
-    <ProjectReference Include="..\PKSim.Presentation\PKSim.Presentation.csproj" />
   </ItemGroup>
 
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.114" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
   </ItemGroup>

--- a/src/PKSim.Infrastructure/PKSimConfiguration.cs
+++ b/src/PKSim.Infrastructure/PKSimConfiguration.cs
@@ -80,7 +80,10 @@ namespace PKSim.Infrastructure
          {
             try
             {
-               return (string) Registry.GetValue($@"HKEY_LOCAL_MACHINE\SOFTWARE\{Constants.RegistryPaths.MOBI_REG_PATH}{Major}", Constants.RegistryPaths.INSTALL_PATH, null);
+               if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                  return (string) Registry.GetValue($@"HKEY_LOCAL_MACHINE\SOFTWARE\{Constants.RegistryPaths.MOBI_REG_PATH}{Major}", Constants.RegistryPaths.INSTALL_PATH, null);
+
+               return string.Empty;
             }
             catch (Exception)
             {

--- a/src/PKSim.Infrastructure/ProjectConverter/v10/Converter9To10.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v10/Converter9To10.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Xml.Linq;
 using OSPSuite.Core.Converters.v10;
@@ -14,7 +13,6 @@ using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots.Services;
-using PKSim.Presentation;
 using static PKSim.Infrastructure.ProjectConverter.ConverterConstants.Parameters;
 
 namespace PKSim.Infrastructure.ProjectConverter.v10
@@ -23,9 +21,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v10
       IVisitor<Individual>,
       IVisitor<Population>,
       IVisitor<Simulation>,
-      IVisitor<ParameterIdentification>,
-      IVisitor<IUserSettings>
-
+      IVisitor<ParameterIdentification>
    {
       private readonly IIndividualMoleculeFactoryResolver _individualMoleculeFactoryResolver;
       private readonly IDefaultIndividualRetriever _defaultIndividualRetriever;
@@ -258,13 +254,5 @@ namespace PKSim.Infrastructure.ProjectConverter.v10
          newParameter.ValueOrigin.UpdateAllFrom(oldParameter.ValueOrigin);
       }
 
-      public void Visit(IUserSettings userSettings)
-      {
-         if (userSettings.ChartBackColor != Color.Transparent)
-            return;
-
-         userSettings.ChartBackColor = Color.White;
-         _converted = true;
-      }
    }
 }

--- a/src/PKSim.Infrastructure/Serialization/CoreWorkspacePersistor.cs
+++ b/src/PKSim.Infrastructure/Serialization/CoreWorkspacePersistor.cs
@@ -1,11 +1,10 @@
 using System;
 using System.IO;
+using NHibernate;
 using OSPSuite.Core.Journal;
 using OSPSuite.Core.Serialization;
 using OSPSuite.Infrastructure.Serialization.ORM.History;
 using OSPSuite.Infrastructure.Serialization.Services;
-using OSPSuite.Presentation.Core;
-using OSPSuite.Presentation.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Events;
 using PKSim.Assets;
@@ -15,11 +14,10 @@ using PKSim.Infrastructure.Services;
 
 namespace PKSim.Infrastructure.Serialization
 {
-   public class WorkspacePersistor : IWorkspacePersistor
+   public class CoreWorkspacePersistor : IWorkspacePersistor
    {
       private readonly IProjectPersistor _projectPersistor;
       private readonly IHistoryManagerPersistor _historyManagerPersistor;
-      private readonly IWorkspaceLayoutPersistor _workspaceLayoutPersistor;
       private readonly ISessionManager _sessionManager;
       private readonly IProgressManager _progressManager;
       private readonly IProjectFileCompressor _projectFileCompressor;
@@ -27,10 +25,9 @@ namespace PKSim.Infrastructure.Serialization
       private readonly IJournalLoader _journalLoader;
       private readonly IProjectClassifiableUpdaterAfterDeserialization _projectClassifiableUpdaterAfterDeserialization;
 
-      public WorkspacePersistor(
+      public CoreWorkspacePersistor(
          IProjectPersistor projectPersistor,
          IHistoryManagerPersistor historyManagerPersistor,
-         IWorkspaceLayoutPersistor workspaceLayoutPersistor,
          ISessionManager sessionManager,
          IProgressManager progressManager,
          IProjectFileCompressor projectFileCompressor,
@@ -40,7 +37,6 @@ namespace PKSim.Infrastructure.Serialization
       {
          _projectPersistor = projectPersistor;
          _historyManagerPersistor = historyManagerPersistor;
-         _workspaceLayoutPersistor = workspaceLayoutPersistor;
          _sessionManager = sessionManager;
          _progressManager = progressManager;
          _projectFileCompressor = projectFileCompressor;
@@ -70,8 +66,7 @@ namespace PKSim.Infrastructure.Serialization
                _historyManagerPersistor.Save(workspace.HistoryManager, session);
 
                progress.IncrementProgress(PKSimConstants.UI.SavingLayout);
-               if (workspace is IWithWorkspaceLayout withWorkspaceLayout)
-                  _workspaceLayoutPersistor.Save(withWorkspaceLayout.WorkspaceLayout, session);
+               SaveLayoutFor(workspace, session);
 
                transaction.Commit();
             }
@@ -79,7 +74,7 @@ namespace PKSim.Infrastructure.Serialization
             progress.IncrementProgress(PKSimConstants.UI.CompressionProject);
             _projectFileCompressor.Compress(fileFullPath);
 
-            //once saved, we can 
+            //once saved, we can
             _projectPersistor.UpdateProjectAfterSave(workspace.Project);
          }
 
@@ -127,21 +122,29 @@ namespace PKSim.Infrastructure.Serialization
                   workspace.Journal = journal;
 
                   progress.IncrementProgress(PKSimConstants.UI.LoadingLayout);
-                  var workspaceLayout = _workspaceLayoutPersistor.Load(session);
-                  // The workspace layout may be null if the workspace was created via CLI. In that case, we simply initialize the workspace layout
-                  if (workspace is IWithWorkspaceLayout withWorkspaceLayout)
-                     withWorkspaceLayout.WorkspaceLayout = workspaceLayout ?? new WorkspaceLayout();
-
+                  LoadLayoutFor(workspace, session);
                }
             }
             catch (Exception)
             {
-               //Exception occurs while opening the project! 
+               //Exception occurs while opening the project!
                //close the file and rethrow the exception
                _sessionManager.CloseFactory();
                throw;
             }
          }
+      }
+
+      // Override in Presentation-aware variant to save workspace layout when workspace
+      // implements IWithWorkspaceLayout. Headless variant: no-op.
+      protected virtual void SaveLayoutFor(ICoreWorkspace workspace, ISession session)
+      {
+      }
+
+      // Override in Presentation-aware variant to load workspace layout when workspace
+      // implements IWithWorkspaceLayout. Headless variant: no-op.
+      protected virtual void LoadLayoutFor(ICoreWorkspace workspace, ISession session)
+      {
       }
 
       private void verifyProjectNotReadOnly(string fileFullPath)

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/CorePKSimXmlSerializerRepository.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/CorePKSimXmlSerializerRepository.cs
@@ -1,17 +1,16 @@
 using System;
 using System.Xml.Linq;
-using OSPSuite.Utility.Extensions;
-using PKSim.Core.Model;
-using PKSim.Core.Model.PopulationAnalyses;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Core.Serialization.Xml.Extensions;
-using OSPSuite.Presentation.Serialization.Extensions;
 using OSPSuite.Serializer;
 using OSPSuite.Serializer.Attributes;
 using OSPSuite.Serializer.Xml;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
 using PKSim.Core.Snapshots.Services;
 
 namespace PKSim.Infrastructure.Serialization.Xml.Serializers
@@ -22,7 +21,7 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
       void DeserializeFormulaCache(XElement element, SerializationContext serializationContext, Type typeToDeserialize);
    }
 
-   public class PKSimXmlSerializerRepository : OSPSuiteXmlSerializerRepository, IPKSimXmlSerializerRepository
+   public class CorePKSimXmlSerializerRepository : OSPSuiteXmlSerializerRepository, IPKSimXmlSerializerRepository
    {
       protected override void AddInitialSerializer()
       {
@@ -34,7 +33,6 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          AttributeMapperRepository.AddAttributeMapper(new ObjectPathXmlAttributeMapper());
          AttributeMapperRepository.AddAttributeMapper(new SystemicProcessTypeXmlAttributeMapper());
          AttributeMapperRepository.AddAttributeMapper(new ApplicationTypeXmlAttributeMapper());
-         AttributeMapperRepository.AddAttributeMapper(new ViewLayoutXmlAttributeMapper());
          AttributeMapperRepository.AddAttributeMapper(new IconSizeAttributeMapper());
          AttributeMapperRepository.AddAttributeMapper(new DosingIntervalXmlAttributeMapper());
          AttributeMapperRepository.AddAttributeMapper(new LabelGenerationStrategyXmlAttributeMapper());
@@ -54,16 +52,13 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<InteractionType, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<LoadTemplateWithReference, SerializationContext>());
 
-         //PKSim Serializers
+         //PKSim Core serializers (IPKSimXmlSerializer implementations in PKSim.Infrastructure)
          this.AddSerializers(x =>
          {
             x.Implementing<IPKSimXmlSerializer>();
-            x.InAssemblyContainingType<PKSimXmlSerializerRepository>();
+            x.InAssemblyContainingType<CorePKSimXmlSerializerRepository>();
             x.UsingAttributeRepository(AttributeMapperRepository);
          });
-
-         //OSPSuite.Presentation serializer
-         this.AddPresentationSerializers();
       }
 
       public void SerializeFormulaCache(XElement element, SerializationContext serializationContext, Type typeToSerialize)

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ParameterGroupsPresenterSettingsXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ParameterGroupsPresenterSettingsXmlSerializer.cs
@@ -1,9 +1,0 @@
-﻿using PKSim.Presentation.Presenters.Parameters;
-using OSPSuite.Presentation.Serialization;
-
-namespace PKSim.Infrastructure.Serialization.Xml.Serializers
-{
-   public class ParameterGroupsPresenterSettingsXmlSerializer : DefaultPresentationSettingsXmlSerializer<ParameterGroupsPresenterSettings>, IPKSimXmlSerializer
-   {
-   }
-}

--- a/src/PKSim.Infrastructure/Services/CoreObservedDataTask.cs
+++ b/src/PKSim.Infrastructure/Services/CoreObservedDataTask.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using OSPSuite.Core.Commands;
-using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.ParameterIdentifications;
@@ -10,33 +8,28 @@ using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Core.Services;
-using OSPSuite.Presentation.Core;
-using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
-using PKSim.Presentation.Presenters;
 using IObservedDataTask = PKSim.Core.Services.IObservedDataTask;
 
 namespace PKSim.Infrastructure.Services
 {
-   public class ObservedDataTask : OSPSuite.Core.Domain.Services.ObservedDataTask, IObservedDataTask
+   public class CoreObservedDataTask : ObservedDataTask, IObservedDataTask
    {
-      private readonly IPKSimProjectRetriever _projectRetriever;
-      private readonly IExecutionContext _executionContext;
-      private readonly IApplicationController _applicationController;
+      protected readonly IPKSimProjectRetriever _projectRetriever;
+      protected readonly IExecutionContext _executionContext;
       private readonly ITemplateTask _templateTask;
       private readonly IParameterChangeUpdater _parameterChangeUpdater;
       private readonly IPKMLPersistor _pkmlPersistor;
       private readonly IOutputMappingMatchingTask _outputMappingMatchingTask;
 
-      public ObservedDataTask(
+      public CoreObservedDataTask(
          IPKSimProjectRetriever projectRetriever,
          IExecutionContext executionContext,
          IDialogCreator dialogCreator,
-         IApplicationController applicationController,
          IDataRepositoryExportTask dataRepositoryTask,
          ITemplateTask templateTask,
          IContainerTask containerTask,
@@ -50,22 +43,16 @@ namespace PKSim.Infrastructure.Services
       {
          _projectRetriever = projectRetriever;
          _executionContext = executionContext;
-         _applicationController = applicationController;
          _templateTask = templateTask;
          _parameterChangeUpdater = parameterChangeUpdater;
          _pkmlPersistor = pkmlPersistor;
          _outputMappingMatchingTask = outputMappingMatchingTask;
       }
 
+      // Rename requires IApplicationController + IRenameObservedDataPresenter (Presentation-only).
+      // The Presentation-aware derived ObservedDataTask overrides this. Headless variant: no-op.
       public override void Rename(DataRepository observedData)
       {
-         using (var renamePresenter = _applicationController.Start<IRenameObservedDataPresenter>())
-         {
-            if (!renamePresenter.Edit(observedData))
-               return;
-
-            _executionContext.AddToHistory(new RenameObservedDataCommand(observedData, renamePresenter.Name).Run(_executionContext));
-         }
       }
 
       public override void UpdateMolWeight(DataRepository observedData)
@@ -87,13 +74,9 @@ namespace PKSim.Infrastructure.Services
          _pkmlPersistor.SaveToPKML(observedData, file);
       }
 
-      public void LoadFromSnapshot()
+      // LoadFromSnapshot lives in the Presentation-aware derived class (needs IApplicationController).
+      public virtual void LoadFromSnapshot()
       {
-         using (var presenter = _applicationController.Start<ILoadFromSnapshotPresenter<DataRepository>>())
-         {
-            var observedData = presenter.LoadModelFromSnapshot();
-            observedData?.Each(AddObservedDataToProject);
-         }
       }
 
       public void AddObservedDataToAnalysable(IReadOnlyList<DataRepository> observedDataList, IAnalysable analysable)
@@ -151,7 +134,7 @@ namespace PKSim.Infrastructure.Services
          return usedObservedDatas.Select(observedDataFrom).ToList();
       }
 
-      private DataRepository observedDataFrom(UsedObservedData usedObservedDatas)
+      protected DataRepository observedDataFrom(UsedObservedData usedObservedDatas)
       {
          return _projectRetriever.CurrentProject.ObservedDataBy(usedObservedDatas.Id);
       }

--- a/src/PKSim.Infrastructure/Services/ProteinExpressionDataHelper.cs
+++ b/src/PKSim.Infrastructure/Services/ProteinExpressionDataHelper.cs
@@ -2,13 +2,11 @@
 using System.Collections;
 using System.Data;
 using System.Reflection;
-using PKSim.Infrastructure.ORM.Core;
+using PKSim.Core.Services;
 using PKSim.Infrastructure.ORM.DAS;
-using PKSim.Presentation.Presenters.ProteinExpression;
 
 namespace PKSim.Infrastructure.Services
 {
-  
    public class ProteinExpressionDataHelper : IProteinExpressionDataHelper
    {
       public DataTable CreateDataJoin(DataRelation dr, JoinType jt, string tableName)
@@ -37,7 +35,7 @@ namespace PKSim.Infrastructure.Services
       }
 
       /// <summary>
-      /// Fills the given data table with given object data.
+      ///    Fills the given data table with given object data.
       /// </summary>
       private static void fillData(PropertyInfo[] properties, DataTable dt, Object o)
       {
@@ -51,7 +49,7 @@ namespace PKSim.Infrastructure.Services
       }
 
       /// <summary>
-      /// All the Properties for the class array are converted to columns.
+      ///    All the Properties for the class array are converted to columns.
       /// </summary>
       private static DataTable createDataTable(PropertyInfo[] properties)
       {
@@ -67,15 +65,17 @@ namespace PKSim.Infrastructure.Services
             {
                propType = Nullable.GetUnderlyingType(propType);
             }
+
             dc.DataType = propType;
 
             dt.Columns.Add(dc);
          }
+
          return dt;
       }
 
       /// <summary>
-      /// Converts an arraylist of a class object to a data table object.
+      ///    Converts an arraylist of a class object to a data table object.
       /// </summary>
       public DataTable ConvertToDataTable(object[] array)
       {
@@ -87,9 +87,8 @@ namespace PKSim.Infrastructure.Services
          return dt;
       }
 
-   
       /// <summary>
-      /// This helping method retrieves a string collection with all distinct values of the given column.
+      ///    This helping method retrieves a string collection with all distinct values of the given column.
       /// </summary>
       public IList GetDistinctLoV(DataColumn column)
       {
@@ -101,8 +100,8 @@ namespace PKSim.Infrastructure.Services
                ret.Add(row[column].ToString());
             }
          }
+
          return ret;
       }
    }
-
 }

--- a/src/PKSim.Presentation/Infrastructure/PresentationSerializerInitializer.cs
+++ b/src/PKSim.Presentation/Infrastructure/PresentationSerializerInitializer.cs
@@ -1,0 +1,23 @@
+using OSPSuite.Core.Serialization.Xml;
+using OSPSuite.Presentation.Serialization.Extensions;
+using OSPSuite.Utility.Container;
+
+namespace PKSim.Presentation.Infrastructure
+{
+   /// <summary>
+   ///    Bridges OSPSuite.Presentation.Serialization (Windows-only) into the cross-platform
+   ///    PKSim.Infrastructure serialization pipeline. Desktop bootstraps call this between
+   ///    <see cref="PKSim.Infrastructure.InfrastructureRegister.RegisterSerializationDependencies"/>
+   ///    and <see cref="PKSim.Infrastructure.InfrastructureRegister.LoadDefaultEntities"/> so that
+   ///    Presentation serializers (e.g. ChartEditorAndDisplaySettingsXmlSerializer) are present on
+   ///    the base IOSPSuiteXmlSerializerRepository singleton before PerformMapping runs against it.
+   ///    PKSim.R and headless callers skip this step.
+   /// </summary>
+   public static class PresentationSerializerInitializer
+   {
+      public static void AddPresentationSerializers(IContainer container)
+      {
+         container.Resolve<IOSPSuiteXmlSerializerRepository>().AddPresentationSerializers();
+      }
+   }
+}

--- a/src/PKSim.Presentation/Infrastructure/Serialization/ORM/Mappers/WorkspaceLayoutMetaDataToWorkspaceLayoutMapper.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/ORM/Mappers/WorkspaceLayoutMetaDataToWorkspaceLayoutMapper.cs
@@ -3,7 +3,7 @@ using PKSim.Core.Services;
 using PKSim.Infrastructure.Serialization.ORM.MetaData;
 using OSPSuite.Presentation.Core;
 
-namespace PKSim.Infrastructure.Serialization.ORM.Mappers
+namespace PKSim.Presentation.Infrastructure.Serialization.ORM.Mappers
 {
    public interface IWorkspaceLayoutMetaDataToWorkspaceLayoutMapper : IMapper<WorkspaceLayoutMetaData, IWorkspaceLayout>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/ORM/Mappers/WorkspaceLayoutToWorkspaceLayoutMetaDataMapper.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/ORM/Mappers/WorkspaceLayoutToWorkspaceLayoutMetaDataMapper.cs
@@ -3,7 +3,7 @@ using PKSim.Infrastructure.Serialization.ORM.MetaData;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Utility;
 
-namespace PKSim.Infrastructure.Serialization.ORM.Mappers
+namespace PKSim.Presentation.Infrastructure.Serialization.ORM.Mappers
 {
    public interface IWorkspaceLayoutToWorkspaceLayoutMetaDataMapper : IMapper<IWorkspaceLayout, WorkspaceLayoutMetaData>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/WorkspaceLayoutPersistor.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/WorkspaceLayoutPersistor.cs
@@ -2,10 +2,10 @@ using System.Linq;
 using NHibernate;
 using OSPSuite.Infrastructure.Serialization;
 using OSPSuite.Presentation.Core;
-using PKSim.Infrastructure.Serialization.ORM.Mappers;
 using PKSim.Infrastructure.Serialization.ORM.MetaData;
+using PKSim.Presentation.Infrastructure.Serialization.ORM.Mappers;
 
-namespace PKSim.Infrastructure.Serialization
+namespace PKSim.Presentation.Infrastructure.Serialization
 {
    public interface IWorkspaceLayoutPersistor : ISessionPersistor<IWorkspaceLayout>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/WorkspacePersistor.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/WorkspacePersistor.cs
@@ -1,0 +1,52 @@
+using NHibernate;
+using OSPSuite.Core.Journal;
+using OSPSuite.Core.Serialization;
+using OSPSuite.Infrastructure.Serialization.ORM.History;
+using OSPSuite.Infrastructure.Serialization.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Utility.Events;
+using PKSim.Core;
+using PKSim.Infrastructure.Serialization;
+using PKSim.Infrastructure.Services;
+
+namespace PKSim.Presentation.Infrastructure.Serialization
+{
+   public class WorkspacePersistor : CoreWorkspacePersistor
+   {
+      private readonly IWorkspaceLayoutPersistor _workspaceLayoutPersistor;
+
+      public WorkspacePersistor(
+         IProjectPersistor projectPersistor,
+         IHistoryManagerPersistor historyManagerPersistor,
+         IWorkspaceLayoutPersistor workspaceLayoutPersistor,
+         ISessionManager sessionManager,
+         IProgressManager progressManager,
+         IProjectFileCompressor projectFileCompressor,
+         IDatabaseSchemaMigrator databaseSchemaMigrator,
+         IJournalLoader journalLoader,
+         IProjectClassifiableUpdaterAfterDeserialization projectClassifiableUpdaterAfterDeserialization)
+         : base(projectPersistor, historyManagerPersistor, sessionManager, progressManager,
+            projectFileCompressor, databaseSchemaMigrator, journalLoader, projectClassifiableUpdaterAfterDeserialization)
+      {
+         _workspaceLayoutPersistor = workspaceLayoutPersistor;
+      }
+
+      protected override void SaveLayoutFor(ICoreWorkspace workspace, ISession session)
+      {
+         if (workspace is IWithWorkspaceLayout withWorkspaceLayout)
+            _workspaceLayoutPersistor.Save(withWorkspaceLayout.WorkspaceLayout, session);
+      }
+
+      protected override void LoadLayoutFor(ICoreWorkspace workspace, ISession session)
+      {
+         if (workspace is not IWithWorkspaceLayout withWorkspaceLayout)
+            return;
+
+         var workspaceLayout = _workspaceLayoutPersistor.Load(session);
+         // The workspace layout may be null if the workspace was created via CLI. In that case,
+         // we simply initialize the workspace layout.
+         withWorkspaceLayout.WorkspaceLayout = workspaceLayout ?? new WorkspaceLayout();
+      }
+   }
+}

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/DirectoryMapSettingsXmlSerializer.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/DirectoryMapSettingsXmlSerializer.cs
@@ -1,6 +1,7 @@
 using OSPSuite.Presentation.Services;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
 
-namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
 {
    public class DirectoryMapSettingsXmlSerializer: BaseXmlSerializer<DirectoryMapSettings>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/DirectoryMapXmlSerializer.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/DirectoryMapXmlSerializer.cs
@@ -1,6 +1,7 @@
 using OSPSuite.Presentation.Services;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
 
-namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
 {
    public class DirectoryMapXmlSerializer : BaseXmlSerializer<DirectoryMap>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/PKSimXmlSerializerRepository.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/PKSimXmlSerializerRepository.cs
@@ -1,0 +1,27 @@
+using OSPSuite.Presentation.Serialization.Extensions;
+using OSPSuite.Serializer;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
+
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
+{
+   public class PKSimXmlSerializerRepository : CorePKSimXmlSerializerRepository
+   {
+      protected override void AddInitialSerializer()
+      {
+         base.AddInitialSerializer();
+
+         AttributeMapperRepository.AddAttributeMapper(new ViewLayoutXmlAttributeMapper());
+
+         //PKSim Presentation serializers (IPKSimXmlSerializer implementations in PKSim.Presentation)
+         this.AddSerializers(x =>
+         {
+            x.Implementing<IPKSimXmlSerializer>();
+            x.InAssemblyContainingType<PKSimXmlSerializerRepository>();
+            x.UsingAttributeRepository(AttributeMapperRepository);
+         });
+
+         //OSPSuite.Presentation serializer
+         this.AddPresentationSerializers();
+      }
+   }
+}

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/ParameterGroupsPresenterSettingsXmlSerializer.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/ParameterGroupsPresenterSettingsXmlSerializer.cs
@@ -1,0 +1,10 @@
+﻿using OSPSuite.Presentation.Serialization;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
+using PKSim.Presentation.Presenters.Parameters;
+
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
+{
+   public class ParameterGroupsPresenterSettingsXmlSerializer : DefaultPresentationSettingsXmlSerializer<ParameterGroupsPresenterSettings>, IPKSimXmlSerializer
+   {
+   }
+}

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/UserSettingsXmlSerializer.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/UserSettingsXmlSerializer.cs
@@ -2,9 +2,9 @@ using System.Xml.Linq;
 using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Serializer;
 using PKSim.Core;
-using PKSim.Presentation;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
 
-namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
 {
    public class UserSettingsXmlSerializer : BaseXmlSerializer<IUserSettings>
    {

--- a/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/ViewLayoutXmlAttributeMapper.cs
+++ b/src/PKSim.Presentation/Infrastructure/Serialization/Xml/Serializers/ViewLayoutXmlAttributeMapper.cs
@@ -1,8 +1,7 @@
-﻿using OSPSuite.Serializer.Attributes;
-using PKSim.Presentation;
-using OSPSuite.Core.Serialization.Xml;
+﻿using OSPSuite.Core.Serialization.Xml;
+using OSPSuite.Serializer.Attributes;
 
-namespace PKSim.Infrastructure.Serialization.Xml.Serializers
+namespace PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers
 {
    public class ViewLayoutXmlAttributeMapper : AttributeMapper<ViewLayout, SerializationContext>
    {

--- a/src/PKSim.Presentation/Infrastructure/Services/ChartTemplatingTask.cs
+++ b/src/PKSim.Presentation/Infrastructure/Services/ChartTemplatingTask.cs
@@ -20,7 +20,7 @@ using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.Services;
 
-namespace PKSim.Infrastructure.Services
+namespace PKSim.Presentation.Infrastructure.Services
 {
    public class ChartTemplatingTask : OSPSuite.Presentation.Services.Charts.ChartTemplatingTask, IChartTemplatingTask
    {

--- a/src/PKSim.Presentation/Infrastructure/Services/ObservedDataTask.cs
+++ b/src/PKSim.Presentation/Infrastructure/Services/ObservedDataTask.cs
@@ -1,0 +1,61 @@
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Serialization.Xml;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core;
+using PKSim.Core.Services;
+using PKSim.Infrastructure.Services;
+using PKSim.Presentation.Presenters;
+
+namespace PKSim.Presentation.Infrastructure.Services
+{
+   public class ObservedDataTask : CoreObservedDataTask
+   {
+      private readonly IApplicationController _applicationController;
+
+      public ObservedDataTask(
+         IPKSimProjectRetriever projectRetriever,
+         IExecutionContext executionContext,
+         IDialogCreator dialogCreator,
+         IApplicationController applicationController,
+         IDataRepositoryExportTask dataRepositoryTask,
+         ITemplateTask templateTask,
+         IContainerTask containerTask,
+         IParameterChangeUpdater parameterChangeUpdater,
+         IPKMLPersistor pkmlPersistor,
+         IObjectTypeResolver objectTypeResolver,
+         IOutputMappingMatchingTask outputMappingMatchingTask,
+         IConfirmationManager confirmationManager)
+         : base(projectRetriever, executionContext, dialogCreator, dataRepositoryTask, templateTask,
+            containerTask, parameterChangeUpdater, pkmlPersistor, objectTypeResolver,
+            outputMappingMatchingTask, confirmationManager)
+      {
+         _applicationController = applicationController;
+      }
+
+      public override void Rename(DataRepository observedData)
+      {
+         using (var renamePresenter = _applicationController.Start<IRenameObservedDataPresenter>())
+         {
+            if (!renamePresenter.Edit(observedData))
+               return;
+
+            _executionContext.AddToHistory(new RenameObservedDataCommand(observedData, renamePresenter.Name).Run(_executionContext));
+         }
+      }
+
+      public override void LoadFromSnapshot()
+      {
+         using (var presenter = _applicationController.Start<ILoadFromSnapshotPresenter<DataRepository>>())
+         {
+            var observedData = presenter.LoadModelFromSnapshot();
+            observedData?.Each(AddObservedDataToProject);
+         }
+      }
+   }
+}

--- a/src/PKSim.Presentation/Infrastructure/Services/SettingsLoader.cs
+++ b/src/PKSim.Presentation/Infrastructure/Services/SettingsLoader.cs
@@ -2,7 +2,7 @@ using OSPSuite.Utility;
 using PKSim.Core.Services;
 using PKSim.Presentation.Services;
 
-namespace PKSim.Infrastructure.Services
+namespace PKSim.Presentation.Infrastructure.Services
 {
    public class SettingsLoader : IStartable
    {

--- a/src/PKSim.Presentation/Infrastructure/Services/SimulationChartsLoader.cs
+++ b/src/PKSim.Presentation/Infrastructure/Services/SimulationChartsLoader.cs
@@ -6,7 +6,7 @@ using PKSim.Infrastructure.Serialization.ORM.Queries;
 using PKSim.Presentation.Services;
 using OSPSuite.Core.Domain;
 
-namespace PKSim.Infrastructure.Services
+namespace PKSim.Presentation.Infrastructure.Services
 {
    public class SimulationChartsLoader : ISimulationChartsLoader
    {

--- a/src/PKSim.Presentation/Infrastructure/Services/UserSettingsPersistor.cs
+++ b/src/PKSim.Presentation/Infrastructure/Services/UserSettingsPersistor.cs
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using PKSim.Core;
 using PKSim.Core.Services;
-using PKSim.Presentation;
+using PKSim.Infrastructure.Services;
 using PKSim.Presentation.Services;
 
-namespace PKSim.Infrastructure.Services
+namespace PKSim.Presentation.Infrastructure.Services
 {
    public class UserSettingsPersistor : SettingsPersistor<IUserSettings>, IUserSettingsPersistor
    {

--- a/src/PKSim.Presentation/Infrastructure/Workspace.cs
+++ b/src/PKSim.Presentation/Infrastructure/Workspace.cs
@@ -12,9 +12,8 @@ using OSPSuite.Utility.Events;
 using OSPSuite.Utility.FileLocker;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
-using IWorkspace = PKSim.Presentation.IWorkspace;
 
-namespace PKSim.Infrastructure
+namespace PKSim.Presentation.Infrastructure
 {
    public class Workspace : Workspace<PKSimProject>, IWorkspace
    {
@@ -36,7 +35,7 @@ namespace PKSim.Infrastructure
          IWorkspacePersistor workspacePersistor,
          IMRUProvider mruProvider,
          IHistoryManagerFactory historyManagerFactory
-         ) : base(eventPublisher,  fileLocker)
+      ) : base(eventPublisher, fileLocker)
       {
          _eventPublisher = eventPublisher;
          _journalSession = journalSession;
@@ -109,7 +108,7 @@ namespace PKSim.Infrastructure
             projectLoadAction();
             if (Project == null)
                return;
-            
+
             _eventPublisher.PublishEvent(new ProjectCreatedEvent(Project));
             _eventPublisher.PublishEvent(new ProjectLoadedEvent(Project));
          }
@@ -133,8 +132,6 @@ namespace PKSim.Infrastructure
       {
          LoadProject(() => Project = project);
       }
-
-   
 
       public bool ProjectLoaded => Project != null;
 

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -4,13 +4,10 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
-    <Authors>Open-Systems-Pharmacology</Authors>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <Version Condition="'$(Version)' == ''">13.0.0</Version>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,11 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,6 +40,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PKSim.Assets\PKSim.Assets.csproj" />
     <ProjectReference Include="..\PKSim.Core\PKSim.Core.csproj" />
+    <ProjectReference Include="..\PKSim.Infrastructure\PKSim.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Presentation/PresenterRegister.cs
+++ b/src/PKSim.Presentation/PresenterRegister.cs
@@ -5,14 +5,18 @@ using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.Comparisons;
 using OSPSuite.Presentation.Presenters.Journal;
 using OSPSuite.Presentation.Presenters.Main;
+using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.UICommands;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Format;
 using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Model;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.DTO.Mappers;
+using PKSim.Presentation.Infrastructure;
+using PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Presentation.Presenters;
 using PKSim.Presentation.Presenters.ContextMenus;
 using PKSim.Presentation.Presenters.Individuals;
@@ -105,6 +109,10 @@ namespace PKSim.Presentation
 
          container.Register<IFormatterFactory, FormatterFactory>();
 
+         //Presentation-aware overrides for Infrastructure services
+         container.Register<IPKSimXmlSerializerRepository, PKSimXmlSerializerRepository>(LifeStyle.Singleton);
+         container.Register<IWorkspace, IWithWorkspaceLayout, ICoreWorkspace, OSPSuite.Core.IWorkspace, Workspace>(LifeStyle.Singleton);
+
          Captions.SimulationPath = PKSimConstants.UI.Simulation;
          Captions.ContainerPath = PKSimConstants.UI.Organ;
          Captions.BottomCompartmentPath = PKSimConstants.UI.Compartment;
@@ -121,9 +129,12 @@ namespace PKSim.Presentation
 
          //This objects were already registered in Bootstrap
          scan.ExcludeType<ApplicationController>();
-         scan.ExcludeType<StartOptions>();
+
+         //Explicit Singleton registrations in RegisterInContainer
+         scan.ExcludeType<PKSimXmlSerializerRepository>();
+         scan.ExcludeType<Workspace>();
       }
-      
+
       protected abstract void RegisterMainViewPresenters(IContainer container);
 
       private static void registerSingleStartPresenters(IContainer container)
@@ -159,7 +170,6 @@ namespace PKSim.Presentation
 
    public class PresenterRegister : BasePresenterRegister
    {
-
       protected override void RegisterMainViewPresenters(IContainer container)
       {
          container.Register<IMainViewPresenter, PKSimMainViewPresenter>(LifeStyle.Singleton);

--- a/src/PKSim.Presentation/Presenters/ProteinExpression/MappingPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/ProteinExpression/MappingPresenter.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Data;
-using PKSim.Presentation.Views.ProteinExpression;
 using OSPSuite.Presentation.Presenters;
+using PKSim.Core.Services;
+using PKSim.Presentation.Views.ProteinExpression;
 
 namespace PKSim.Presentation.Presenters.ProteinExpression
 {
@@ -44,6 +45,5 @@ namespace PKSim.Presentation.Presenters.ProteinExpression
          dataTable.RejectChanges();
          View.Hide();
       }
-
    }
 }

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -1,15 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--
-      Temporary: PKSim.R is meant to be cross-platform net10.0, but transitively pulls
-      OSPSuite.Presentation (Windows-only) via PKSim.Infrastructure, and also pulls a
-      System.Drawing surface from PKSim.Core (PKSimColors, ColorGenerator, chart/snapshot
-      models). Once both are addressed, this TFM returns to net10.0 and the assembly
-      loads honestly on Linux / macOS .NET 10.
-      Tracked in https://github.com/Open-Systems-Pharmacology/PK-Sim/issues/3537.
-    -->
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -44,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.113" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.114" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.R/RRegister.cs
+++ b/src/PKSim.R/RRegister.cs
@@ -1,7 +1,12 @@
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Utility.Container;
 using PKSim.CLI.Core;
+using PKSim.CLI.Core.MinimalImplementations;
 using PKSim.Core;
+using PKSim.Core.Services;
+using PKSim.Infrastructure.Serialization;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
+using PKSim.Infrastructure.Services;
 using PKSim.R.Services;
 
 namespace PKSim.R
@@ -27,6 +32,10 @@ namespace PKSim.R
       private static void registerCLITypes(IContainer container)
       {
          container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
+         container.Register<IPKSimXmlSerializerRepository, CorePKSimXmlSerializerRepository>(LifeStyle.Singleton);
+         container.Register<IWorkspacePersistor, CoreWorkspacePersistor>(LifeStyle.Singleton);
+         container.Register<IObservedDataTask, CoreObservedDataTask>();
+         container.Register<ISimulationChartsLoader, CLISimulationChartsLoader>();
       }
    }
 }

--- a/src/PKSim.Starter/CLIApplicationStartup.cs
+++ b/src/PKSim.Starter/CLIApplicationStartup.cs
@@ -57,10 +57,11 @@ public class CLIApplicationStartup : ApplicationStartup
          pkSimContainer.AddRegister(x => x.FromType<CLI.Core.CLIRegister>());
 
          pkSimContainer.Register<IInteractiveSimulationRunner, InteractiveSimulationRunner>(LifeStyle.Singleton);
-         InfrastructureRegister.LoadSerializers(pkSimContainer);
+         InfrastructureRegister.RegisterSerializationDependencies(pkSimContainer);
+         PKSim.Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(pkSimContainer);
+         InfrastructureRegister.LoadDefaultEntities(pkSimContainer);
          pkSimContainer.Register<IExceptionManager, ExceptionManager>(LifeStyle.Singleton);
-         InfrastructureRegister.RegisterWorkspace(pkSimContainer);
-         
+
          pkSimContainer.Register<IMRUProvider, MRUProvider>();
 
          registerCLITypes(pkSimContainer);

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.113" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.114" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Starter/UIApplicationStartup.cs
+++ b/src/PKSim.Starter/UIApplicationStartup.cs
@@ -89,9 +89,10 @@ namespace PKSim.Starter
             pkSimContainer.AddRegister(x => x.FromType<PKSimStarterUserInterfaceRegister>());
 
             pkSimContainer.Register<IInteractiveSimulationRunner, InteractiveSimulationRunner>(LifeStyle.Singleton);
-            InfrastructureRegister.LoadSerializers(pkSimContainer);
+            InfrastructureRegister.RegisterSerializationDependencies(pkSimContainer);
+            PKSim.Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(pkSimContainer);
+            InfrastructureRegister.LoadDefaultEntities(pkSimContainer);
             pkSimContainer.Register<IExceptionManager, ExceptionManager>(LifeStyle.Singleton);
-            InfrastructureRegister.RegisterWorkspace(pkSimContainer);
          }
 
          return pkSimContainer;

--- a/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
+++ b/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
@@ -128,7 +128,9 @@ namespace PKSim.UI.BootStrapping
                RegisterCommands(container);
 
                showStatusMessage(progress, PKSimConstants.UI.RegisterSerializationDependencies);
-               InfrastructureRegister.LoadSerializers(container);
+               InfrastructureRegister.RegisterSerializationDependencies(container);
+               Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(container);
+               InfrastructureRegister.LoadDefaultEntities(container);
 
                finalizeRegistration(container);
             }
@@ -143,8 +145,7 @@ namespace PKSim.UI.BootStrapping
       /// </summary>
       private void finalizeRegistration(IContainer container)
       {
-         InfrastructureRegister.RegisterWorkspace(container);
-         //Create one instance of the invokers so that the object is available in the application 
+         //Create one instance of the invokers so that the object is available in the application
          //since the object is not created anywhere and is only used as event listener
          container.Resolve<ICloseSubjectPresenterInvoker>();
 

--- a/src/PKSim.UI/BootStrapping/PKSimApplication.cs
+++ b/src/PKSim.UI/BootStrapping/PKSimApplication.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using Microsoft.VisualBasic.ApplicationServices;
-using PKSim.Presentation;
+using PKSim.Core;
 using PKSim.Presentation.Presenters.Main;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters.Main;

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,13 +63,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.111" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,13 +63,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.113" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.114" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--
-      Temporary: tracks the TFM of PKSim.R. See note in src/PKSim.R/PKSim.R.csproj and
-      https://github.com/Open-Systems-Pharmacology/PK-Sim/issues/3537.
-    -->
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <RootNamespace>PKSim.R</RootNamespace>
@@ -21,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Core/SettingsLoaderSpecs.cs
+++ b/tests/PKSim.Tests/Core/SettingsLoaderSpecs.cs
@@ -4,8 +4,8 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Utility;
 using PKSim.Core.Services;
 using FakeItEasy;
-using PKSim.Infrastructure.Services;
 using PKSim.Presentation;
+using PKSim.Presentation.Infrastructure.Services;
 using PKSim.Presentation.Services;
 
 

--- a/tests/PKSim.Tests/Core/WorkspaceSpecs.cs
+++ b/tests/PKSim.Tests/Core/WorkspaceSpecs.cs
@@ -13,8 +13,8 @@ using OSPSuite.Utility.Events;
 using OSPSuite.Utility.FileLocker;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
-using PKSim.Infrastructure;
 using PKSim.Presentation;
+using PKSim.Presentation.Infrastructure;
 
 namespace PKSim.Core
 {

--- a/tests/PKSim.Tests/Infrastructure/ChartTemplatingTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/ChartTemplatingTaskSpecs.cs
@@ -22,6 +22,7 @@ using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Infrastructure.Services;
+using PKSim.Presentation.Infrastructure.Services;
 using PKSim.Presentation.Services;
 
 namespace PKSim.Infrastructure

--- a/tests/PKSim.Tests/Infrastructure/ObservedDataTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/ObservedDataTaskSpecs.cs
@@ -22,7 +22,7 @@ using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.Presenters.Snapshots;
 using IObservedDataTask = PKSim.Core.Services.IObservedDataTask;
-using ObservedDataTask = PKSim.Infrastructure.Services.ObservedDataTask;
+using ObservedDataTask = PKSim.Presentation.Infrastructure.Services.ObservedDataTask;
 
 namespace PKSim.Infrastructure
 {

--- a/tests/PKSim.Tests/Infrastructure/SimulationChartsLoaderSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/SimulationChartsLoaderSpecs.cs
@@ -7,7 +7,7 @@ using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Infrastructure.Serialization.ORM.MetaData;
 using PKSim.Infrastructure.Serialization.ORM.Queries;
-using PKSim.Infrastructure.Services;
+using PKSim.Presentation.Infrastructure.Services;
 using PKSim.Presentation.Services;
 using OSPSuite.Core.Domain;
 

--- a/tests/PKSim.Tests/Infrastructure/UserSettingsPersistorSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/UserSettingsPersistorSpecs.cs
@@ -5,7 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Utility;
 using PKSim.Core;
 using PKSim.Core.Services;
-using PKSim.Infrastructure.Services;
+using PKSim.Presentation.Infrastructure.Services;
 using FakeItEasy;
 using PKSim.Presentation;
 using PKSim.Presentation.Services;

--- a/tests/PKSim.Tests/Infrastructure/WorkspaceLayoutPersistorSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/WorkspaceLayoutPersistorSpecs.cs
@@ -4,9 +4,9 @@ using NHibernate;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Presentation.Core;
-using PKSim.Infrastructure.Serialization;
-using PKSim.Infrastructure.Serialization.ORM.Mappers;
 using PKSim.Infrastructure.Serialization.ORM.MetaData;
+using PKSim.Presentation.Infrastructure.Serialization;
+using PKSim.Presentation.Infrastructure.Serialization.ORM.Mappers;
 
 namespace PKSim.Infrastructure
 {

--- a/tests/PKSim.Tests/Infrastructure/WorkspacePersistorSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/WorkspacePersistorSpecs.cs
@@ -8,6 +8,7 @@ using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Infrastructure.Serialization;
 using PKSim.Infrastructure.Services;
+using PKSim.Presentation.Infrastructure.Serialization;
 using OSPSuite.Core.Journal;
 using OSPSuite.Core.Serialization;
 using OSPSuite.Infrastructure.Serialization.ORM.History;

--- a/tests/PKSim.Tests/IntegrationTests/ContextForIntegration.cs
+++ b/tests/PKSim.Tests/IntegrationTests/ContextForIntegration.cs
@@ -71,8 +71,10 @@ namespace PKSim.IntegrationTests
             userSettings.NumberOfBins = CoreConstants.DEFAULT_NUMBER_OF_BINS;
 
 
-            InfrastructureRegister.LoadSerializers(container);
-            InfrastructureRegister.RegisterWorkspace(container);
+            InfrastructureRegister.RegisterSerializationDependencies(container);
+            PKSim.Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(container);
+            InfrastructureRegister.LoadDefaultEntities(container);
+            //Workspace registration handled by PresenterRegister now (PKSim.Presentation owns Workspace).
          }
 
          //Required for usage with nunit 3

--- a/tests/PKSim.Tests/IntegrationTests/PKSimXmlSerializerRepositorySpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/PKSimXmlSerializerRepositorySpecs.cs
@@ -1,5 +1,6 @@
 using OSPSuite.BDDHelper;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
+using PKSim.Presentation.Infrastructure.Serialization.Xml.Serializers;
 
 namespace PKSim.IntegrationTests
 {

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.111" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.111" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.113" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.113" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.113" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.114" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.114" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Presentation/StartOptionsSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/StartOptionsSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Utility;
+using PKSim.Core;
 
 namespace PKSim.Presentation
 {

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.111" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.111" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.113" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.111" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.113" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.113" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.114" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.113" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.114" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.113" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.114" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<None Include="..\..\src\Db\PKSimDB.sqlite" Link="PKSimDB.sqlite">


### PR DESCRIPTION
## Summary

`PKSim.R` (and its test project) flips back from `net10.0-windows` (introduced in #3533 as a temporary measure) to honest `net10.0`. Achieved by removing `OSPSuite.Presentation.Serialization` PackageRef and `PKSim.Presentation` ProjectRef from `PKSim.Infrastructure` and physically relocating / splitting the Presentation-coupled types out of `PKSim.Infrastructure`. Follows the same approach used in MoBi#2388.

Verification:
- `dotnet nuget why src/PKSim.R/PKSim.R.csproj OSPSuite.Presentation` reports no path.
- `PKSim.R.Tests` 31/31 ✓
- `PKSim.Tests` 5092/5098 ✓ (6 pre-existing skipped)
- OSPSuite-R full test suite runs green against the locally-packed PKSim/MoBi.

## Class-by-class changes

### Relocated (moved as-is, namespace renamed `PKSim.Infrastructure.*` → `PKSim.Presentation.Infrastructure.*`)

Pure Presentation-coupled types — no Core methods worth preserving. Moved under a new `src/PKSim.Presentation/Infrastructure/` folder.

| Class | Why |
|---|---|
| `Workspace` | implements `PKSim.Presentation.IWorkspace`; depends on `IWorkspaceLayout`, `IMRUProvider` |
| `WorkspaceLayoutPersistor` | `ISessionPersistor<IWorkspaceLayout>` — UI layout |
| `WorkspaceLayoutMetaDataToWorkspaceLayoutMapper` | handles `IWorkspaceLayout` |
| `WorkspaceLayoutToWorkspaceLayoutMetaDataMapper` | same |
| `DirectoryMapSettingsXmlSerializer` | `DirectoryMapSettings` lives in `OSPSuite.Presentation.Services` |
| `DirectoryMapXmlSerializer` | `DirectoryMap` lives in `OSPSuite.Presentation.Services` |
| `ParameterGroupsPresenterSettingsXmlSerializer` | presenter-specific settings |
| `UserSettingsXmlSerializer` | `IUserSettings` lives in `PKSim.Presentation` |
| `ViewLayoutXmlAttributeMapper` | `ViewLayout` lives in `PKSim.Presentation` |
| `ChartTemplatingTask` | depends on `IChartEditorAndDisplayPresenter`, `IChartEditorPresenter`, `IApplicationController` |
| `UserSettingsPersistor` | persists `IUserSettings` |
| `SettingsLoader` | injects `IUserSettingsPersistor` (Presentation) |
| `SimulationChartsLoader` | depends on `IChartTask` (Presentation) |

### Split (Core base in `PKSim.Infrastructure`, derived in `PKSim.Presentation.Infrastructure`)

Following the MoBi pattern: rename the Core variant so the IoC convention auto-registration (`X → IX` simple-name match) doesn't collide. Bootstrap layers wire the right variant per host.

| Pair | Why split |
|---|---|
| `CorePKSimXmlSerializerRepository` + `PKSimXmlSerializerRepository` | Core base does the `IPKSimXmlSerializer` scan and PKSim attribute mappers; derived adds the Presentation `ViewLayoutXmlAttributeMapper`, scans `IPKSimXmlSerializer` impls in PKSim.Presentation, and calls `AddPresentationSerializers()` (OSPSuite.Presentation.Serialization, Windows-only). |
| `CoreWorkspacePersistor` + `WorkspacePersistor` | Core base persists project/history/journal without layout (`SaveLayoutFor`/`LoadLayoutFor` virtual no-ops); derived adds `IWorkspaceLayoutPersistor` dep and overrides the virtuals for `IWithWorkspaceLayout` workspaces. |
| `CoreObservedDataTask` + `ObservedDataTask` | Core base has the data-only methods (`ExportToPkml`, `AddObservedDataToAnalysable`, `LoadObservedDataFromTemplateAsync`, `UpdateMolWeight`, `SaveToTemplate`); derived adds `IApplicationController` and overrides `Rename`/`LoadFromSnapshot` which need `IRenameObservedDataPresenter` / `ILoadFromSnapshotPresenter<T>`. |

### Down-moved (to PKSim.Core or PKSim.CLI.Core)

| Class | New home | Why |
|---|---|---|
| `StartOptions` + `StartOptionMode` | `PKSim.Core` | Pure CLI arg parser — only used `OSPSuite.Core` / `OSPSuite.Utility`. Was always architecturally Core-shaped; lived in Presentation only by historical accident. Moving it lets `InfrastructureRegister.registerRunOptionsIn` register `IStartOptions` in `InfrastructureRegister.Initialize` (which runs before `IoC.Resolve<PKSimApplication>` in `Program.Main`). |
| `IProteinExpressionDataHelper` + `JoinType` enum | `PKSim.Core.Services` | The interface uses only `System.Data` types (cross-platform) and the enum is pure data. The concrete `ProteinExpressionDataHelper` impl stays in `PKSim.Infrastructure` because it composes with `DASHelper` from `PKSim.Infrastructure.ORM.DAS`. |
| `CLISimulationChartsLoader` (new) | `PKSim.CLI.Core/MinimalImplementations` | No-op `ISimulationChartsLoader` stub for headless flows. Charts aren't loaded in R/CLI, but `LazyLoadTask` injects `ISimulationChartsLoader`, so something needs to satisfy IoC. Joins `CLIWorkspace`, `CLIUserSettings`, `CLIIndividualOntogenyTask`. |

### Bootstrap / register changes

- **`InfrastructureRegister`** — stripped `using PKSim.Presentation;` / `using IWorkspace = PKSim.Presentation.IWorkspace;`; removed `RegisterWorkspace` (moved to `PresenterRegister`); removed `AddPresentationSerializers()` call from `LoadDefaultEntities` (now a Presentation-side step, see below); excluded `CoreWorkspacePersistor` and `CoreObservedDataTask` from the scanner (`PKSimRegistrationConvention` falls back to "first PKSim-namespace interface" so renaming alone isn't enough to avoid collision against the shared interface).
- **`PresenterRegister`** — registers the derived `PKSimXmlSerializerRepository` as singleton; registers `Workspace` against `IWorkspace, IWithWorkspaceLayout, ICoreWorkspace, OSPSuite.Core.IWorkspace`.
- **`PresentationSerializerInitializer`** (new) — small static helper in `PKSim.Presentation.Infrastructure` that calls `Resolve<IOSPSuiteXmlSerializerRepository>().AddPresentationSerializers()`. Desktop bootstraps (PKSim.UI, PKSim.Starter, PKSim.BatchTool, PKSim.CLI, ContextForIntegration) call it between `RegisterSerializationDependencies` and `LoadDefaultEntities` so the base `IOSPSuiteXmlSerializerRepository` singleton picks up Presentation serializers (e.g. `ChartEditorAndDisplaySettingsXmlSerializer`) before `PerformMapping`. PKSim.R skips this step.
- **`RRegister`** — explicitly registers `CorePKSimXmlSerializerRepository`, `CoreWorkspacePersistor`, `CoreObservedDataTask`, `CLISimulationChartsLoader` against their shared interfaces (the renamed Core variants don't auto-register via convention).
- **`PKSim.CLI.csproj`** — gained `PKSim.Presentation` ProjectRef so it can call `PresentationSerializerInitializer.AddPresentationSerializers`.
- **`PKSim.Presentation.csproj`** / **`MoBi.Presentation.csproj`** — marked `<IsPackable>false</IsPackable>`; neither is published as a NuGet package any more.

### Converter9To10

Dropped the `IVisitor<IUserSettings>` interface and the `Visit(IUserSettings)` body (it reset `ChartBackColor` to white when transparent — a Presentation-only concern). Project conversion shouldn't bridge Domain → Presentation; if the v9→v10 user-settings tweak proves necessary later it can be re-homed in a Presentation-side converter.

## Test plan

- [x] `dotnet build PKSim.sln -c Debug` — clean
- [x] `dotnet test tests/PKSim.R.Tests/PKSim.R.Tests.csproj` — 31/31 pass
- [x] `dotnet test tests/PKSim.Tests/PKSim.Tests.csproj` — 5092/5098 pass (6 pre-existing skipped)
- [x] `dotnet nuget why src/PKSim.R/PKSim.R.csproj OSPSuite.Presentation` — no path
- [x] OSPSuite-R full R test suite (sequential) — all green except 2 pre-existing `vdiffr` snapshot drifts unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to version 13.0.113 for enhanced stability and compatibility.
  * Enhanced cross-platform support by removing Windows-specific framework targeting.

* **Bug Fixes**
  * Fixed registry access handling on non-Windows platforms in configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->