### PR TITLE
Fixes #3574 SnapshotTask returns simulations with a null SimulationConfiguration

### DIFF
--- a/src/PKSim.R/Services/SnapshotTask.cs
+++ b/src/PKSim.R/Services/SnapshotTask.cs
@@ -2,7 +2,10 @@ using System;
 using System.Linq;
 using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.R.Domain;
+using PKSim.Core.Services;
 using CoreSnapshotTask = PKSim.Core.Snapshots.Services.ISnapshotTask;
 using CoreSimulation = PKSim.Core.Model.Simulation;
 
@@ -32,11 +35,18 @@ namespace PKSim.R.Services
    {
       private readonly CoreSnapshotTask _snapshotTask;
       private readonly IBatchRunner<SnapshotRunOptions> _snapshotRunner;
+      private readonly ISimulationConfigurationTask _simulationConfigurationTask;
+      private readonly ISimulationToModelCoreSimulationMapper _modelCoreSimulationMapper;
 
-      public SnapshotTask(CoreSnapshotTask snapshotTask, IBatchRunner<SnapshotRunOptions> snapshotRunner)
+      public SnapshotTask(CoreSnapshotTask snapshotTask, 
+         IBatchRunner<SnapshotRunOptions> snapshotRunner,
+         ISimulationConfigurationTask simulationConfigurationTask, 
+         ISimulationToModelCoreSimulationMapper modelCoreSimulationMapper)
       {
          _snapshotTask = snapshotTask;
          _snapshotRunner = snapshotRunner;
+         _simulationConfigurationTask = simulationConfigurationTask;
+         _modelCoreSimulationMapper = modelCoreSimulationMapper;
       }
 
       public Simulation[] LoadSimulationsFromSnapshot(string snapshotFile, params string[] simulationNames)
@@ -51,7 +61,13 @@ namespace PKSim.R.Services
             ? allSimulations
             : allSimulations.Where(x => simulationNames.Contains(x.Name));
 
-         return matched.Select(x => new Simulation(x)).ToArray();
+         return matched.Select(x => new Simulation(coreSimulationFrom(x))).ToArray();
+      }
+
+      private IModelCoreSimulation coreSimulationFrom(CoreSimulation simulation)
+      {
+         var simulationConfiguration = _simulationConfigurationTask.CreateFor(simulation, shouldValidate: true, createAgingDataInSimulation: false);
+         return _modelCoreSimulationMapper.MapFrom(simulation, simulationConfiguration, shouldCloneModel: false);
       }
 
       public void RunSnapshot(string inputFolder, string outputFolder, bool runSimulations = true,

--- a/tests/PKSim.R.Tests/SnapshotTaskSpecs.cs
+++ b/tests/PKSim.R.Tests/SnapshotTaskSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.CLI.Core.Services;
+using OSPSuite.Core.Domain;
 using OSPSuite.R.Domain;
 using OSPSuite.Utility;
 using PKSim.R.Services;
@@ -41,6 +42,18 @@ namespace PKSim.R
       {
          _simulations.ShouldNotBeNull();
          _simulations.Length.ShouldBeGreaterThan(0);
+      }
+
+      [Observation]
+      public void should_return_simulations_that_carry_a_simulation_configuration()
+      {
+         _simulations.All(x => x.Configuration != null).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_simulations_that_wrap_a_model_core_simulation()
+      {
+         _simulations.All(x => x.CoreSimulation is ModelCoreSimulation).ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
## Summary

`PKSim.R.Services.SnapshotTask.LoadSimulationsFromSnapshot` returned the raw PK-Sim domain `Simulation`, whose `SimulationConfiguration` is always `null` (it is built on demand to construct the model and then discarded). Wrapping such a simulation into an R `Simulation` (Open-Systems-Pharmacology/OSPSuite-R#1972) therefore threw a `NullReferenceException` in `SimulationBuilder.buildingBlockAndMergeBehaviors`.

Each loaded simulation is now mapped to an `OSPSuite.Core.Domain.ModelCoreSimulation` carrying a populated configuration, using the same `CreateFor` + `MapFrom` recipe as the run engines and `MoBiExportTask`, so it behaves like a `.pkml`-loaded simulation.

- `shouldCloneModel: false` reuses the model already built during snapshot load (the model is **not** built twice; the configuration is rebuilt once — the copy `CreateModelFor` builds internally is discarded).
- `SnapshotTask` gains two constructor dependencies, both already resolvable in the PKSim.R container: `PKSim.Core.Services.ISimulationConfigurationTask` and `OSPSuite.Core.Domain.Mappers.ISimulationToModelCoreSimulationMapper`.

## Test plan

`tests/PKSim.R.Tests/SnapshotTaskSpecs.cs` — the load-all spec now also asserts each returned simulation:
- carries a non-null `Configuration`, and
- wraps an `OSPSuite.Core.Domain.ModelCoreSimulation`.

- [x] `dotnet build` of `PKSim.R` and `PKSim.R.Tests` — clean (0 warnings, 0 errors)
- [x] All 5 `SnapshotTask` specs pass locally

Fixes #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
