### PR TITLE
Fixes #3562 Reset of distributed individual parameters in a simulation does not work

### DIFF
--- a/src/PKSim.Core/Services/SimulationModelCreator.cs
+++ b/src/PKSim.Core/Services/SimulationModelCreator.cs
@@ -92,6 +92,20 @@ namespace PKSim.Core.Services
             });
          });
 
+         //Distributed parameters (e.g. organ volumes) are created in the model without a DefaultValue, but resetting
+         //them relies on DefaultValue to restore the percentile (otherwise the percentile keeps the overwritten value
+         //and a wrong value is computed). Propagate the DefaultValue defined in the individual to the matching model
+         //parameter (#3562).
+         allIndividualParameters.KeyValues.Each(kv =>
+         {
+            if (!kv.Value.IsDistributed())
+               return;
+
+            var simulationParameter = allSimulationParameters[_entityPathResolver.PathFor(kv.Value)];
+            if (simulationParameter != null)
+               simulationParameter.DefaultValue = kv.Value.DefaultValue;
+         });
+
          _simulationPersistableUpdater.ResetPersistable(simulation);
       }
 

--- a/tests/PKSim.Tests/IntegrationTests/SimulationParameterResetSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationParameterResetSpecs.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+using static PKSim.Core.CoreConstants.Organ;
+using static OSPSuite.Core.Domain.Constants.Parameters;
+
+namespace PKSim.IntegrationTests
+{
+   public abstract class concern_for_SimulationParameterReset : ContextForSimulationIntegration<IParameterTask>
+   {
+      protected Individual _individual;
+      protected IDistributedParameter _modelVolume;
+      protected double _originalValue;
+      protected double _originalPercentile;
+      protected double _newValue;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         var compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+
+         _simulation = DomainFactoryForSpecs.CreateSimulationWith(_individual, compound, protocol) as IndividualSimulation;
+
+         var project = new PKSimProject();
+         project.AddBuildingBlock(compound);
+         project.AddBuildingBlock(protocol);
+         project.AddBuildingBlock(_simulation);
+         project.AddBuildingBlock(_individual);
+         var workspace = IoC.Resolve<ICoreWorkspace>();
+         workspace.Project = project;
+
+         //The UI edits/resets the parameters in the simulation MODEL (Model.Root). The Simulation.Individual is only
+         //a synchronization copy. The distributed parameters in the model are the ones affected by #3562.
+         _modelVolume = _simulation.Model.Root.GetAllChildren<IDistributedParameter>()
+            .First(x => x.IsNamed(VOLUME) && x.ParentContainer.IsNamed(VENOUS_BLOOD));
+
+         _originalValue = _modelVolume.Value;
+         _originalPercentile = _modelVolume.Percentile;
+         _newValue = _originalValue * 3;
+
+         //simulate user changing the value in the simulation (sut is not resolved yet in GlobalContext)
+         IoC.Resolve<IParameterTask>().SetParameterValue(_modelVolume, _newValue);
+      }
+   }
+
+   public class When_resetting_a_distributed_organ_volume_changed_in_a_simulation : concern_for_SimulationParameterReset
+   {
+      protected override void Because()
+      {
+         //simulate user clicking the reset button
+         sut.ResetParameter(_modelVolume);
+      }
+
+      [Observation]
+      public void should_restore_the_original_value()
+      {
+         _modelVolume.Value.ShouldBeEqualTo(_originalValue, 1e-7);
+      }
+
+      [Observation]
+      public void should_restore_the_original_percentile()
+      {
+         _modelVolume.Percentile.ShouldBeEqualTo(_originalPercentile, 1e-7);
+      }
+
+      [Observation]
+      public void should_no_longer_be_a_fixed_value()
+      {
+         _modelVolume.IsFixedValue.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_be_marked_as_default()
+      {
+         _modelVolume.IsDefault.ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
## Issue

Fixes #3562 — Resetting a distributed individual parameter (e.g. an organ volume such as venous blood volume) in a simulation reset the value to a wrong one and left the percentile unchanged.

## Root cause

The parameters edited/reset in the simulation UI live in `Simulation.Model.Root`. For distributed parameters, every model parameter is built with `DefaultValue == null`:

- A distributed organ volume's `DefaultValue` is computed **per-individual** by `CreateIndividualAlgorithm` and exists only on the individual instance.
- The model build works from static definitions, so it cannot reproduce that value — the model parameter ends up with `DefaultValue == null` (the `Simulation.Individual` synchronization copy still has it).

`DistributedParameter.ResetToDefault()` restores the percentile only through the `if (DefaultValue != null) Value = DefaultValue.Value;` branch (writing the default value re-derives the default percentile). With `DefaultValue` null, that branch is skipped, so the percentile child's constant formula keeps the overwritten percentile and a wrong value is recomputed.

This is distributed-specific in terms of what's user-reachable: `ValueDiffersFromDefault` returns `IsFixedValue` for distributed parameters (so the Reset button is always offered), whereas constant parameters generally carry their `DefaultValue` from static definitions and reset correctly.

## Fix

`SimulationModelCreator.updateSimulationAfterModelCreation` now propagates the individual's `DefaultValue` onto the matching distributed model parameter after model creation — mirroring how molecule parameters are already reconciled there.

## Tests

`SimulationParameterResetSpecs` edits the venous-blood-volume distributed parameter in `Model.Root`, clicks reset (via `IParameterTask`), and asserts the value, percentile, fixed flag, and default flag are all restored. Fails before the fix, passes after.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
