### PR TITLE
Fixes #3096 Automatically add observed data to simulation comparisons

### DIFF
--- a/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
+++ b/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
@@ -62,9 +62,6 @@ namespace PKSim.Core.Services
 
       public void ApplySourceCurveOptionsTo(IndividualSimulationComparison chart, IndividualSimulation simulation)
       {
-         //only consider the simulation's time profile charts so a non-time-profile chart
-         //(e.g. PredictedVsObserved, ResidualsVsTime) cannot match the lookup and propagate
-         //unintended styling to the comparison.
          var sourceCurves = simulation
             .AnalysesOfType<SimulationTimeProfileChart>()
             .SelectMany(c => c.Curves)

--- a/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
+++ b/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Chart;
+using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
+
+namespace PKSim.Core.Services
+{
+   public interface IObservedDataInComparisonTask
+   {
+      /// <summary>
+      ///    Returns the observed data repositories referenced by <paramref name="simulation" />, resolved against
+      ///    the current project.
+      /// </summary>
+      IReadOnlyList<DataRepository> ResolveObservedDataFor(Simulation simulation);
+
+      /// <summary>
+      ///    Adds the observed data referenced by all simulations in <paramref name="comparison" />
+      ///    to <paramref name="chart" />, then templates the per-column curve options from each
+      ///    simulation's own time profile analyses so the comparison adopts the user's styling.
+      /// </summary>
+      void AddObservedDataToTimeProfile(PopulationSimulationComparison comparison, TimeProfileAnalysisChart chart);
+
+      /// <summary>
+      ///    Applies the curve options from <paramref name="simulation" />'s own charts to any matching
+      ///    observation curves that already exist on <paramref name="chart" />. The caller is responsible
+      ///    for registering the observed data on the chart and creating the curves before calling this.
+      /// </summary>
+      void ApplySourceCurveOptionsTo(IndividualSimulationComparison chart, IndividualSimulation simulation);
+   }
+
+   public class ObservedDataInComparisonTask : IObservedDataInComparisonTask
+   {
+      private readonly IExecutionContext _executionContext;
+
+      public ObservedDataInComparisonTask(IExecutionContext executionContext)
+      {
+         _executionContext = executionContext;
+      }
+
+      public IReadOnlyList<DataRepository> ResolveObservedDataFor(Simulation simulation)
+      {
+         var project = _executionContext.CurrentProject;
+         return simulation.UsedObservedData
+            .Select(x => project.ObservedDataBy(x.Id))
+            .ToList();
+      }
+
+      public void AddObservedDataToTimeProfile(PopulationSimulationComparison comparison, TimeProfileAnalysisChart chart)
+      {
+         var allObservedData = comparison.AllBaseSimulations
+            .SelectMany(ResolveObservedDataFor)
+            .Distinct()
+            .ToList();
+
+         allObservedData.Each(chart.AddObservedData);
+         applyTemplatedObservationCurveOptions(comparison, chart, allObservedData);
+      }
+
+      public void ApplySourceCurveOptionsTo(IndividualSimulationComparison chart, IndividualSimulation simulation)
+      {
+         var sourceCurves = simulation.Charts.SelectMany(c => c.Curves).ToList();
+         foreach (var observation in ResolveObservedDataFor(simulation).SelectMany(x => x.ObservationColumns()))
+         {
+            var sourceCurve = sourceCurves.FirstOrDefault(c => c.PlotsColumn(observation));
+            if (sourceCurve == null) continue;
+            chart.FindCurveWithSameData(observation.BaseGrid, observation)?.CurveOptions.UpdateFrom(sourceCurve.CurveOptions);
+         }
+      }
+
+      private static void applyTemplatedObservationCurveOptions(ISimulationComparison comparison, TimeProfileAnalysisChart chart, IReadOnlyList<DataRepository> observedData)
+      {
+         var sourceCurveOptions = comparison.AllBaseSimulations
+            .SelectMany(sim => sim.AnalysesOfType<TimeProfileAnalysisChart>())
+            .SelectMany(timeProfile => timeProfile.ObservedDataCollection.ObservedDataCurveOptions())
+            .ToList();
+
+         foreach (var observation in observedData.SelectMany(x => x.ObservationColumns()))
+         {
+            var sourceOptions = sourceCurveOptions.FirstOrDefault(o => o.ColumnId == observation.Id);
+            if (sourceOptions == null) continue;
+            chart.CurveOptionsFor(observation).UpdateFrom(sourceOptions.CurveOptions);
+         }
+      }
+   }
+}

--- a/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
+++ b/src/PKSim.Core/Services/ObservedDataInComparisonTask.cs
@@ -62,7 +62,13 @@ namespace PKSim.Core.Services
 
       public void ApplySourceCurveOptionsTo(IndividualSimulationComparison chart, IndividualSimulation simulation)
       {
-         var sourceCurves = simulation.Charts.SelectMany(c => c.Curves).ToList();
+         //only consider the simulation's time profile charts so a non-time-profile chart
+         //(e.g. PredictedVsObserved, ResidualsVsTime) cannot match the lookup and propagate
+         //unintended styling to the comparison.
+         var sourceCurves = simulation
+            .AnalysesOfType<SimulationTimeProfileChart>()
+            .SelectMany(c => c.Curves)
+            .ToList();
          foreach (var observation in ResolveObservedDataFor(simulation).SelectMany(x => x.ObservationColumns()))
          {
             var sourceCurve = sourceCurves.FirstOrDefault(c => c.PlotsColumn(observation));

--- a/src/PKSim.Core/Services/SimulationAnalysisCreator.cs
+++ b/src/PKSim.Core/Services/SimulationAnalysisCreator.cs
@@ -5,6 +5,7 @@ using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Visitor;
 using PKSim.Core.Chart;
 using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
 
 namespace PKSim.Core.Services
 {
@@ -29,16 +30,24 @@ namespace PKSim.Core.Services
       private readonly IPKSimChartFactory _chartFactory;
       private readonly ICoreUserSettings _userSettings;
       private readonly ICloner _cloner;
+      private readonly IObservedDataInComparisonTask _observedDataInComparisonTask;
       private ISimulationAnalysis _simulationAnalysis;
 
-      public SimulationAnalysisCreator(IPopulationSimulationAnalysisStarter populationSimulationAnalysisStarter,
-         IExecutionContext executionContext, IContainerTask containerTask, IPKSimChartFactory chartFactory,
-         ICoreUserSettings userSettings, ICloner cloner) : base(containerTask, executionContext)
+      public SimulationAnalysisCreator(
+         IPopulationSimulationAnalysisStarter populationSimulationAnalysisStarter,
+         IExecutionContext executionContext, 
+         IContainerTask containerTask, 
+         IPKSimChartFactory chartFactory,
+         ICoreUserSettings userSettings, 
+         ICloner cloner, 
+         IObservedDataInComparisonTask observedDataInComparisonTask) : 
+         base(containerTask, executionContext)
       {
          _populationSimulationAnalysisStarter = populationSimulationAnalysisStarter;
          _chartFactory = chartFactory;
          _userSettings = userSettings;
          _cloner = cloner;
+         _observedDataInComparisonTask = observedDataInComparisonTask;
       }
 
       public ISimulationAnalysis CreateAnalysisFor(Simulation simulation)
@@ -80,6 +89,10 @@ namespace PKSim.Core.Services
       {
          var populationSimulationAnalysis =
             _populationSimulationAnalysisStarter.CreateAnalysisForPopulationSimulation(populationDataCollector, populationAnalysisType);
+
+         if (populationDataCollector is PopulationSimulationComparison comparison && populationSimulationAnalysis is TimeProfileAnalysisChart timeProfileChart)
+            _observedDataInComparisonTask.AddObservedDataToTimeProfile(comparison, timeProfileChart);
+
          AddSimulationAnalysisTo(populationDataCollector, populationSimulationAnalysis);
          return populationSimulationAnalysis;
       }

--- a/src/PKSim.Presentation/Presenters/Charts/IndividualSimulationComparisonPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Charts/IndividualSimulationComparisonPresenter.cs
@@ -43,6 +43,7 @@ namespace PKSim.Presentation.Presenters.Charts
    {
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IDialogCreator _dialogCreator;
+      private readonly IObservedDataInComparisonTask _observedDataInComparisonTask;
 
       public event EventHandler Closing = delegate { };
 
@@ -56,11 +57,13 @@ namespace PKSim.Presentation.Presenters.Charts
          IChartTemplatingTask chartTemplatingTask,
          IChartUpdater chartUpdater,
          IUserSettings userSettings,
-         IDialogCreator dialogCreator) :
+         IDialogCreator dialogCreator,
+         IObservedDataInComparisonTask observedDataInComparisonTask) :
          base(view, chartPresenterContext, chartTemplatingTask, pkAnalysisPresenter, chartTask, observedDataTask, chartUpdater, useSimulationNameToCreateCurveName: true, userSettings)
       {
          _lazyLoadTask = lazyLoadTask;
          _dialogCreator = dialogCreator;
+         _observedDataInComparisonTask = observedDataInComparisonTask;
          PresentationKey = PresenterConstants.PresenterKeys.IndividualSimulationComparisonPresenter;
          ChartEditorPresenter.SetLinkSimDataMenuItemVisibility(true);
       }
@@ -115,12 +118,6 @@ namespace PKSim.Presentation.Presenters.Charts
          return treeNodes.OfType<SimulationNode>().Select(x => x.Simulation).OfType<IndividualSimulation>();
       }
 
-      protected override void AddObservedData(IReadOnlyList<DataRepository> observedData, bool asResultOfDragAndDrop)
-      {
-         base.AddObservedData(observedData, asResultOfDragAndDrop);
-         showChartView();
-      }
-
       private void addSimulationToChart(IndividualSimulation simulation)
       {
          _lazyLoadTask.Load(simulation);
@@ -131,13 +128,24 @@ namespace PKSim.Presentation.Presenters.Charts
          ChartEditorPresenter.AddOutputMappings(simulation.OutputMappings);
          UpdateAnalysisBasedOn(simulation, simulation.DataRepository);
          _chartTemplatingTask.UpdateDefaultSettings(ChartEditorPresenter, simulation.DataRepository.ToList(), new[] {simulation}, addCurveIfNoSourceDefined: false);
+         addObservedDataFor(simulation);
          InitializeFromTemplateIfRequired();
-         showChartView();
       }
 
-      private void showChartView()
+      protected override void AddObservedData(IReadOnlyList<DataRepository> observedData, bool asResultOfDragAndDrop)
       {
-         _view.SetChartView(_chartPresenterContext.EditorAndDisplayPresenter.BaseView);
+         observedData.Each(Chart.AddObservedData);
+         base.AddObservedData(observedData, asResultOfDragAndDrop);
+      }
+
+      private void addObservedDataFor(IndividualSimulation simulation)
+      {
+         var observedData = _observedDataInComparisonTask.ResolveObservedDataFor(simulation);
+         if (!observedData.Any())
+            return;
+         
+         AddObservedData(observedData, asResultOfDragAndDrop: true);
+         _observedDataInComparisonTask.ApplySourceCurveOptionsTo(Chart, simulation);
       }
 
       protected override string NameForColumn(DataColumn dataColumn)
@@ -228,8 +236,11 @@ namespace PKSim.Presentation.Presenters.Charts
          {
             UpdateAnalysisBasedOn(s, s.DataRepository);
             //if there are no curves in the chart, we are probably just creating it programatically
-            if (isEmptyChart)
-               _chartTemplatingTask.UpdateDefaultSettings(ChartEditorPresenter, s.DataRepository.ToList(), new[] {s}, addCurveIfNoSourceDefined: false);
+            if (!isEmptyChart)
+               return;
+
+            _chartTemplatingTask.UpdateDefaultSettings(ChartEditorPresenter, s.DataRepository.ToList(), new[] {s}, addCurveIfNoSourceDefined: false);
+            addObservedDataFor(s);
          });
       }
 

