### PR TITLE
Fixes #3549 IndividualBuildingBlock displays gestational age with wrong unit conversion

### DIFF
--- a/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/IndividualToIndividualBuildingBlockMapper.cs
@@ -5,6 +5,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Format;
 using PKSim.Assets;
@@ -128,11 +129,11 @@ namespace PKSim.Core.Mappers
          individual.OriginData.DiseaseStateParameters.Each(x => addOriginDataToBuildingBlock(buildingBlock, x.Name, x));
          addOriginDataToBuildingBlock(buildingBlock, PKSimConstants.UI.Species, individual.Species?.DisplayName);
          addOriginDataToBuildingBlock(buildingBlock, PKSimConstants.UI.Gender, individual.OriginData.Gender?.DisplayName);
-         addOriginDataToBuildingBlock(buildingBlock, Age, individual.OriginData.Age);
-         addOriginDataToBuildingBlock(buildingBlock, GestationalAge, individual.OriginData.GestationalAge);
-         addOriginDataToBuildingBlock(buildingBlock, Height, individual.OriginData.Height);
-         addOriginDataToBuildingBlock(buildingBlock, BMI, individual.OriginData.BMI);
-         addOriginDataToBuildingBlock(buildingBlock, Weight, individual.OriginData.Weight);
+         addOriginDataToBuildingBlock(buildingBlock, Age, individual.OriginData.Age, _dimensionRepository.AgeInYears);
+         addOriginDataToBuildingBlock(buildingBlock, GestationalAge, individual.OriginData.GestationalAge, _dimensionRepository.AgeInWeeks);
+         addOriginDataToBuildingBlock(buildingBlock, Height, individual.OriginData.Height, _dimensionRepository.Length);
+         addOriginDataToBuildingBlock(buildingBlock, BMI, individual.OriginData.BMI, _dimensionRepository.BMI);
+         addOriginDataToBuildingBlock(buildingBlock, Weight, individual.OriginData.Weight, _dimensionRepository.Mass);
          addOriginDataToBuildingBlock(buildingBlock, PKSimConstants.UI.Population, individual.OriginData.Population?.DisplayName);
 
          individual.OriginData.AllCalculationMethods().Where(cm => _calculationMethodCategoryRepository.HasMoreThanOneOption(cm, individual.Species))
@@ -147,18 +148,27 @@ namespace PKSim.Core.Mappers
          addOriginDataToBuildingBlock(buildingBlock, repInfo.DisplayName, calculationMethod.DisplayName);
       }
 
+      //Fallback for disease state parameters where the dimension is not statically known.
+      //DimensionForUnit can return an incorrect dimension when the unit name is defined in multiple dimensions.
       private void addOriginDataToBuildingBlock(IndividualBuildingBlock buildingBlock, string key, OriginDataParameter parameter)
       {
          if (parameter == null)
             return;
 
-         var displayValue = originDataFormattedForDisplay(parameter);
+         addOriginDataToBuildingBlock(buildingBlock, key, parameter, _dimensionRepository.DimensionForUnit(parameter.Unit));
+      }
+
+      private void addOriginDataToBuildingBlock(IndividualBuildingBlock buildingBlock, string key, OriginDataParameter parameter, IDimension dimension)
+      {
+         if (parameter == null)
+            return;
+
+         var displayValue = originDataFormattedForDisplay(parameter, dimension);
          addOriginDataToBuildingBlock(buildingBlock, keyForOriginDataParameter(key, parameter), $"{displayValue} {parameter.Unit}");
       }
 
-      private string originDataFormattedForDisplay(OriginDataParameter parameter)
+      private string originDataFormattedForDisplay(OriginDataParameter parameter, IDimension dimension)
       {
-         var dimension = _dimensionRepository.DimensionForUnit(parameter.Unit);
          var unit = dimension.UnitOrDefault(parameter.Unit);
          return _formatter.Format(dimension.BaseUnitValueToUnitValue(unit, parameter.Value));
       }

