### PR TITLE
Fixes #3554 Preserve untouched entries on overwrite parameter set update commit

### DIFF
--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -71,7 +71,7 @@ namespace PKSim.Core.Services
 
          var command = commitInfo.ShouldCreateNew
             ? createNewSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues)
-            : updateExistingSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues, simulation, commitInfo.ParameterPaths);
+            : updateExistingSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues, simulation, commitInfo.ParameterPaths, parameterCache);
 
          command.Run(_executionContext);
 
@@ -105,24 +105,18 @@ namespace PKSim.Core.Services
 
       /// <summary>
       ///    Creates a macro command that updates existing OverwriteParameterSets (identified by <paramref name="setName" />)
-      ///    in both the simulation and template compounds. Parameters that were previously in the set but are no longer
-      ///    tracked (i.e., reset by the user) are removed from the set.
+      ///    in both the simulation and template compounds. Parameters that were previously in the set but have been
+      ///    reset by the user (no longer differ from their original/default value) are removed from the set. Entries
+      ///    the user has not touched since the previous commit are preserved.
       /// </summary>
-      /// <param name="simulationCompound">The compound used in the simulation whose OverwriteParameterSet will be updated.</param>
-      /// <param name="templateCompound">The project template compound whose corresponding OverwriteParameterSet will be updated.</param>
-      /// <param name="setName">Name of the existing OverwriteParameterSet to update in both compounds.</param>
-      /// <param name="parameterValues">The new parameter values to apply to the set.</param>
-      /// <param name="simulation">The simulation, used to check which paths are still tracked.</param>
-      /// <param name="parameterPaths">The parameter paths being committed, used to determine which paths the user has reset.</param>
-      /// <returns>A macro command containing the update commands for both compounds.</returns>
       private PKSimMacroCommand updateExistingSetsCommand(Compound simulationCompound, Compound templateCompound, string setName,
-         List<ParameterValue> parameterValues, Simulation simulation, IReadOnlyList<string> parameterPaths)
+         List<ParameterValue> parameterValues, Simulation simulation, IReadOnlyList<string> parameterPaths, PathCache<IParameter> parameterCache)
       {
          var command = new PKSimMacroCommand();
 
          var existingSimulationSet = simulationCompound.OverwriteParameterSets.FindByName(setName);
          var existingTemplateSet = templateCompound.OverwriteParameterSets.FindByName(setName);
-         var pathsToRemove = pathsResetByUser(existingSimulationSet, parameterPaths, simulation);
+         var pathsToRemove = pathsResetByUser(existingSimulationSet, parameterPaths, simulation, parameterCache);
 
          command.Add(new UpdateOverwriteParameterSetCommand(existingSimulationSet, simulationCompound, parameterValues, pathsToRemove));
          command.Add(new UpdateOverwriteParameterSetCommand(existingTemplateSet, templateCompound, parameterValues, pathsToRemove));
@@ -150,16 +144,31 @@ namespace PKSim.Core.Services
       }
 
       /// <summary>
-      ///    When updating an existing set, find paths that were in the set but are no longer tracked
-      ///    (i.e., the user reset those parameters). These should be removed from the set.
+      ///    When updating an existing set, find entries the user has reset to the parameter's original value.
+      ///    An entry is considered reset when the user is not committing the path, the path is no longer tracked
+      ///    as changed, and the simulation parameter's current value no longer matches the value stored in the
+      ///    set. Entries the user has not touched (parameter value still matches the set's stored value) are
+      ///    preserved so that they are not stripped from the set on a subsequent update commit.
       /// </summary>
