### PR TITLE
Infusion visualization #3273

### DIFF
--- a/src/PKSim.Core/Model/SchemaItem.cs
+++ b/src/PKSim.Core/Model/SchemaItem.cs
@@ -12,6 +12,7 @@ namespace PKSim.Core.Model
       bool NeedsFormulation { get; }
       IParameter StartTime { get; }
       IParameter Dose { get; }
+      IParameter InfusionTime { get; }
    }
 
    public class SchemaItem : Container, ISchemaItem

--- a/src/PKSim.Core/Model/SchemaItem.cs
+++ b/src/PKSim.Core/Model/SchemaItem.cs
@@ -62,6 +62,9 @@ namespace PKSim.Core.Model
 
       public virtual IParameter Dose => this.Parameter(CoreConstants.Parameters.INPUT_DOSE);
 
+      //only defined for infusion application types; null otherwise
+      public virtual IParameter InfusionTime => this.Parameter(Constants.Parameters.INFUSION_TIME);
+
       public override void UpdatePropertiesFrom(IUpdatable sourceObject, ICloneManager cloneManager)
       {
          base.UpdatePropertiesFrom(sourceObject, cloneManager);

--- a/src/PKSim.Core/Model/SimpleProtocol.cs
+++ b/src/PKSim.Core/Model/SimpleProtocol.cs
@@ -54,6 +54,8 @@ namespace PKSim.Core.Model
 
       public virtual IParameter Dose => this.Parameter(CoreConstants.Parameters.INPUT_DOSE);
 
+      public virtual IParameter InfusionTime => this.Parameter(Constants.Parameters.INFUSION_TIME);
+
       public virtual IParameter EndTimeParameter => this.Parameter(Constants.Parameters.END_TIME);
 
       public virtual bool IsSingleDosing => DosingInterval == DosingIntervals.Single;

--- a/src/PKSim.Presentation/DTO/Mappers/SchemaItemToSchemaItemDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/SchemaItemToSchemaItemDTOMapper.cs
@@ -1,5 +1,6 @@
 using OSPSuite.Utility;
 using PKSim.Core.Model;
+using PKSim.Presentation.DTO.Parameters;
 using PKSim.Presentation.DTO.Protocols;
 using OSPSuite.Presentation.Mappers;
 
@@ -23,6 +24,12 @@ namespace PKSim.Presentation.DTO.Mappers
          var schemaItemDTO = new SchemaItemDTO(schemaItem);
          schemaItemDTO.DoseParameter = _parameterDTOMapper.MapFrom(schemaItem.Dose, schemaItemDTO, x => x.Dose, x => x.DoseParameter);
          schemaItemDTO.StartTimeParameter = _parameterDTOMapper.MapFrom(schemaItem.StartTime, schemaItemDTO, x => x.StartTime, x => x.StartTimeParameter);
+
+         //the infusion time only exists for infusion application types. It is a read-only value source for the
+         //protocol chart (it is edited through the dynamic parameter grid), so it is not bound for editing here.
+         if (schemaItem.InfusionTime != null)
+            schemaItemDTO.InfusionTimeParameter = new ParameterDTO(schemaItem.InfusionTime);
+
          return schemaItemDTO;
       }
    }

--- a/src/PKSim.Presentation/DTO/Mappers/SchemaItemToSchemaItemDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/SchemaItemToSchemaItemDTOMapper.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Utility;
 using PKSim.Core.Model;
-using PKSim.Presentation.DTO.Parameters;
 using PKSim.Presentation.DTO.Protocols;
 using OSPSuite.Presentation.Mappers;
 
