### PR TITLE
Fixes #3580 Effective molecular weight validation no longer depends on display-unit round-trip

### DIFF
--- a/src/PKSim.Presentation/DTO/Compounds/EffectiveMolWeightParameterDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/EffectiveMolWeightParameterDTO.cs
@@ -30,28 +30,14 @@ namespace PKSim.Presentation.DTO.Compounds
             .Property(item => item.Value)
             .WithRule((dto, valueInDisplayUnit) =>
             {
-               var valueInBaseUnit = dto.Parameter.ConvertToBaseUnit(valueInDisplayUnit);
-
                // Nan values are invalid
-               if (double.IsNaN(valueInBaseUnit))
+               if (double.IsNaN(valueInDisplayUnit))
                   return false;
 
-               // evaluate without updating the parameter because writing a value will trigger another validation
-               if (valueInBaseUnit == dto.Parameter.Value)
-                  return effectiveMolWeightIsValid(dto);
-
-               // Update the parameter value to evaluate if the effective mol weight will be valid.
-               // Reset to the old value after
-               var oldValue = dto.Parameter.Value;
-               try
-               {
-                  dto.Parameter.Value = valueInBaseUnit;
-                  return effectiveMolWeightIsValid(dto);
-               }
-               finally
-               {
-                  dto.Parameter.Value = oldValue;
-               }
+               // For effective mol weight is a formula-only calculation and is updated through halogens and/or mol weight
+               // and never directly from user input. The value at time of validation is always current because the triggering
+               // update has already occurred. Either mol weight was updated, or halogen count
+               return effectiveMolWeightIsValid(dto);
             })
             .WithError((dto, value) =>
                PKSimConstants.Error.EffectiveMolWeightMustBeGreaterThan(


### PR DESCRIPTION
## What
The "effective molecular weight must be greater than the minimum" validation rule converted the candidate value from display units to base units and compared it against the parameter's formula-computed base value. That `base ↔ g/mol` conversion round-trip is **bit-exact for most values but off by ~1 ULP for a sparse subset**, so for certain molecular-weight / halogen combinations the equality guard failed and the rule fell into a branch that temporarily wrote the round-tripped value onto the formula parameter and reset it.

## Fix
Effective molecular weight is a formula-only calculation (derived from molecular weight and halogen count) and is never edited directly by the user. The rule now simply validates the parameter's current value against its minimum, reading the precise formula value and avoiding the unreliable cross-conversion comparison entirely.

See [#3580](https://github.com/Open-Systems-Pharmacology/PK-Sim/issues/3580) for the full root-cause analysis with concrete numbers.

Fixes #3580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal validation logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->