-      private IReadOnlyList<string> pathsResetByUser(OverwriteParameterSet existingSet, IReadOnlyList<string> parameterPaths, Simulation simulation)
+      private IReadOnlyList<string> pathsResetByUser(OverwriteParameterSet existingSet, IReadOnlyList<string> parameterPaths,
+         Simulation simulation, PathCache<IParameter> parameterCache)
       {
          var committedPaths = new HashSet<string>(parameterPaths);
 
          return existingSet.ParameterValues
+            .Where(pv =>
+            {
+               var path = pv.Path.PathAsString;
+               if (committedPaths.Contains(path))
+                  return false;
+               if (simulation.ParameterChangeTracker.IsTracked(path))
+                  return false;
+               var parameter = parameterCache[path];
+               if (parameter == null)
+                  return false;
+               return !ValueComparer.AreValuesEqual(parameter.Value, pv.Value.GetValueOrDefault());
+            })
             .Select(pv => pv.Path.PathAsString)
-            .Where(path => !committedPaths.Contains(path) && !simulation.ParameterChangeTracker.IsTracked(path))
             .ToList();
       }
    }

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -167,13 +167,17 @@ namespace PKSim.Core.Services
             .Where(pv =>
             {
                var path = pv.Path.PathAsString;
+               //user is committing this path: it will be re-added with a new value, not reset
                if (committedPaths.Contains(path))
                   return false;
+               //path is still tracked as changed: user has uncommitted changes for it, not reset
                if (simulation.ParameterChangeTracker.IsTracked(path))
                   return false;
                var parameter = parameterCache[path];
+               //parameter is no longer present in the simulation: preserve the stored entry
                if (parameter == null)
                   return false;
+               //parameter's current value no longer matches the value stored in the set: user has reset it
                return !ValueComparer.AreValuesEqual(parameter.Value, pv.Value.GetValueOrDefault());
             })
             .Select(pv => pv.Path.PathAsString)

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -109,6 +109,14 @@ namespace PKSim.Core.Services
       ///    reset by the user (no longer differ from their original/default value) are removed from the set. Entries
       ///    the user has not touched since the previous commit are preserved.
       /// </summary>