--- a/src/PKSim.Presentation/Services/SimulationComparisonTask.cs
+++ b/src/PKSim.Presentation/Services/SimulationComparisonTask.cs
@@ -14,6 +14,7 @@ using PKSim.Core;
 using PKSim.Core.Chart;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots.Mappers;
 using PKSim.Presentation.Presenters.PopulationAnalyses;
@@ -32,6 +33,7 @@ namespace PKSim.Presentation.Services
       private readonly ISimulationAnalysisCreator _simulationAnalysisCreator;
       private readonly IDialogCreator _dialogCreator;
       private readonly SimulationComparisonMapper _simulationComparisonMapper;
+      private readonly IObservedDataInComparisonTask _observedDataInComparisonTask;
 
       public SimulationComparisonTask(
          IPKSimChartFactory chartFactory,
@@ -42,7 +44,8 @@ namespace PKSim.Presentation.Services
          IExecutionContext executionContext,
          ISimulationAnalysisCreator simulationAnalysisCreator,
          IDialogCreator dialogCreator,
-         SimulationComparisonMapper simulationComparisonMapper
+         SimulationComparisonMapper simulationComparisonMapper,
+         IObservedDataInComparisonTask observedDataInComparisonTask
       )
       {
          _chartFactory = chartFactory;
@@ -54,6 +57,7 @@ namespace PKSim.Presentation.Services
          _simulationAnalysisCreator = simulationAnalysisCreator;
          _dialogCreator = dialogCreator;
          _simulationComparisonMapper = simulationComparisonMapper;
+         _observedDataInComparisonTask = observedDataInComparisonTask;
       }
 
       public ISimulationComparison CreateIndividualSimulationComparison(IndividualSimulation individualSimulation = null)
