### PR TITLE
Fixes #3560 Add headless snapshot exchange to PKSim.R.Exchange

### DIFF
--- a/src/PKSim.R/Exchange/SnapshotExchange.cs
+++ b/src/PKSim.R/Exchange/SnapshotExchange.cs
@@ -1,0 +1,50 @@
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Serialization.Xml;
+using PKSim.Core.Services;
+
+namespace PKSim.R.Exchange;
+
+/// <summary>
+///    Headless counterpart to <c>PKSim.Starter.SnapshotExchange</c>. It is intended to be
+///    dynamically loaded by MoBi from the shipped <c>PKSim.R.dll</c> which, unlike
+///    <c>PKSim.Starter.dll</c>, carries no UI/Presentation dependencies and therefore ships
+///    with the headless distributions (e.g. the R package).
+/// </summary>
+public static class SnapshotExchange
+{
+   public static string CreateModule(string projectSnapshot)
+   {
+      Api.InitializeOnce();
+      var (projectSnapshotToModuleMapper, objectIdResetter, serializer) =
+         Api.ResolveTasks<IProjectSnapshotToModuleMapper, IObjectIdResetter, IPKMLPersistor>();
+
+      var module = projectSnapshotToModuleMapper.MapFrom(projectSnapshot).module;
+      objectIdResetter.ResetIdFor(module);
+
+      return serializer.Serialize(module);
+   }
+
+   public static string CreateIndividualBuildingBlock(string individualSnapshot)
+   {
+      Api.InitializeOnce();
+      var (mapper, serializer) =
+         Api.ResolveTasks<IIndividualSnapshotToIndividualBuildingBlockMapper, IPKMLPersistor>();
+
+      var individualBuildingBlock = mapper.MapFrom(individualSnapshot);
+      individualBuildingBlock.Snapshot = individualSnapshot;
+
+      return serializer.Serialize(individualBuildingBlock);
+   }
+
+   public static string CreateExpressionProfileBuildingBlock(string expressionProfileSnapshot)
+   {
+      Api.InitializeOnce();
+      var (mapper, serializer) =
+         Api.ResolveTasks<IExpressionProfileSnapshotToExpressionProfileBuildingBlockMapper, IPKMLPersistor>();
+
+      var expressionProfileBuildingBlock = mapper.MapFrom(expressionProfileSnapshot);
+      expressionProfileBuildingBlock.Snapshot = expressionProfileSnapshot;
+
+      return serializer.Serialize(expressionProfileBuildingBlock);
+   }
+}

--- a/src/PKSim.R/Services/SnapshotTask.cs
+++ b/src/PKSim.R/Services/SnapshotTask.cs
@@ -41,7 +41,7 @@ namespace PKSim.R.Services
 
       public Simulation[] LoadSimulationsFromSnapshot(string snapshotFile, params string[] simulationNames)
       {
-         var project = _snapshotTask.LoadProjectFromSnapshotFileAsync(snapshotFile).GetAwaiter().GetResult();
+         var project = _snapshotTask.LoadProjectFromSnapshotFileAsync(snapshotFile, runSimulations: false).GetAwaiter().GetResult();
          if (project == null)
             return Array.Empty<Simulation>();
 


### PR DESCRIPTION
## Summary
Headless counterpart to `PKSim.Starter.SnapshotExchange` so MoBi can convert PK-Sim modules from a snapshot in headless hosts (e.g. the OSPSuite-R package) without `PKSim.Starter.dll`, which can't ship because it references UI/Presentation.

- Add `PKSim.R.Exchange.SnapshotExchange` (`CreateModule`, `CreateIndividualBuildingBlock`, `CreateExpressionProfileBuildingBlock`), resolving services from the R `Api` container and exchanging via serialized strings — same pattern as the existing `PKSim.R.Exchange.BuildingBlockCreator`.
- `SnapshotTask.LoadSimulationsFromSnapshot` now passes `runSimulations: false`: it only loads the simulations; running them is left to the caller.

## Notes
Companion to MoBi Open-Systems-Pharmacology/MoBi#2404, which routes MoBi's headless snapshot-module loading through this type. Validated end-to-end locally via OSPSuite-R against a clean snapshot (module loads, simulation runs cleanly afterward).

Fixes #3560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot exchange API with factory methods for creating modules and building blocks from snapshots.

* **Bug Fixes**
  * Fixed snapshot project loading to prevent simulations from running by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/PK-Sim/pull/3563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->