### PR TITLE
Fixes #3530 Modified distributed parameters not exported to snapshot

### DIFF
--- a/src/PKSim.Core/Services/ParameterSetUpdater.cs
+++ b/src/PKSim.Core/Services/ParameterSetUpdater.cs
@@ -117,8 +117,12 @@ namespace PKSim.Core.Services
       {
          var updateCommands = new PKSimMacroCommand {CommandType = PKSimConstants.Command.CommandTypeEdit, ObjectType = PKSimConstants.ObjectTypes.Parameter};
 
-         //should update non distributed parameters first and then distributed parameter
-         foreach (var sourceParameter in sourceParameters.KeyValues.OrderBy(x => x.Value.IsDistributed()))
+         //Process distributed parameters first. Writing a distributed parameter's value implicitly updates its
+         //percentile child (DistributedParameter.Value setter), so the child compare-equal afterwards and gets
+         //skipped. If we processed the child first instead, writing the percentile would change the parent's
+         //computed Value, the parent would then compare-equal and skip its own update — leaving the parent
+         //with IsDefault=true, which keeps it out of snapshot export (see #3530).
+         foreach (var sourceParameter in sourceParameters.KeyValues.OrderByDescending(x => x.Value.IsDistributed()))
          {
             var targetParameter = targetParameters[sourceParameter.Key];
             if (targetParameter == null)

--- a/src/PKSim.Core/Services/ParameterUpdater.cs
+++ b/src/PKSim.Core/Services/ParameterUpdater.cs
@@ -100,9 +100,11 @@ namespace PKSim.Core.Services
 
       private ICommand setDistributionValue(IParameter sourceParameter, IDistributedParameter targetParameter)
       {
-         //distributed to distributed
+         //distributed to distributed: force the update when the source is fixed, otherwise the parent parameter's
+         //areValuesEqual check short-circuits after the percentile child has already been written and the parent
+         //never gets its IsFixedValue/IsDefault flags updated (see #3530)
          if (sourceParameter is IDistributedParameter sourceDistributedParameter)
-            return setParameterValue(sourceDistributedParameter, targetParameter, false);
+            return setParameterValue(sourceDistributedParameter, targetParameter, forceUpdate: sourceDistributedParameter.IsFixedValue);
 
          //source parameter it not distributed. Is the formula a table parameter? In that case, we are most likely
          //updating from simulation table parameter to distributed parameter in individual

--- a/src/PKSim.Core/Services/ParameterUpdater.cs
+++ b/src/PKSim.Core/Services/ParameterUpdater.cs
@@ -100,11 +100,9 @@ namespace PKSim.Core.Services
 
       private ICommand setDistributionValue(IParameter sourceParameter, IDistributedParameter targetParameter)
       {
-         //distributed to distributed: force the update when the source is fixed, otherwise the parent parameter's
-         //areValuesEqual check short-circuits after the percentile child has already been written and the parent
-         //never gets its IsFixedValue/IsDefault flags updated (see #3530)
+         //distributed to distributed
          if (sourceParameter is IDistributedParameter sourceDistributedParameter)
-            return setParameterValue(sourceDistributedParameter, targetParameter, forceUpdate: sourceDistributedParameter.IsFixedValue);
+            return setParameterValue(sourceDistributedParameter, targetParameter, false);
 
          //source parameter it not distributed. Is the formula a table parameter? In that case, we are most likely
          //updating from simulation table parameter to distributed parameter in individual
@@ -121,13 +119,13 @@ namespace PKSim.Core.Services
 
       private ICommand setParameterValue(IParameter sourceParameter, IParameter targetParameter, bool forceUpdate)
       {
-         //If the parameter we are updating from is a default parameter, the target parameter should either remain as is (default or not default)
-         bool shouldUpdateDefaultState = !sourceParameter.IsDefault;
-
          //Always update the default value of the target parameter
          targetParameter.DefaultValue = sourceParameter.DefaultValue;
          if (!forceUpdate && areValuesEqual(targetParameter, sourceParameter))
          {
+            //If the parameter we are updating from is a default parameter, the target parameter should either remain as is (default or not default)
+            bool shouldUpdateDefaultState = !sourceParameter.IsDefault;
+
             //same value but not same display unit, simply update the display unit
             if (areDisplayUnitsEqual(targetParameter, sourceParameter))
                return null;
@@ -135,14 +133,17 @@ namespace PKSim.Core.Services
             return _parameterTask.SetParameterDisplayUnit(targetParameter, sourceParameter.DisplayUnit, shouldUpdateDefaultState);
          }
 
-         var setValueCommand = _parameterTask.SetParameterValue(targetParameter, sourceParameter.Value, shouldUpdateDefaultState);
+         //When we reach this branch we are explicitly writing a value to the target (either values differ or forceUpdate
+         //was requested). The target should become non-default regardless of the source's IsDefault flag, otherwise
+         //a snapshot export of the template would miss the change (see #3530).
+         var setValueCommand = _parameterTask.SetParameterValue(targetParameter, sourceParameter.Value, shouldUpdateDefaultStateAndValueOriginForDefaultParameter: true);
 
          //Only value differs
          if (areDisplayUnitsEqual(targetParameter, sourceParameter))
             return setValueCommand;
 
          //in that case, we create a macro command that updates value and unit
-         var setDisplayUnitCommand = _parameterTask.SetParameterDisplayUnit(targetParameter, sourceParameter.DisplayUnit, shouldUpdateDefaultState);
+         var setDisplayUnitCommand = _parameterTask.SetParameterDisplayUnit(targetParameter, sourceParameter.DisplayUnit, shouldUpdateDefaultStateAndValueOriginForDefaultParameter: true);
          var macroCommand = new PKSimMacroCommand {CommandType = setValueCommand.CommandType, ObjectType = setValueCommand.ObjectType, Description = PKSimConstants.Command.SetParameterValueAndDisplayUnitDescription};
          macroCommand.Add(setValueCommand);
          macroCommand.Add(setDisplayUnitCommand);

--- a/src/PKSim.Core/Services/ParameterUpdater.cs
+++ b/src/PKSim.Core/Services/ParameterUpdater.cs
@@ -142,7 +142,10 @@ namespace PKSim.Core.Services
          if (areDisplayUnitsEqual(targetParameter, sourceParameter))
             return setValueCommand;
 
-         //in that case, we create a macro command that updates value and unit
+         //in that case, we create a macro command that updates value and unit. Passing true here is symmetric with
+         //the setValueCommand above and a no-op in practice — the value command has already cleared IsDefault on
+         //the target, so withUpdatedDefaultStateAndValue short-circuits regardless. Keeping the flag explicit
+         //protects this branch if the order of operations is ever rearranged.
          var setDisplayUnitCommand = _parameterTask.SetParameterDisplayUnit(targetParameter, sourceParameter.DisplayUnit, shouldUpdateDefaultStateAndValueOriginForDefaultParameter: true);
          var macroCommand = new PKSimMacroCommand {CommandType = setValueCommand.CommandType, ObjectType = setValueCommand.ObjectType, Description = PKSimConstants.Command.SetParameterValueAndDisplayUnitDescription};
          macroCommand.Add(setValueCommand);

--- a/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
@@ -129,4 +129,52 @@ namespace PKSim.IntegrationTests
          _result.IsEmpty().ShouldBeFalse();
       }
    }
+
+   public class When_updating_a_distributed_organ_volume_in_a_simulation_in_the_template_building_block : concern_for_SimulationParametersToBuildingBlockUpdater
+   {
+      private IParameter _templateFatVolume;
+      private IParameter _simulationFatVolume;
+      private double _originalFatVolumeValue;
+      private double _newFatVolumeValue;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _simulationFatVolume = _simulation.Individual.Organism.Organ(FAT).Parameter(VOLUME);
+         _templateFatVolume = _templateIndividual.Organism.Organ(FAT).Parameter(VOLUME);
+
+         _originalFatVolumeValue = _simulationFatVolume.Value;
+         _newFatVolumeValue = _originalFatVolumeValue * 3;
+         _simulationFatVolume.Value = _newFatVolumeValue;
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateParametersFromSimulationInBuildingBlock(_simulation, _templateIndividual);
+      }
+
+      [Observation]
+      public void should_have_transferred_the_new_value_to_the_template_parameter()
+      {
+         _templateFatVolume.Value.ShouldBeEqualTo(_newFatVolumeValue, 1e-7);
+      }
+
+      [Observation]
+      public void should_mark_the_template_parameter_as_fixed_value()
+      {
+         _templateFatVolume.IsFixedValue.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_mark_the_template_parameter_as_non_default()
+      {
+         _templateFatVolume.IsDefault.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_make_the_template_parameter_eligible_for_snapshot_export()
+      {
+         _templateFatVolume.ShouldExportToSnapshot().ShouldBeTrue();
+      }
+   }
 }


### PR DESCRIPTION
## Summary
- Reorder `ParameterSetUpdater.UpdateValues` to iterate distributed parameters **before** their non-distributed children. Writing a distributed parameter's value cascades to its percentile child via the `DistributedParameter.Value` setter, so the child compare-equal afterward and is skipped — preserving the parent's own `IsFixedValue=true` and `IsDefault=false` flags. The previous child-first ordering caused the parent to compare equal (the percentile had already been written, so its computed value matched the source) and skip its own update, leaving `IsDefault=true` and dropping the modified parameter from snapshot export.
- In `ParameterUpdater.setParameterValue`, the explicit value-change branch now passes `shouldUpdateDefaultStateAndValueOriginForDefaultParameter: true` instead of `!sourceParameter.IsDefault`. When the source had retained `IsDefault=true` (which happens whenever the value was set via the property setter rather than through a parameter task command), the previous code prevented the target from being marked non-default. The early-return path for equal values keeps the original `!source.IsDefault` semantics.
- Added an integration test (`When_updating_a_distributed_organ_volume_in_a_simulation_in_the_template_building_block`) that triples Fat Volume in a simulation, commits to the template, and asserts the template's `IsFixedValue`, `IsDefault`, and `ShouldExportToSnapshot()` all reflect the change.

## Test plan
- [x] New integration test passes (4/4 observations)
- [x] Full PKSim.Tests suite passes (5229 passed, 0 failed, 3 skipped)
- [ ] Manually verify in PK-Sim UI that scaling distributed organ volumes in a simulation and committing to the individual now leaves the parent Volume parameter visibly marked as changed (reset button visible)
- [ ] Manually verify that saving the individual to snapshot includes the modified Volume parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parameter update ordering and default-state handling so distributed parameters (and their percentile children) update reliably; display unit and default-value state are now handled consistently during updates.
* **Tests**
  * Added an integration test verifying distributed organ-volume updates propagate from simulations to template building blocks and adjust parameter state accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->