@@ -61,7 +65,10 @@ namespace PKSim.Presentation.Services
          var simulationComparison = _chartFactory.CreateIndividualSimulationComparison();
          addComparisonToProject(simulationComparison);
          if (individualSimulation != null && individualSimulation.HasResults)
+         {
             simulationComparison.AddSimulation(individualSimulation);
+            _observedDataInComparisonTask.ResolveObservedDataFor(individualSimulation).Each(simulationComparison.AddObservedData);
+         }
 
          return simulationComparison;
       }
@@ -103,6 +110,9 @@ namespace PKSim.Presentation.Services
          {
             if (!presenter.Edit(simulationComparison))
                return;
+
+            simulationComparison.Analyses.OfType<TimeProfileAnalysisChart>()
+               .Each(analysis => _observedDataInComparisonTask.AddObservedDataToTimeProfile(simulationComparison, analysis));
 
             _executionContext.ProjectChanged();
             var presenterWasOpen = _applicationController.HasPresenterOpenedFor(simulationComparison);

--- a/src/PKSim.Presentation/Views/Charts/IIndividualSimulationComparisonView.cs
+++ b/src/PKSim.Presentation/Views/Charts/IIndividualSimulationComparisonView.cs
@@ -1,5 +1,3 @@
-using System;
-using OSPSuite.Presentation.Core;
 using PKSim.Presentation.Presenters.Charts;
 
 namespace PKSim.Presentation.Views.Charts

--- a/src/PKSim.UI/Views/Charts/SimulationAnalysisChartView.cs
+++ b/src/PKSim.UI/Views/Charts/SimulationAnalysisChartView.cs
@@ -1,10 +1,9 @@
 ﻿using OSPSuite.Assets;
-using PKSim.Presentation.Presenters.Charts;
-using PKSim.Presentation.Views.Charts;
-using OSPSuite.Presentation;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
+using PKSim.Presentation.Presenters.Charts;
+using PKSim.Presentation.Views.Charts;
 
 namespace PKSim.UI.Views.Charts
 {

--- a/tests/PKSim.Tests/Presentation/IndividualSimulationComparisonPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/IndividualSimulationComparisonPresenterSpecs.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
-using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
@@ -38,13 +39,13 @@ namespace PKSim.Presentation
       protected ILazyLoadTask _lazyLoadTask;
       protected IChartEditorLayoutTask _chartLayoutTask;
       protected IChartTemplatingTask _chartTemplatingTask;
-      protected IDataColumnToPathElementsMapper _dataColumnToPathElementsMapper;
       protected IProjectRetriever _projectRetriever;
       protected IUserSettings _userSettings;
       private ChartPresenterContext _chartPresenterContext;
       private ICurveNamer _curveNamer;
       private IChartUpdater _chartUpdateTask;
       protected IDialogCreator _dialogCreator;
+      protected IObservedDataInComparisonTask _observedDataInComparisonTask;
 
       protected override void Context()
       {
@@ -57,12 +58,12 @@ namespace PKSim.Presentation
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _chartLayoutTask = A.Fake<IChartEditorLayoutTask>();
          _chartTemplatingTask = A.Fake<IChartTemplatingTask>();
-         _dataColumnToPathElementsMapper = A.Fake<IDataColumnToPathElementsMapper>();
          _projectRetriever = A.Fake<IProjectRetriever>();
          _chartPresenterContext = A.Fake<ChartPresenterContext>();
          _chartUpdateTask = A.Fake<IChartUpdater>();
          _userSettings = A.Fake<IUserSettings>();
          _dialogCreator = A.Fake<IDialogCreator>();
+         _observedDataInComparisonTask = A.Fake<IObservedDataInComparisonTask>();
          A.CallTo(() => _chartPresenterContext.EditorAndDisplayPresenter).Returns(_chartPresenter);
          A.CallTo(() => _chartPresenterContext.CurveNamer).Returns(_curveNamer);
          A.CallTo(() => _chartPresenterContext.EditorLayoutTask).Returns(_chartLayoutTask);
@@ -70,7 +71,7 @@ namespace PKSim.Presentation
          A.CallTo(() => _chartPresenterContext.ProjectRetriever).Returns(_projectRetriever);
 
          sut = new IndividualSimulationComparisonPresenter(_view, _chartPresenterContext, _pkAnalysisPresenter,
-            _chartTask, _observedDataTask, _lazyLoadTask, _chartTemplatingTask, _chartUpdateTask, _userSettings, _dialogCreator);
+            _chartTask, _observedDataTask, _lazyLoadTask, _chartTemplatingTask, _chartUpdateTask, _userSettings, _dialogCreator, _observedDataInComparisonTask);
       }
    }
 