+      /// <param name="simulationCompound">The compound used in the simulation whose OverwriteParameterSet will be updated.</param>
+      /// <param name="templateCompound">The project template compound whose corresponding OverwriteParameterSet will be updated.</param>
+      /// <param name="setName">Name of the existing OverwriteParameterSet to update in both compounds.</param>
+      /// <param name="parameterValues">The new parameter values to apply to the set.</param>
+      /// <param name="simulation">The simulation, used to check which paths are still tracked.</param>
+      /// <param name="parameterPaths">The parameter paths being committed, used to determine which paths the user has reset.</param>
+      /// <param name="parameterCache">Cache of simulation parameters, used to compare current values against the set's stored values when detecting resets.</param>
+      /// <returns>A macro command containing the update commands for both compounds.</returns>
       private PKSimMacroCommand updateExistingSetsCommand(Compound simulationCompound, Compound templateCompound, string setName,
          List<ParameterValue> parameterValues, Simulation simulation, IReadOnlyList<string> parameterPaths, PathCache<IParameter> parameterCache)
       {

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -164,6 +164,161 @@ namespace PKSim.Core
       {
          _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
       }
+
+      [Observation]
+      public void should_preserve_existing_entries_for_parameters_no_longer_present_in_the_simulation()
+      {
+         _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
+         _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
+      }
+   }
+
+   public class When_committing_a_tracked_parameter_to_an_existing_set_with_other_untouched_entries : concern_for_CommitSimulationParametersTask
+   {
+      private OverwriteParameterSet _simulationExistingSet;
+      private OverwriteParameterSet _templateExistingSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         //Permeability is in the existing set with the same value the simulation parameter currently holds (7.2),
+         //modelling a parameter that was previously committed and has not been touched since.
+         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
+         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
+         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
+
+         _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
+         _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
+         _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
+
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+      }
+
+      protected override void Because()
+      {
+         sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
+         {
+            TemplateCompoundId = _templateCompound.Id,
+            ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity" },
+            OverwriteParameterSetName = "ExistingSet",
+            ShouldCreateNew = false
+         });
+      }
+
+      [Observation]
+      public void should_preserve_the_existing_untouched_entry_in_the_simulation_set()
+      {
+         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_preserve_the_existing_untouched_entry_in_the_template_set()
+      {
+         _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_add_the_newly_committed_entry_to_the_simulation_set()
+      {
+         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
+      }
+   }
+
+   public class When_committing_to_an_existing_set_after_user_has_reset_a_parameter_in_that_set : concern_for_CommitSimulationParametersTask
+   {
+      private OverwriteParameterSet _simulationExistingSet;
+      private OverwriteParameterSet _templateExistingSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         //Permeability is in the existing set with stored value 99.0. The simulation's Permeability parameter is
+         //at 7.2 — different from the stored value and not tracked — which models a parameter the user has reset
+         //since the previous commit.
+         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
+         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 99.0 });
+         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
+
+         _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
+         _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 99.0 });
+         _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
+
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+      }
+
+      protected override void Because()
+      {
+         sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
+         {
+            TemplateCompoundId = _templateCompound.Id,
+            ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity" },
+            OverwriteParameterSetName = "ExistingSet",
+            ShouldCreateNew = false
+         });
+      }
+
+      [Observation]
+      public void should_remove_the_reset_entry_from_the_simulation_set()
+      {
+         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_remove_the_reset_entry_from_the_template_set()
+      {
+         _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_add_the_newly_committed_entry_to_the_simulation_set()
+      {
+         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
+      }
+   }
+
+   public class When_committing_to_an_existing_set_with_an_unchecked_tracked_parameter : concern_for_CommitSimulationParametersTask
+   {
+      private OverwriteParameterSet _simulationExistingSet;
+
+      protected override void Context()
+      {
+         base.Context();
+         //Permeability is tracked AND in the existing set with the same stored value, but the user unchecks it in
+         //the commit dialog (it is not in ParameterPaths). The entry should be preserved as-is rather than removed.
+         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
+         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
+         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
+
+         var templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
+         templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
+         _templateCompound.AddOverwriteParameterSet(templateExistingSet);
+
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Permeability");
+      }
+
+      protected override void Because()
+      {
+         sut.CommitParametersToCompound(_simulation, new CompoundCommitInfo
+         {
+            TemplateCompoundId = _templateCompound.Id,
+            ParameterPaths = new[] { "Organism|Aspirin|Lipophilicity" },
+            OverwriteParameterSetName = "ExistingSet",
+            ShouldCreateNew = false
+         });
+      }
+
+      [Observation]
+      public void should_preserve_the_unchecked_tracked_entry()
+      {
+         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_keep_the_unchecked_path_tracked()
+      {
+         _simulation.ParameterChangeTracker.IsTracked("Organism|Aspirin|Permeability").ShouldBeTrue();
+      }
    }
 
    public class When_committing_and_a_parameter_cannot_be_resolved : concern_for_CommitSimulationParametersTask


### PR DESCRIPTION
## Summary

- `CommitSimulationParametersTask.pathsResetByUser` flagged every existing entry whose path was not currently in the change tracker for removal. That conflated "user reset the parameter" with "parameter was committed in a previous round and untracked at that time," so subsequent update commits stripped all prior entries from the set.
- Threaded the simulation's parameter cache through to `pathsResetByUser` and now treat an entry as reset only when the simulation parameter's current value no longer matches the stored set value (and the path is neither tracked nor being recommitted). Untouched entries pass the value comparison and remain in the set.

Fixes #3554.

## Test plan

- [x] Manual: commit a tracked parameter to an existing OverwriteParameterSet, then track another parameter and update-commit the same set; confirm the first parameter's entry remains.
- [x] Manual: reset a parameter that is in an existing set, then update-commit; confirm the reset entry is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update logic now removes parameter entries the user reset while preserving untouched or unchecked entries; comparisons are value-aware so removals only occur when stored values truly differ from current parameter values.

* **Tests**
  * Added scenarios for partial commits, user resets, and unchecked tracked parameters to validate preservation and removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->