--- a/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/IndividualToIndividualBuildingBlockMapperSpecs.cs
@@ -81,4 +81,20 @@ namespace PKSim.IntegrationTests
          allOntogenyFactors.Count().ShouldBeEqualTo(2);
       }
    }
+
+   public class When_mapping_a_building_block_from_an_individual_with_gestational_age_in_weeks : concern_for_IndividualToIndividualBuildingBlockMapper
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         //value stored in base unit of "Age in weeks" dimension i.e. weeks
+         _individual.OriginData.GestationalAge = new OriginDataParameter(40, "week(s)");
+      }
+
+      [Observation]
+      public void should_format_gestational_age_using_the_age_in_weeks_dimension()
+      {
+         _individualBuildingBlock.OriginData["Gestational age"].ValueAsObject.ShouldBeEqualTo("40.00 week(s)");
+      }
+   }
 }


### PR DESCRIPTION
## Summary

`createIndividualBuildingBlock()` (R, MoBi) with `gestationalAge = 40` and `gestationalAgeUnit = "week(s)"` produced an `IndividualBuildingBlock` whose `gestationalAge` origin-data field read `"2087.14 week(s)"` instead of `"40.00 week(s)"`. `2087.14 = 40 * 365.25/7` — the value was being formatted as if it were `40 years`.

`OriginData.GestationalAge.Value` is correctly stored in weeks (base unit of the `Age in weeks` dimension that the `GESTATIONAL_AGE` parameter uses). The bug was in `IndividualToIndividualBuildingBlockMapper.originDataFormattedForDisplay`, which used `DimensionForUnit(parameter.Unit)` to discover the dimension for display. Because both `Age in years` and `Age in weeks` define a `week(s)` unit, and `Age in years` is registered first in `OSPSuite.Dimensions.xml`, the lookup returned `Age in years` — converting `40 [years]` to `40 * 365.25/7 = 2087.14 [weeks]` for display.

`Age` happened to work by coincidence (`year(s)` is the base unit of `Age in years`, so the conversion factor was 1).

## Fix

Pass the parameter's correct dimension explicitly to `addOriginDataToBuildingBlock` / `originDataFormattedForDisplay`, mirroring what `OriginDataMapper.MapToSnapshot` already does. In `MapFrom`, supply explicit dimensions for `Age`, `GestationalAge`, `Height`, `BMI`, `Weight`. The old dimension-less overload is retained as a fallback for `DiseaseStateParameters`, where the dimension is not statically known.

## Other affected call sites (also covered by the fix because they go through this mapper)

- `PKSim.UI.Starter/IndividualCreator.cs` — PKSim "Create Individual" dialog launched from MoBi.
- `PKSim.Core/Services/SimulationConfigurationTask.cs` — every simulation embeds an `IndividualBuildingBlock`.
- `PKSim.Presentation/UICommands/ExportIndividualToPkmlCommand.cs` — exporting an Individual to PKML.

(Display/metadata only — actual simulation values were unaffected because `IndividualParameter` values are stored in base units.)

## Related

- Discovered while reviewing Open-Systems-Pharmacology/OSPSuite-R#1931. That PR's snapshot at `tests/testthat/_snaps/utilities-mobi-individual.md` captures the buggy `* Gestational age: 2087.14 week(s)` line and will need regeneration once a new `PKSim.Core` is consumed.
- Sibling bug not covered here: `PKSim.Infrastructure/Reporting/Summary/OriginDataReportBuilder.displayValueFor` uses the same `DimensionForUnit(unit)` pattern. Only surfaces for preterm individuals in summary/TEX reports. Recommend a follow-up issue.

## Test plan

- [x] New integration spec `When_mapping_a_building_block_from_an_individual_with_gestational_age_in_weeks` asserts `"40.00 week(s)"`.
- [x] All 5 specs in `IndividualToIndividualBuildingBlockMapperSpecs.cs` pass locally on `V13` (net10.0-windows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dimension handling and formatting for individual parameters when exporting to building blocks, ensuring age, gestational age, height, BMI, and weight display with correct unit specifications.
  * Enhanced gestational age formatting to accurately apply week-based dimensions and improve data representation consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->