@@ -94,9 +95,10 @@ namespace PKSim.Presentation
          sut.InitializeAnalysis(_individualSimulationComparison);
          _simulation = A.Fake<IndividualSimulation>();
          A.CallTo(() => _simulation.HasResults).Returns(true);
-         var simulationNode = new SimulationNode(new ClassifiableSimulation {Subject = _simulation});
+         A.CallTo(() => _simulation.UsedObservedData).Returns(Enumerable.Empty<UsedObservedData>());
+         var simulationNode = new SimulationNode(new ClassifiableSimulation { Subject = _simulation });
          _dropEventArgs = A.Fake<IDragEvent>();
-         A.CallTo(() => _dropEventArgs.Data<IReadOnlyList<ITreeNode>>()).Returns(new List<SimulationNode> {simulationNode});
+         A.CallTo(() => _dropEventArgs.Data<IReadOnlyList<ITreeNode>>()).Returns(new List<SimulationNode> { simulationNode });
       }
 
       protected override void Because()
@@ -120,6 +122,99 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_adding_a_simulation_with_observed_data_to_the_summary_chart : concern_for_IndividualSimulationComparisonPresenter
+   {
+      private IDragEvent _dropEventArgs;
+      private IndividualSimulation _simulation;
+      private IndividualSimulationComparison _individualSimulationComparison;
+      private DataRepository _observedData;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualSimulationComparison = new IndividualSimulationComparison();
+         sut.InitializeAnalysis(_individualSimulationComparison);
+
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _simulation = new IndividualSimulation
+         {
+            DataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim")
+         };
+         A.CallTo(() => _observedDataInComparisonTask.ResolveObservedDataFor(_simulation)).Returns(new List<DataRepository> { _observedData });
+
+         var simulationNode = new SimulationNode(new ClassifiableSimulation { Subject = _simulation });
+         _dropEventArgs = A.Fake<IDragEvent>();
+         A.CallTo(() => _dropEventArgs.Data<IReadOnlyList<ITreeNode>>()).Returns(new List<SimulationNode> { simulationNode });
+      }
+
+      protected override void Because()
+      {
+         sut.DragDrop(this, _dropEventArgs);
+      }
+
+      [Observation]
+      public void should_register_the_observed_data_on_the_chart()
+      {
+         _individualSimulationComparison.UsesObservedData(_observedData).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_create_curves_for_the_observation_columns_of_the_observed_data()
+      {
+         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<bool>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_delegate_source_curve_options_templating_to_the_service()
+      {
+         A.CallTo(() => _observedDataInComparisonTask.ApplySourceCurveOptionsTo(_individualSimulationComparison, _simulation)).MustHaveHappened();
+      }
+   }
+
+   public class When_editing_an_empty_individual_simulation_comparison_whose_simulation_has_observed_data : concern_for_IndividualSimulationComparisonPresenter
+   {
+      private IndividualSimulation _simulation;
+      private IndividualSimulationComparison _individualSimulationComparison;
+      private DataRepository _observedData;
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _simulation = new IndividualSimulation
+         {
+            DataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim")
+         };
+         A.CallTo(() => _observedDataInComparisonTask.ResolveObservedDataFor(_simulation)).Returns(new List<DataRepository> { _observedData });
+
+         _individualSimulationComparison = new IndividualSimulationComparison();
+         _individualSimulationComparison.AddSimulation(_simulation);
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_individualSimulationComparison);
+      }
+
+      [Observation]
+      public void should_register_the_observed_data_on_the_chart()
+      {
+         _individualSimulationComparison.UsesObservedData(_observedData).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_create_curves_for_the_observation_columns_of_the_observed_data()
+      {
+         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<bool>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_delegate_source_curve_options_templating_to_the_service()
+      {
+         A.CallTo(() => _observedDataInComparisonTask.ApplySourceCurveOptionsTo(_individualSimulationComparison, _simulation)).MustHaveHappened();
+      }
+   }
+
    public class When_adding_a_simulation_to_the_summary_without_results : concern_for_IndividualSimulationComparisonPresenter
    {
       private IDragEvent _dropEventArgs;
@@ -134,9 +229,9 @@ namespace PKSim.Presentation
          sut.InitializeAnalysis(_individualSimulationComparison);
          _simulation = A.Fake<IndividualSimulation>().WithName("test");
          A.CallTo(() => _simulation.HasResults).Returns(false);
-         var simulationNode = new SimulationNode(new ClassifiableSimulation {Subject = _simulation});
+         var simulationNode = new SimulationNode(new ClassifiableSimulation { Subject = _simulation });
          _dropEventArgs = A.Fake<IDragEvent>();
-         A.CallTo(() => _dropEventArgs.Data<IReadOnlyList<ITreeNode>>()).Returns(new List<SimulationNode> {simulationNode});
+         A.CallTo(() => _dropEventArgs.Data<IReadOnlyList<ITreeNode>>()).Returns(new List<SimulationNode> { simulationNode });
       }
 
       protected override void Because()
@@ -179,7 +274,6 @@ namespace PKSim.Presentation
       }
    }
 