@@ -12,23 +11,24 @@ namespace PKSim.Presentation.DTO.Mappers
 
    public class SchemaItemToSchemaItemDTOMapper : ISchemaItemToSchemaItemDTOMapper
    {
-      private readonly IParameterToParameterDTOInContainerMapper<SchemaItemDTO> _parameterDTOMapper;
+      private readonly IParameterToParameterDTOInContainerMapper<SchemaItemDTO> _parameterInContainerMapper;
+      private readonly IParameterToParameterDTOMapper _parameterMapper;
 
-      public SchemaItemToSchemaItemDTOMapper(IParameterToParameterDTOInContainerMapper<SchemaItemDTO> parameterDTOMapper)
+      public SchemaItemToSchemaItemDTOMapper(IParameterToParameterDTOInContainerMapper<SchemaItemDTO> parameterInContainerMapper, IParameterToParameterDTOMapper parameterMapper)
       {
-         _parameterDTOMapper = parameterDTOMapper;
+         _parameterInContainerMapper = parameterInContainerMapper;
+         _parameterMapper = parameterMapper;
       }
 
       public SchemaItemDTO MapFrom(SchemaItem schemaItem)
       {
          var schemaItemDTO = new SchemaItemDTO(schemaItem);
-         schemaItemDTO.DoseParameter = _parameterDTOMapper.MapFrom(schemaItem.Dose, schemaItemDTO, x => x.Dose, x => x.DoseParameter);
-         schemaItemDTO.StartTimeParameter = _parameterDTOMapper.MapFrom(schemaItem.StartTime, schemaItemDTO, x => x.StartTime, x => x.StartTimeParameter);
+         schemaItemDTO.DoseParameter = _parameterInContainerMapper.MapFrom(schemaItem.Dose, schemaItemDTO, x => x.Dose, x => x.DoseParameter);
+         schemaItemDTO.StartTimeParameter = _parameterInContainerMapper.MapFrom(schemaItem.StartTime, schemaItemDTO, x => x.StartTime, x => x.StartTimeParameter);
 
-         //the infusion time only exists for infusion application types. It is a read-only value source for the
-         //protocol chart (it is edited through the dynamic parameter grid), so it is not bound for editing here.
+         //the infusion time only exists for infusion application types
          if (schemaItem.InfusionTime != null)
-            schemaItemDTO.InfusionTimeParameter = new ParameterDTO(schemaItem.InfusionTime);
+            schemaItemDTO.InfusionTimeParameter = _parameterMapper.MapFrom(schemaItem.InfusionTime);
 
          return schemaItemDTO;
       }

--- a/src/PKSim.Presentation/DTO/Protocols/SchemaItemDTO.cs
+++ b/src/PKSim.Presentation/DTO/Protocols/SchemaItemDTO.cs
@@ -11,6 +11,11 @@ namespace PKSim.Presentation.DTO.Protocols
       public IParameterDTO StartTimeParameter { get; set; }
       public IParameterDTO DoseParameter { get; set; }
 
+      /// <summary>
+      ///    Infusion duration of the administration. <c>null</c> for application types that are not an infusion.
+      /// </summary>
+      public IParameterDTO InfusionTimeParameter { get; set; }
+
       public SchemaItemDTO(SchemaItem schemaItem) : base(schemaItem)
       {
          SchemaItem = schemaItem;

--- a/src/PKSim.Presentation/Presenters/Protocols/ProtocolChartData.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/ProtocolChartData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -16,22 +17,23 @@ namespace PKSim.Presentation.Presenters.Protocols
       DataTable DataTable { get; }
       string GroupingName { get; }
       string XValue { get; }
+      string XValue2 { get; }
       string YValue { get; }
+      string SchemaItemName { get; }
       double XMin { get; }
       double XMax { get; }
-      IDimension TimeDimension { get; }
-      Unit TimeUnit { get; }
       Unit YAxisUnit { get; }
       Unit Y2AxisUnit { get; }
       bool NeedsMultipleAxis { get; }
 
-      bool SeriesShouldBeOnSecondAxis(string serieName);
+      bool SeriesShouldBeOnSecondAxis(string seriesName);
       SchemaItemDTO SchemaItemFor(object tag);
    }
 
    public class ProtocolChartData : IProtocolChartData
    {
       private readonly double _endTimeInMin;
+      private double _maxEndTimeInDisplayUnit;
 
       private readonly ICache<Compound, IReadOnlyList<SchemaItemDTO>> _allSchemaItemDTO;
       public IDimension TimeDimension { get; }
@@ -41,23 +43,24 @@ namespace PKSim.Presentation.Presenters.Protocols
 
       private const string GROUPING_NAME = "GroupingName";
       private const string TIME = "Time";
+      private const string END_TIME = "EndTime";
       private const string DOSE = "Dose";
       private const string UNIT = "Unit";
       private const string SCHEMA_ITEM = "SchemaItem";
 
       public bool NeedsMultipleAxis => YAxisUnit != Y2AxisUnit;
 
-      public bool SeriesShouldBeOnSecondAxis(string serieName)
+      public bool SeriesShouldBeOnSecondAxis(string seriesName)
       {
          return (from DataRow dataRow in DataTable.Rows
-            where Equals(dataRow[GroupingName], serieName)
+            where Equals(dataRow[GroupingName], seriesName)
             select Equals(dataRow[UnitName], Y2AxisUnit)).FirstOrDefault();
       }
 
       public SchemaItemDTO SchemaItemFor(object tag)
       {
-         var dataRow = tag as DataRowView;
-         return dataRow?[SchemaItemName].DowncastTo<SchemaItemDTO>();
+         //the chart attaches the schema item DTO directly as the tag of each series point
+         return tag as SchemaItemDTO;
       }
 
       public DataTable DataTable { get; }
@@ -71,6 +74,7 @@ namespace PKSim.Presentation.Presenters.Protocols
          TimeUnit = timeUnit;
          DataTable.AddColumn(GROUPING_NAME);
          DataTable.AddColumn<double>(TIME);
+         DataTable.AddColumn<double>(END_TIME);
          DataTable.AddColumn<double>(DOSE);
          DataTable.AddColumn<Unit>(UNIT);
          DataTable.AddColumn<SchemaItemDTO>(SCHEMA_ITEM);
@@ -81,6 +85,8 @@ namespace PKSim.Presentation.Presenters.Protocols
 
       public string XValue => TIME;
 
+      public string XValue2 => END_TIME;
+
       public string YValue => DOSE;
 
       public string UnitName => UNIT;
@@ -89,7 +95,7 @@ namespace PKSim.Presentation.Presenters.Protocols
 
       public double XMin => 0;
 
-      public double XMax => timeValueInDisplayUnit(_endTimeInMin);
+      public double XMax => Math.Max(timeValueInDisplayUnit(_endTimeInMin), _maxEndTimeInDisplayUnit);
 
       private double timeValueInDisplayUnit(double timeValueInBaseUnit)
       {
@@ -115,8 +121,11 @@ namespace PKSim.Presentation.Presenters.Protocols
             {
                var row = DataTable.NewRow();
                var schemaItemDTO = schemaItemDTOGroup.First();
+               var endTime = endTimeValueInDisplayUnit(schemaItemDTO);
+               _maxEndTimeInDisplayUnit = Math.Max(_maxEndTimeInDisplayUnit, endTime);
                row[GROUPING_NAME] = createDataGroupingNameFor(hasOnlyOneDoseUnit, compound, schemaItemDTO);
                row[TIME] = timeValueInDisplayUnit(schemaItemDTO.StartTimeParameter.KernelValue);
+               row[END_TIME] = endTime;
                row[DOSE] = schemaItemDTOGroup.Sum(x => x.Dose);
                row[UNIT] = schemaItemDTO.DoseParameter.DisplayUnit;
                row[SCHEMA_ITEM] = schemaItemDTO;
@@ -131,8 +140,23 @@ namespace PKSim.Presentation.Presenters.Protocols
          if (dto.NeedsFormulation)
             key = $"{key}|{dto.FormulationKey}";
 
+         //infusions of different durations should not be aggregated even when they share a start time and dose unit
+         if (isInfusion(dto))
+            key = $"{key}|{dto.InfusionTimeParameter.KernelValue}";
+
          return key;
       }
+
+      private double endTimeValueInDisplayUnit(SchemaItemDTO schemaItemDTO)
+      {
+         var startTimeInBaseUnit = schemaItemDTO.StartTimeParameter.KernelValue;
+         if (isInfusion(schemaItemDTO))
+            return timeValueInDisplayUnit(startTimeInBaseUnit + schemaItemDTO.InfusionTimeParameter.KernelValue);
+
+         return timeValueInDisplayUnit(startTimeInBaseUnit);
+      }
+
+      private static bool isInfusion(SchemaItemDTO schemaItemDTO) => schemaItemDTO.InfusionTimeParameter != null && schemaItemDTO.InfusionTimeParameter.KernelValue > 0;
 
       private static string createDataGroupingNameFor(bool hasOnlyOneDoseUnit, Compound compound, SchemaItemDTO schemaItemDTO)
       {

--- a/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
+++ b/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
@@ -1,10 +1,15 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Drawing;
 using System.Drawing.Imaging;
+using System.Linq;
 using DevExpress.Utils;
 using DevExpress.XtraCharts;
 using OSPSuite.Core.Chart;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Services;
+using OSPSuite.Utility.Extensions;
 using PKSim.Presentation.Presenters.Protocols;
 using PKSim.Presentation.Views.Protocols;
 
@@ -14,6 +19,9 @@ namespace PKSim.UI.Views.Protocols
    {
       private readonly IImageListRetriever _imageListRetriever;
       private IProtocolChartPresenter _presenter;
+
+      //moderate translucency so overlapping infusion rectangles remain readable
+      private const int INFUSION_AREA_TRANSPARENCY = 100;
 
       public string XAxisTitle { get; set; }
       public string YAxisTitle { get; set; }
@@ -48,21 +56,14 @@ namespace PKSim.UI.Views.Protocols
       public void Plot(IProtocolChartData dataToPlot)
       {
          Clear();
-         chart.DataSource = dataToPlot.DataTable;
-         chart.SeriesDataMember = dataToPlot.GroupingName;
-         chart.InitializeColor();
 
-         // Specify the date-time argument scale type for the series,
-         // as it is qualitative, by default.
-         chart.SeriesTemplate.ArgumentScaleType = ScaleType.Numerical;
-         chart.SeriesTemplate.ArgumentDataMember = dataToPlot.XValue;
-         chart.SeriesTemplate.ValueScaleType = ScaleType.Numerical;
-         chart.SeriesTemplate.ValueDataMembers.AddRange(dataToPlot.YValue);
-         chart.SeriesTemplate.LabelsVisibility = DefaultBoolean.False;
-         var stackedBarSeriesView = new StackedBarSeriesView {BarWidth = BarWidth};
-         chart.SeriesTemplate.View = stackedBarSeriesView;
-         var diagram = (XYDiagram) chart.Diagram;
-         ////// Access the type-specific options of the diagram.
+         if (dataToPlot.DataTable.Rows.Count == 0)
+            return;
+
+         chart.InitializeColor();
+         addSeries(dataToPlot);
+
+         var diagram = (XYDiagram)chart.Diagram;
          diagram.AxisX.Title.Text = XAxisTitle;
          diagram.AxisX.Title.Visibility = DefaultBoolean.True;
          diagram.AxisY.Title.Text = YAxisTitle;
@@ -83,15 +84,97 @@ namespace PKSim.UI.Views.Protocols
 
          foreach (Series series in chart.Series)
          {
-            var view = (BarSeriesView) series.View;
-            if (dataToPlot.NeedsMultipleAxis)
-            {
-               if (dataToPlot.SeriesShouldBeOnSecondAxis(series.Name))
-                  view.AxisY = axisY2;
-            }
-            series.Visible = true;
+            if (dataToPlot.NeedsMultipleAxis && dataToPlot.SeriesShouldBeOnSecondAxis(series.Name))
+               ((XYDiagramSeriesViewBase)series.View).AxisY = axisY2;
          }
       }
+
+      private void addSeries(IProtocolChartData dataToPlot)
+      {
+         //one administration grouping (= one application type) maps to one color and one legend entry
+         var groups = dataToPlot.DataTable.Rows.Cast<DataRow>()
+            .GroupBy(row => row[dataToPlot.GroupingName].ToString())
+            .ToList();
+
+         var paletteColors = chart.GetPaletteEntries(groups.Count);
+
+         groups.Each((group, i) =>
+            createSeriesFor(group.Key, group.ToList(), dataToPlot, paletteColors[i].Color).Each(series => chart.Series.Add(series)));
+      }
+
+      private IEnumerable<Series> createSeriesFor(string applicationName, IReadOnlyList<DataRow> rows, IProtocolChartData dataToPlot, Color color)
+      {
+         var isInfusion = rows.Any(row => endTimeFor(row, dataToPlot) > startTimeFor(row, dataToPlot));
+         if (!isInfusion)
+            return [createApplicationSeries(applicationName, rows, dataToPlot, color)];
+
+         //each infusion is its own area series so overlapping infusions render as independent translucent rectangles
+         //(a single area series cannot represent two different heights over the same time span)
+         return rows.Select((row, index) => createInfusionSeries(applicationName, row, dataToPlot, color, showInLegend: index == 0));
+      }
+
+      /// <summary>
+      ///    Builds an <see cref="ViewType.Area" /> series for a single infusion, drawn as a rectangle that spans
+      ///    [start, start + infusion time] with a height equal to the dose. One series is created per infusion so
+      ///    that overlapping infusions render as independent (translucent) rectangles instead of a single merged
+      ///    shape (an area series can only have one height at any given time).
+      /// </summary>
+      private Series createInfusionSeries(string applicationName, DataRow row, IProtocolChartData dataToPlot, Color color, bool showInLegend)
+      {
+         var series = newSeries(applicationName, ViewType.Area);
+         //only one legend entry per grouping; keep the rectangle corner points in the order added
+         series.ShowInLegend = showInLegend;
+         series.SeriesPointsSorting = SortingMode.None;
+
+         var start = startTimeFor(row, dataToPlot);
+         var end = endTimeFor(row, dataToPlot);
+         var dose = doseFor(row, dataToPlot);
+         var tag = tagFor(row, dataToPlot);
+
+         //trace the rectangle [start, end] x [0, dose]
+         series.Points.Add(taggedPoint(start, 0, tag));
+         series.Points.Add(taggedPoint(start, dose, tag));
+         series.Points.Add(taggedPoint(end, dose, tag));
+         series.Points.Add(taggedPoint(end, 0, tag));
+
+         var view = (AreaSeriesView)series.View;
+         view.Color = color;
+         view.Transparency = INFUSION_AREA_TRANSPARENCY;
+         return series;
+      }
+
+      /// <summary>
+      ///    Builds a single <see cref="ViewType.StackedBar" /> series for instantaneous administrations (e.g. IV
+      ///    bolus, oral): one thin bar per administration, centered on its start time with a height equal to the
+      ///    dose. Bars belonging to different application types that share a start time stack on top of each other.
+      /// </summary>
+      private Series createApplicationSeries(string applicationName, IReadOnlyList<DataRow> rows, IProtocolChartData dataToPlot, Color color)
+      {
+         var series = newSeries(applicationName, ViewType.StackedBar);
+         rows.Each(row => series.Points.Add(taggedPoint(startTimeFor(row, dataToPlot), doseFor(row, dataToPlot), tagFor(row, dataToPlot))));
+
+         var view = (BarSeriesView)series.View;
+         view.Color = color;
+         view.BarWidth = BarWidth;
+         return series;
+      }
+
+      private static Series newSeries(string name, ViewType viewType)
+      {
+         return new Series(name, viewType)
+         {
+            ArgumentScaleType = ScaleType.Numerical,
+            ValueScaleType = ScaleType.Numerical,
+            LabelsVisibility = DefaultBoolean.False
+         };
+      }
+
+      private static SeriesPoint taggedPoint(double argument, double value, object tag) => new SeriesPoint(argument, value) { Tag = tag };
+
+      private static double startTimeFor(DataRow row, IProtocolChartData dataToPlot) => (double)row[dataToPlot.XValue];
+      private static double endTimeFor(DataRow row, IProtocolChartData dataToPlot) => (double)row[dataToPlot.XValue2];
+      private static double doseFor(DataRow row, IProtocolChartData dataToPlot) => (double)row[dataToPlot.YValue];
+      private static object tagFor(DataRow row, IProtocolChartData dataToPlot) => row[dataToPlot.SchemaItemName];
 
       private void chartObjectHotTracked(object sender, HotTrackEventArgs e)
       {
@@ -126,7 +209,7 @@ namespace PKSim.UI.Views.Protocols
 
       public void CopyToClipboard(string watermark) => chart.CopyToClipboard(watermark);
 
-      public void ExportToPng(string filePath, string watermark) => 
+      public void ExportToPng(string filePath, string watermark) =>
          chart.ExportChartToImageFile(watermark, filePath, ImageFormat.Png);
    }
 }

--- a/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
+++ b/tests/PKSim.Tests/Core/DomainHelperForSpecs.cs
@@ -329,7 +329,7 @@ namespace PKSim.Core
          return quantityValues;
       }
 
-      public static SchemaItemDTO SchemaItemDTO(ApplicationType applicationType, Unit doseDisplayUnit = null, double? doseValue = null, double? startTimeValue = null)
+      public static SchemaItemDTO SchemaItemDTO(ApplicationType applicationType, Unit doseDisplayUnit = null, double? doseValue = null, double? startTimeValue = null, double? infusionTimeValue = null)
       {
          var schemaItemDTO = new SchemaItemDTO(new SchemaItem {ApplicationType = applicationType})
          {
@@ -339,6 +339,9 @@ namespace PKSim.Core
 
          if (doseDisplayUnit != null)
             schemaItemDTO.DoseParameter.Parameter.DisplayUnit = doseDisplayUnit;
+
+         if (infusionTimeValue != null)
+            schemaItemDTO.InfusionTimeParameter = new ParameterDTO(ConstantParameterWithValue(infusionTimeValue.Value).WithName(Constants.Parameters.INFUSION_TIME));
 
          return schemaItemDTO;
       }

--- a/tests/PKSim.Tests/Presentation/ProtocolChartDataSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ProtocolChartDataSpecs.cs
@@ -145,7 +145,98 @@ namespace PKSim.Presentation
       [Observation]
       public void should_not_return_any_data_to_plot()
       {
-         _data.Rows.Count.ShouldBeEqualTo(0);   
+         _data.Rows.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_creating_the_chart_data_for_an_infusion_schema_item : concern_for_ProtocolChartData
+   {
+      protected override void Context()
+      {
+         var infusion = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.Intravenous, _doseUnit, startTimeValue: 10, infusionTimeValue: 30); //min
+         _allSchemaItemsDTOForCompoundCache.Add(new Compound(), new[] {infusion});
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 10.0)).Returns(10);
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 40.0)).Returns(40);
+         base.Context();
+      }
+
+      [Observation]
+      public void should_span_from_the_start_time_to_the_start_time_plus_the_infusion_time()
+      {
+         _data.AllValuesInColumn<double>(sut.XValue).ShouldOnlyContain(10);
+         _data.AllValuesInColumn<double>(sut.XValue2).ShouldOnlyContain(40);
+      }
+   }
+
+   public class When_creating_the_chart_data_for_an_infusion_that_ends_after_the_protocol_end_time : concern_for_ProtocolChartData
+   {
+      protected override void Context()
+      {
+         //protocol end time (_endTimeMin) is 60 min, but the infusion runs from 60 to 90 min
+         var infusion = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.Intravenous, _doseUnit, startTimeValue: 60, infusionTimeValue: 30);
+         _allSchemaItemsDTOForCompoundCache.Add(new Compound(), new[] {infusion});
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 60.0)).Returns(60);
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 90.0)).Returns(90);
+         base.Context();
+      }
+
+      [Observation]
+      public void should_extend_the_x_axis_maximum_to_the_end_of_the_infusion()
+      {
+         sut.XMax.ShouldBeEqualTo(90);
+      }
+   }
+
+   public class When_creating_the_chart_data_for_a_protocol_that_ends_after_the_last_administration : concern_for_ProtocolChartData
+   {
+      protected override void Context()
+      {
+         //protocol end time (_endTimeMin) is 60 min, but the only administration is a bolus at 10 min
+         var bolus = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.IntravenousBolus, _doseUnit, startTimeValue: 10);
+         _allSchemaItemsDTOForCompoundCache.Add(new Compound(), new[] {bolus});
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 10.0)).Returns(10);
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 60.0)).Returns(60);
+         base.Context();
+      }
+
+      [Observation]
+      public void should_use_the_protocol_end_time_as_the_x_axis_maximum()
+      {
+         sut.XMax.ShouldBeEqualTo(60);
+      }
+   }
+
+   public class When_creating_the_chart_data_for_a_non_infusion_schema_item : concern_for_ProtocolChartData
+   {
+      protected override void Context()
+      {
+         var bolus = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.IntravenousBolus, _doseUnit, startTimeValue: 10); //min
+         _allSchemaItemsDTOForCompoundCache.Add(new Compound(), new[] {bolus});
+         A.CallTo(() => _timeDimension.BaseUnitValueToUnitValue(_timeDisplayUnit, 10.0)).Returns(10);
+         base.Context();
+      }
+
+      [Observation]
+      public void should_set_the_end_time_equal_to_the_start_time()
+      {
+         _data.AllValuesInColumn<double>(sut.XValue2).ShouldOnlyContain(10);
+      }
+   }
+
+   public class When_creating_the_chart_data_for_two_infusions_with_the_same_start_time_but_different_durations : concern_for_ProtocolChartData
+   {
+      protected override void Context()
+      {
+         var infusion1 = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.Intravenous, _doseUnit, doseValue: 1, startTimeValue: 0, infusionTimeValue: 30);
+         var infusion2 = DomainHelperForSpecs.SchemaItemDTO(ApplicationTypes.Intravenous, _doseUnit, doseValue: 2, startTimeValue: 0, infusionTimeValue: 60);
+         _allSchemaItemsDTOForCompoundCache.Add(new Compound(), new[] {infusion1, infusion2});
+         base.Context();
+      }
+
+      [Observation]
+      public void should_not_aggregate_infusions_that_differ_only_in_duration()
+      {
+         _data.Rows.Count.ShouldBeEqualTo(2);
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/SchemaItemToSchemaItemDTOMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SchemaItemToSchemaItemDTOMapperSpecs.cs
@@ -2,6 +2,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Utility.Extensions;
 using FakeItEasy;
+using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Presentation.DTO.Mappers;
 using PKSim.Presentation.DTO.Parameters;
@@ -66,6 +67,55 @@ namespace PKSim.Presentation
       public void should_have_mapped_the_start_time_parameter()
       {
          _schemaItemDTO.StartTimeParameter.ShouldBeEqualTo(_startTimeParameterDTO);
+      }
+   }
+
+   public class When_mapping_an_infusion_schema_item_to_a_schema_item_dto : concern_for_SchemaItemToSchemaItemDTOMapper
+   {
+      private SchemaItem _schemaItem;
+      private SchemaItemDTO _schemaItemDTO;
+
+      protected override void Context()
+      {
+         base.Context();
+         _schemaItem = new SchemaItem {ApplicationType = ApplicationTypes.Intravenous};
+         _schemaItem.Add(DomainHelperForSpecs.ConstantParameterWithValue(15).WithName(Constants.Parameters.INFUSION_TIME));
+         A.CallTo(_parameterToParameterDTOMapper).WithReturnType<IParameterDTO>().Returns(A.Fake<IParameterDTO>());
+      }
+
+      protected override void Because()
+      {
+         _schemaItemDTO = sut.MapFrom(_schemaItem);
+      }
+
+      [Observation]
+      public void should_have_mapped_the_infusion_time_parameter()
+      {
+         _schemaItemDTO.InfusionTimeParameter.ShouldNotBeNull();
+      }
+   }
+
+   public class When_mapping_a_non_infusion_schema_item_to_a_schema_item_dto : concern_for_SchemaItemToSchemaItemDTOMapper
+   {
+      private SchemaItem _schemaItem;
+      private SchemaItemDTO _schemaItemDTO;
+
+      protected override void Context()
+      {
+         base.Context();
+         _schemaItem = new SchemaItem {ApplicationType = ApplicationTypes.IntravenousBolus};
+         A.CallTo(_parameterToParameterDTOMapper).WithReturnType<IParameterDTO>().Returns(A.Fake<IParameterDTO>());
+      }
+
+      protected override void Because()
+      {
+         _schemaItemDTO = sut.MapFrom(_schemaItem);
+      }
+
+      [Observation]
+      public void should_not_have_mapped_an_infusion_time_parameter()
+      {
+         _schemaItemDTO.InfusionTimeParameter.ShouldBeNull();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/SchemaItemToSchemaItemDTOMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SchemaItemToSchemaItemDTOMapperSpecs.cs
@@ -16,11 +16,13 @@ namespace PKSim.Presentation
    public abstract class concern_for_SchemaItemToSchemaItemDTOMapper : ContextSpecification<ISchemaItemToSchemaItemDTOMapper>
    {
       protected IParameterToParameterDTOInContainerMapper<SchemaItemDTO> _parameterToParameterDTOMapper;
+      protected PKSim.Presentation.DTO.Mappers.IParameterToParameterDTOMapper _parameterMapper;
 
       protected override void Context()
       {
          _parameterToParameterDTOMapper = A.Fake<IParameterToParameterDTOInContainerMapper<SchemaItemDTO>>();
-         sut = new SchemaItemToSchemaItemDTOMapper(_parameterToParameterDTOMapper);
+         _parameterMapper = A.Fake<PKSim.Presentation.DTO.Mappers.IParameterToParameterDTOMapper>();
+         sut = new SchemaItemToSchemaItemDTOMapper(_parameterToParameterDTOMapper, _parameterMapper);
       }
    }
 
@@ -80,7 +82,7 @@ namespace PKSim.Presentation
          base.Context();
          _schemaItem = new SchemaItem {ApplicationType = ApplicationTypes.Intravenous};
          _schemaItem.Add(DomainHelperForSpecs.ConstantParameterWithValue(15).WithName(Constants.Parameters.INFUSION_TIME));
-         A.CallTo(_parameterToParameterDTOMapper).WithReturnType<IParameterDTO>().Returns(A.Fake<IParameterDTO>());
+         A.CallTo(() => _parameterMapper.MapFrom(A<IParameter>._)).Returns(A.Fake<IParameterDTO>());
       }
 
       protected override void Because()


### PR DESCRIPTION
Fixes #3273

## Problem
In an advanced protocol, infusion administrations were drawn as fixed-width bars centered on their start time rather than spanning the infusion duration. With two infusions (e.g. 1 h then 0.5 h), the bars appeared as thin marks at the start times instead of covering each infusion's window.

## Change
- Each Intravenous Infusion is now drawn as an **area rectangle** spanning `[start, start + infusion time]` with height = dose.
- **One area series per infusion**, so overlapping infusions of the same compound render as independent translucent rectangles (a single area series can't show two heights over the same time span).
- The **x-axis maximum is extended** to cover an infusion that ends after the protocol's computed end time (that end time is derived from administration start times only).
- **Bolus/oral** (instantaneous) administrations are unchanged — still bars at their start time.

## Why the full manual-series approach
The whole chart was moved to manually-built series rather than a hybrid that kept the original `SeriesDataMember` data binding for non-infusions and only layered infusion rectangles on top. DevExpress has no native series that draws an X-axis span with a Y height (RangeBar spans Y; Gantt rotates the axes with fixed bar thickness), a single Area series can't represent overlapping infusions, and the hybrid added fragile seams (relying on manual series coexisting with template binding, filtering the data source, and coordinating colors between auto-colored bound bars and manually-colored infusion areas). The uniform manual approach keeps colors, legend, secondary-axis, and tooltips on one consistent code path.

## Tests
- Added specs covering the infusion end-time span, the non-infusion case, not aggregating infusions that differ only in duration, and the x-axis extension past the protocol end time.
- Full `PKSim.Presentation` and `PKSim.Core` spec suites pass.

Non infusion still represented by a bar series. Infusion is represented by an area series. The series height is dose and width is endTime - startTime.

<img width="942" height="812" alt="image" src="https://github.com/user-attachments/assets/c648eb36-5b41-43b7-8067-a1e7fd749fdd" />


here's an overlapping infusion
<img width="767" height="835" alt="image" src="https://github.com/user-attachments/assets/c2ecf538-e07a-4cdb-b820-bc1f176b1ef9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infusion time duration tracking for administration schema items.
  * Enhanced protocol charts to visualize infusion time spans, displaying administrations from start time through duration end.
  * Charts now automatically extend the time axis when infusions extend beyond the protocol end time.

* **Tests**
  * Expanded test coverage for infusion time functionality and chart visualization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->