-
    public class When_editing_an_individual_simulation_comparison_without_any_predefined_curves_in_a_simulation : concern_for_IndividualSimulationComparisonPresenter
    {
       private IndividualSimulationComparison _individualSimulationComparison;
@@ -188,7 +282,7 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
-         _simulation= new IndividualSimulation
+         _simulation = new IndividualSimulation
          {
             DataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim")
          };
@@ -241,5 +335,4 @@ namespace PKSim.Presentation
          A.CallTo(() => _chartTemplatingTask.UpdateDefaultSettings(_chartPresenter.EditorPresenter, A<IReadOnlyCollection<DataColumn>>._, A<IReadOnlyCollection<IndividualSimulation>>._, false, null)).MustNotHaveHappened();
       }
    }
-
 }

--- a/tests/PKSim.Tests/Presentation/ObservedDataInComparisonTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ObservedDataInComparisonTaskSpecs.cs
@@ -1,0 +1,169 @@
+using System.Drawing;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Chart;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Domain.UnitSystem;
+using PKSim.Core;
+using PKSim.Core.Chart;
+using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
+using PKSim.Core.Services;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_ObservedDataInComparisonTask : ContextSpecification<IObservedDataInComparisonTask>
+   {
+      protected IExecutionContext _executionContext;
+      protected PKSimProject _project;
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _project = new PKSimProject();
+         A.CallTo(() => _executionContext.CurrentProject).Returns(_project);
+
+         sut = new ObservedDataInComparisonTask(_executionContext);
+      }
+   }
+
+   public class When_adding_observed_data_to_a_time_profile_analysis : concern_for_ObservedDataInComparisonTask
+   {
+      private PopulationSimulationComparison _comparison;
+      private PopulationSimulation _populationSimulation;
+      private DataRepository _observedData;
+      private TimeProfileAnalysisChart _targetChart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _project.AddObservedData(_observedData);
+
+         _populationSimulation = new PopulationSimulation().WithName("popSim");
+         _populationSimulation.AddUsedObservedData(_observedData);
+
+         _comparison = new PopulationSimulationComparison();
+         _comparison.AddSimulation(_populationSimulation);
+
+         _targetChart = new TimeProfileAnalysisChart();
+      }
+
+      protected override void Because()
+      {
+         sut.AddObservedDataToTimeProfile(_comparison, _targetChart);
+      }
+
+      [Observation]
+      public void should_register_the_observed_data_referenced_by_the_compared_simulations()
+      {
+         _targetChart.UsesObservedData(_observedData).ShouldBeTrue();
+      }
+   }
+
+   public class When_adding_observed_data_with_existing_source_curve_options : concern_for_ObservedDataInComparisonTask
+   {
+      private PopulationSimulationComparison _comparison;
+      private PopulationSimulation _populationSimulation;
+      private DataRepository _observedData;
+      private TimeProfileAnalysisChart _targetChart;
+      private CurveOptions _sourceCurveOptions;
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _project.AddObservedData(_observedData);
+
+         _populationSimulation = new PopulationSimulation().WithName("popSim");
+         _populationSimulation.AddUsedObservedData(_observedData);
+
+         //source: a time profile analysis on the simulation that already plots the observed
+         //data with non-default styling.
+         var sourceAnalysis = new TimeProfileAnalysisChart();
+         sourceAnalysis.AddObservedData(_observedData);
+         _sourceCurveOptions = sourceAnalysis.CurveOptionsFor(_observedData.ObservationColumns().First());
+         _sourceCurveOptions.Color = Color.Red;
+         _sourceCurveOptions.LineStyle = LineStyles.Dash;
+         _populationSimulation.AddAnalysis(sourceAnalysis);
+
+         _comparison = new PopulationSimulationComparison();
+         _comparison.AddSimulation(_populationSimulation);
+
+         _targetChart = new TimeProfileAnalysisChart();
+      }
+
+      protected override void Because()
+      {
+         sut.AddObservedDataToTimeProfile(_comparison, _targetChart);
+      }
+
+      [Observation]
+      public void should_template_the_curve_options_from_the_source_time_profile_analysis()
+      {
+         var curveOptions = _targetChart.CurveOptionsFor(_observedData.ObservationColumns().First());
+         curveOptions.Color.ShouldBeEqualTo(Color.Red);
+         curveOptions.LineStyle.ShouldBeEqualTo(LineStyles.Dash);
+      }
+   }
+
+   public class When_applying_source_curve_options_to_an_individual_comparison : concern_for_ObservedDataInComparisonTask
+   {
+      private IndividualSimulation _simulation;
+      private DataRepository _observedData;
+      private IndividualSimulationComparison _targetChart;
+      private IDimensionFactory _dimensionFactory;
+
+      protected override void Context()
+      {
+         base.Context();
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _project.AddObservedData(_observedData);
+
+         _dimensionFactory = A.Fake<IDimensionFactory>();
+
+         _simulation = new IndividualSimulation
+         {
+            DataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim")
+         };
+         _simulation.AddUsedObservedData(_observedData);
+
+         //source: a time profile chart on the simulation that already plots the observed data
+         //with non-default styling.
+         var observation = _observedData.ObservationColumns().First();
+         var sourceChart = new SimulationTimeProfileChart();
+         var sourceCurve = new Curve();
+         sourceCurve.SetxData(_observedData.BaseGrid, _dimensionFactory);
+         sourceCurve.SetyData(observation, _dimensionFactory);
+         //useAxisDefault: false so the axis default doesn't overwrite the styling we set below.
+         sourceChart.AddCurve(sourceCurve, useAxisDefault: false);
+         sourceCurve.Color = Color.Red;
+         sourceCurve.LineStyle = LineStyles.Dash;
+         _simulation.AddAnalysis(sourceChart);
+
+         //target: the comparison chart with a curve already in place for the observation column.
+         _targetChart = new IndividualSimulationComparison();
+         var targetCurve = new Curve();
+         targetCurve.SetxData(_observedData.BaseGrid, _dimensionFactory);
+         targetCurve.SetyData(observation, _dimensionFactory);
+         _targetChart.AddCurve(targetCurve, useAxisDefault: false);
+      }
+
+      protected override void Because()
+      {
+         sut.ApplySourceCurveOptionsTo(_targetChart, _simulation);
+      }
+
+      [Observation]
+      public void should_apply_the_source_curve_options_to_the_observation_curve()
+      {
+         var observation = _observedData.ObservationColumns().First();
+         var curve = _targetChart.FindCurveWithSameData(observation.BaseGrid, observation);
+         curve.Color.ShouldBeEqualTo(Color.Red);
+         curve.LineStyle.ShouldBeEqualTo(LineStyles.Dash);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationAnalysisCreatorSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationAnalysisCreatorSpecs.cs
@@ -1,15 +1,14 @@
-﻿using OSPSuite.BDDHelper;
+﻿using FakeItEasy;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
-using OSPSuite.Utility.Events;
-using FakeItEasy;
-using PKSim.Core;
-using PKSim.Core.Chart;
-using PKSim.Core.Events;
-using PKSim.Core.Model;
-using PKSim.Core.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
+using PKSim.Core;
+using PKSim.Core.Chart;
+using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
+using PKSim.Core.Services;
 using SimulationAnalysisCreator = PKSim.Core.Services.SimulationAnalysisCreator;
 
 namespace PKSim.Presentation
@@ -22,6 +21,7 @@ namespace PKSim.Presentation
       protected IPKSimChartFactory _chartFactory;
       protected ICoreUserSettings _userSettings;
       protected ICloner _cloner;
+      protected IObservedDataInComparisonTask _observedDataInComparisonTask;
 
       protected override void Context()
       {
@@ -31,9 +31,10 @@ namespace PKSim.Presentation
          _chartFactory = A.Fake<IPKSimChartFactory>();
          _userSettings = A.Fake<ICoreUserSettings>();
          _cloner = A.Fake<ICloner>();
+         _observedDataInComparisonTask = A.Fake<IObservedDataInComparisonTask>();
 
          sut = new SimulationAnalysisCreator(_populationSimulationAnalysisStarter, _executionContext,
-            _containerTask, _chartFactory, _userSettings, _cloner);
+            _containerTask, _chartFactory, _userSettings, _cloner, _observedDataInComparisonTask);
       }
    }
 
@@ -51,13 +52,12 @@ namespace PKSim.Presentation
          _simulation = new IndividualSimulation();
          _chart = new SimulationTimeProfileChart();
          A.CallTo(() => _chartFactory.CreateChartFor<SimulationTimeProfileChart>(_simulation)).Returns(_chart);
-         _chart1 = new SimulationTimeProfileChart {Name = "Results 1"};
-         _chart2 = new SimulationTimeProfileChart {Name = "My Results"};
+         _chart1 = new SimulationTimeProfileChart { Name = "Results 1" };
+         _chart2 = new SimulationTimeProfileChart { Name = "My Results" };
          _simulation.AddAnalysis(_chart1);
          _simulation.AddAnalysis(_chart2);
          A.CallTo(_containerTask).WithReturnType<string>().Returns("Results 3");
-         A.CallTo(() => _executionContext.PublishEvent(A<SimulationAnalysisCreatedEvent>.Ignored)).Invokes(
-            x => _plotEvent = x.GetArgument<SimulationAnalysisCreatedEvent>(0));
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationAnalysisCreatedEvent>.Ignored)).Invokes(x => _plotEvent = x.GetArgument<SimulationAnalysisCreatedEvent>(0));
       }
 
       protected override void Because()
@@ -105,6 +105,81 @@ namespace PKSim.Presentation
       public void should_start_the_analyses_selection()
       {
          A.CallTo(() => _populationSimulationAnalysisStarter.CreateAnalysisForPopulationSimulation(_populationDataCollector, _userSettings.DefaultPopulationAnalysis)).MustHaveHappened();
+      }
+   }
+
+   public class When_creating_a_time_profile_analysis_for_a_population_simulation_comparison : concern_for_SimulationAnalysisCreator
+   {
+      private PopulationSimulationComparison _comparison;
+      private TimeProfileAnalysisChart _timeProfileChart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _comparison = new PopulationSimulationComparison();
+         _timeProfileChart = new TimeProfileAnalysisChart();
+         A.CallTo(() => _populationSimulationAnalysisStarter.CreateAnalysisForPopulationSimulation(_comparison, PopulationAnalysisType.TimeProfile)).Returns(_timeProfileChart);
+      }
+
+      protected override void Because()
+      {
+         sut.CreatePopulationAnalysisFor(_comparison, PopulationAnalysisType.TimeProfile);
+      }
+
+      [Observation]
+      public void should_apply_observed_data_templating_to_the_new_analysis()
+      {
+         A.CallTo(() => _observedDataInComparisonTask.AddObservedDataToTimeProfile(_comparison, _timeProfileChart)).MustHaveHappened();
+      }
+   }
+
+   public class When_creating_a_box_whisker_analysis_for_a_population_simulation_comparison : concern_for_SimulationAnalysisCreator
+   {
+      private PopulationSimulationComparison _comparison;
+      private BoxWhiskerAnalysisChart _boxWhiskerChart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _comparison = new PopulationSimulationComparison();
+         _boxWhiskerChart = new BoxWhiskerAnalysisChart();
+         A.CallTo(() => _populationSimulationAnalysisStarter.CreateAnalysisForPopulationSimulation(_comparison, PopulationAnalysisType.BoxWhisker)).Returns(_boxWhiskerChart);
+      }
+
+      protected override void Because()
+      {
+         sut.CreatePopulationAnalysisFor(_comparison, PopulationAnalysisType.BoxWhisker);
+      }
+
+      [Observation]
+      public void should_not_attempt_to_template_observed_data_on_a_non_time_profile_analysis()
+      {
+         A.CallTo(_observedDataInComparisonTask).MustNotHaveHappened();
+      }
+   }
+
+   public class When_creating_a_time_profile_analysis_for_a_standalone_population_simulation : concern_for_SimulationAnalysisCreator
+   {
+      private PopulationSimulation _populationSimulation;
+      private TimeProfileAnalysisChart _timeProfileChart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _populationSimulation = new PopulationSimulation();
+         _timeProfileChart = new TimeProfileAnalysisChart();
+         A.CallTo(() => _populationSimulationAnalysisStarter.CreateAnalysisForPopulationSimulation(_populationSimulation, PopulationAnalysisType.TimeProfile)).Returns(_timeProfileChart);
+      }
+
+      protected override void Because()
+      {
+         sut.CreatePopulationAnalysisFor(_populationSimulation, PopulationAnalysisType.TimeProfile);
+      }
+
+      [Observation]
+      public void should_not_attempt_to_template_observed_data_when_the_data_collector_is_not_a_comparison()
+      {
+         A.CallTo(_observedDataInComparisonTask).MustNotHaveHappened();
       }
    }
 

--- a/tests/PKSim.Tests/Presentation/SimulationComparisonTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationComparisonTaskSpecs.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Services;
 using OSPSuite.Core.Snapshots.Mappers;
@@ -14,6 +15,7 @@ using PKSim.Core;
 using PKSim.Core.Chart;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
+using PKSim.Core.Model.PopulationAnalyses;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots;
 using PKSim.Core.Snapshots.Mappers;
@@ -36,6 +38,7 @@ namespace PKSim.Presentation
       protected IDialogCreator _dialogCreator;
       protected IndividualSimulationComparison _individualSimulationComparison;
       protected SimulationComparisonMapper _simulationComparisonMapper;
+      protected IObservedDataInComparisonTask _observedDataInComparisonTask;
 
       protected override void Context()
       {
@@ -49,6 +52,7 @@ namespace PKSim.Presentation
          _simulationAnalysisCreator = A.Fake<ISimulationAnalysisCreator>();
          _dialogCreator = A.Fake<IDialogCreator>();
          _simulationComparisonMapper = A.Fake<SimulationComparisonMapper>();
+         _observedDataInComparisonTask = A.Fake<IObservedDataInComparisonTask>();
          A.CallTo(() => _executionContext.CurrentProject).Returns(_project);
 
          _individualSimulationComparison = new IndividualSimulationComparison().WithName("chart");
@@ -62,7 +66,8 @@ namespace PKSim.Presentation
             _executionContext,
             _simulationAnalysisCreator,
             _dialogCreator,
-            _simulationComparisonMapper
+            _simulationComparisonMapper,
+            _observedDataInComparisonTask
          );
       }
    }
@@ -75,8 +80,7 @@ namespace PKSim.Presentation
       {
          base.Context();
          A.CallTo(() => _chartFactory.CreateIndividualSimulationComparison()).Returns(_individualSimulationComparison);
-         A.CallTo(() => _executionContext.PublishEvent(A<SimulationComparisonCreatedEvent>.Ignored)).Invokes(
-            x => _event = x.GetArgument<SimulationComparisonCreatedEvent>(0));
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationComparisonCreatedEvent>.Ignored)).Invokes(x => _event = x.GetArgument<SimulationComparisonCreatedEvent>(0));
       }
 
       protected override void Because()
@@ -95,6 +99,38 @@ namespace PKSim.Presentation
       {
          _event.SimulationComparison.ShouldBeEqualTo(_individualSimulationComparison);
          _event.Project.ShouldBeEqualTo(_project);
+      }
+   }
+
+   public class When_creating_an_individual_simulation_comparison_for_a_simulation_with_observed_data : concern_for_SimulationComparisonTask
+   {
+      private IndividualSimulation _simulation;
+      private DataRepository _observedData;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _chartFactory.CreateIndividualSimulationComparison()).Returns(_individualSimulationComparison);
+
+         _observedData = DomainHelperForSpecs.ObservedData("obs");
+         _project.AddObservedData(_observedData);
+
+         _simulation = new IndividualSimulation();
+         _simulation.AddUsedObservedData(_observedData);
+         _simulation.DataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim");
+
+         A.CallTo(() => _observedDataInComparisonTask.ResolveObservedDataFor(_simulation)).Returns(new[] { _observedData });
+      }
+
+      protected override void Because()
+      {
+         sut.CreateIndividualSimulationComparison(_simulation);
+      }
+
+      [Observation]
+      public void should_register_the_simulations_observed_data_on_the_chart()
+      {
+         _individualSimulationComparison.UsesObservedData(_observedData).ShouldBeTrue();
       }
    }
 
@@ -195,17 +231,57 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_configuring_a_population_simulation_comparison_with_an_existing_time_profile_analysis : concern_for_SimulationComparisonTask
+   {
+      private PopulationSimulationComparison _populationSimulationComparison;
+      private ISimulationSelectionForComparisonPresenter _selectionPresenter;
+      private TimeProfileAnalysisChart _timeProfileAnalysis;
+      private BoxWhiskerAnalysisChart _boxWhiskerAnalysis;
+
+      protected override void Context()
+      {
+         base.Context();
+         _selectionPresenter = A.Fake<ISimulationSelectionForComparisonPresenter>();
+         A.CallTo(() => _applicationController.Start<ISimulationSelectionForComparisonPresenter>()).Returns(_selectionPresenter);
+
+         _timeProfileAnalysis = new TimeProfileAnalysisChart();
+         _boxWhiskerAnalysis = new BoxWhiskerAnalysisChart();
+         _populationSimulationComparison = new PopulationSimulationComparison();
+         _populationSimulationComparison.AddAnalysis(_timeProfileAnalysis);
+         _populationSimulationComparison.AddAnalysis(_boxWhiskerAnalysis);
+
+         A.CallTo(() => _selectionPresenter.Edit(_populationSimulationComparison)).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.ConfigurePopulationSimulationComparison(_populationSimulationComparison);
+      }
+
+      [Observation]
+      public void should_re_template_the_time_profile_analysis_against_the_current_simulation_selection()
+      {
+         A.CallTo(() => _observedDataInComparisonTask.AddObservedDataToTimeProfile(_populationSimulationComparison, _timeProfileAnalysis)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_touch_other_population_analysis_types()
+      {
+         A.CallTo(() => _observedDataInComparisonTask.AddObservedDataToTimeProfile(_populationSimulationComparison, A<TimeProfileAnalysisChart>.That.Not.IsEqualTo(_timeProfileAnalysis))).MustNotHaveHappened();
+      }
+   }
+
    public class When_the_user_decides_to_delete_some_simulation_comparisons : concern_for_SimulationComparisonTask
    {
       protected override void Because()
       {
-         sut.Delete(new[] {_individualSimulationComparison,});
+         sut.Delete(new[] { _individualSimulationComparison, });
       }
 
       [Observation]
       public void the_user_should_be_asked_to_confirm_the_deletion()
       {
-         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] {_individualSimulationComparison.Name}), ViewResult.Yes)).MustHaveHappened();
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] { _individualSimulationComparison.Name }), ViewResult.Yes)).MustHaveHappened();
       }
    }
 
@@ -214,13 +290,13 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] {_individualSimulationComparison.Name}), ViewResult.Yes)).Returns(ViewResult.No);
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] { _individualSimulationComparison.Name }), ViewResult.Yes)).Returns(ViewResult.No);
          _project.AddSimulationComparison(_individualSimulationComparison);
       }
 
       protected override void Because()
       {
-         sut.Delete(new[] {_individualSimulationComparison,});
+         sut.Delete(new[] { _individualSimulationComparison, });
       }
 
       [Observation]
@@ -237,15 +313,14 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] {_individualSimulationComparison.Name}), ViewResult.Yes)).Returns(ViewResult.Yes);
-         A.CallTo(() => _executionContext.PublishEvent(A<SimulationComparisonDeletedEvent>.Ignored)).Invokes(
-            x => _comparisonDeletedEvent = x.GetArgument<SimulationComparisonDeletedEvent>(0));
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(PKSimConstants.UI.ReallyDeleteSimulationComparisons(new[] { _individualSimulationComparison.Name }), ViewResult.Yes)).Returns(ViewResult.Yes);
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationComparisonDeletedEvent>.Ignored)).Invokes(x => _comparisonDeletedEvent = x.GetArgument<SimulationComparisonDeletedEvent>(0));
          _project.AddSimulationComparison(_individualSimulationComparison);
       }
 
       protected override void Because()
       {
-         sut.Delete(new[] {_individualSimulationComparison,});
+         sut.Delete(new[] { _individualSimulationComparison, });
       }
 
       [Observation]
@@ -274,8 +349,8 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
-         var snapshot  =new SimulationComparison();
-         _clone =new IndividualSimulationComparison();
+         var snapshot = new SimulationComparison();
+         _clone = new IndividualSimulationComparison();
          A.CallTo(() => _simulationComparisonMapper.MapToSnapshot(_individualSimulationComparison)).Returns(snapshot);
          A.CallTo(() => _simulationComparisonMapper.MapToModel(snapshot, A<SnapshotContext>._)).Returns(_clone);
       }
@@ -283,7 +358,7 @@ namespace PKSim.Presentation
       [Observation]
       public async Task should_use_the_snapshot_to_create_a_snapshot_and_a_brand_new_instance_of_the_comparison()
       {
-         var clone =  await sut.CloneSimulationComparision(_individualSimulationComparison);
+         var clone = await sut.CloneSimulationComparision(_individualSimulationComparison);
          clone.ShouldBeEqualTo(_clone);
       }
    }


### PR DESCRIPTION
## Summary

When a simulation is added to an individual or population simulation comparison, the comparison now automatically displays the observed data the simulation references — instead of requiring the user to re-drag every observed data set from the building block tree.

Curve styling for observed data is also templated from each simulation's own time-profile chart, so colors/line styles/symbols carry over.

## Implementation

Centralized in a new `IObservedDataInComparisonTask` (PKSim.Core) so every entry point goes through the same logic:

| Entry point | What triggers the auto-add |
|---|---|
| `SimulationComparisonTask.CreateIndividualSimulationComparison(sim)` | resolves simulation's observed data and registers it on the new chart |
| `IndividualSimulationComparisonPresenter` drag-drop / open | registers on chart + creates editor curves + templates source curve options |
| `SimulationComparisonTask.CreatePopulationSimulationComparison` (via the creator) | default time-profile analysis gets data + templated `ObservedDataCurveOptions` |
| `SimulationAnalysisCreator.CreatePopulationAnalysisFor(comparison, TimeProfile)` | every later "Add time profile analysis" on an existing comparison gets the same treatment |
| `SimulationComparisonTask.ConfigurePopulationSimulationComparison` | re-templates existing time-profile analyses after a sim-selection change |

Other population analysis types (BoxWhisker, Scatter, Range) are deliberately left alone — they don't render observed data.

The first source curve encountered wins on color (first-sim-wins for shared observed data). User customizations are preserved.

## Test plan

- [x] Unit tests pass (`ObservedDataInComparisonTaskSpecs`, `SimulationAnalysisCreatorSpecs`, `SimulationComparisonTaskSpecs`, `IndividualSimulationComparisonPresenterSpecs`)
- [x] Manual: drag an individual sim with observed data into a new comparison — observed data curves appear with sim's source styling
- [x] Manual: create an individual comparison from a sim that uses observed data — data shown when comparison opens
- [x] Manual: create a new population comparison with sims that use observed data — default time-profile analysis includes the data
- [x] Manual: add a second time-profile analysis to an existing population comparison — observed data added there too
- [x] Manual: reconfigure a population comparison to include a new sim — existing time-profile analyses pick up its observed data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observed data is now automatically resolved and included in individual and population simulation comparisons and time‑profile analyses.
  * Curve styling from source analyses is preserved and templated onto matching observation curves in comparison charts.

* **Tests**
  * Added comprehensive specs covering observed‑data registration, curve templating, and applying source curve options in comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->