### PR TITLE
Fixes #3434 Apply overwrite parameter set during model construction

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -457,6 +457,9 @@ namespace PKSim.Assets
                $" {simulationNameList.ToString("", "'")} ";
          }
 
+         public static string CannotApplyOverwriteParameterSetUnresolvedPaths(IReadOnlyList<string> unresolvedPaths) =>
+            $"The selected {ObjectTypes.OverwriteParameterSet.ToLower()} could not be applied because the following parameter path(s) could not be resolved in the simulation:{nameListFrom(unresolvedPaths)}The simulation cannot be created.";
+
          public static string CouldNotFindAdvancedParameterContainerForParameter(string parameterName) => $"Could not find advanced parameter container for parameter '{parameterName}'.";
          public static string CouldNotFindAdvancedParameterInContainerForParameter(string containerName, string parameterName) => $"Could not find advanced parameter in container '{containerName}' for parameter '{parameterName}'.";
          public static string CompoundProcessParameterMappingNotAvailable(string process, string parameter) => $"No compound process parameter mapping found for process='{process}' and parameter ='{parameter}'.";

--- a/src/PKSim.Core/Services/CannotApplyOverwriteParameterSetException.cs
+++ b/src/PKSim.Core/Services/CannotApplyOverwriteParameterSetException.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using PKSim.Assets;
+
+namespace PKSim.Core.Services
+{
+   public class CannotApplyOverwriteParameterSetException : PKSimException
+   {
+      public CannotApplyOverwriteParameterSetException(IReadOnlyList<string> unresolvedPaths)
+         : base(PKSimConstants.Error.CannotApplyOverwriteParameterSetUnresolvedPaths(unresolvedPaths))
+      {
+      }
+   }
+}

--- a/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Services
+{
+   public interface IOverwriteParameterSetApplicationTask
+   {
+      /// <summary>
+      ///    Applies the values of the <see cref="OverwriteParameterSet" /> selected for each compound in the
+      ///    <paramref name="simulation" /> to the matching simulation parameters (matched by path). Affected parameters
+      ///    become <see cref="PKSimBuildingBlockType.Compound" /> so that subsequent changes follow normal compound
+      ///    parameter logic, and their value origin is set to identify the originating overwrite parameter set.
+      ///    Compounds whose selection is "None" are skipped.
+      ///    Throws a <see cref="CannotApplyOverwriteParameterSetException" /> if any path cannot be resolved in the
+      ///    simulation, in which case no value is applied.
+      /// </summary>
+      void ApplyOverwriteParameterSetsTo(Simulation simulation);
+   }
+
+   public class OverwriteParameterSetApplicationTask : IOverwriteParameterSetApplicationTask
+   {
+      private readonly IContainerTask _containerTask;
+
+      public OverwriteParameterSetApplicationTask(IContainerTask containerTask)
+      {
+         _containerTask = containerTask;
+      }
+
+      public void ApplyOverwriteParameterSetsTo(Simulation simulation)
+      {
+         var selections = simulation.OverwriteParameterSetSelections.Selections
+            .Where(x => x.OverwriteParameterSet != null)
+            .ToList();
+
+         if (!selections.Any())
+            return;
+
+         var parameterCache = _containerTask.CacheAllChildren<IParameter>(simulation.Model.Root);
+         var unresolvedPaths = new List<string>();
+         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)>();
+
+         selections.Each(selection => resolveSelection(selection, simulation, parameterCache, resolvedValues, unresolvedPaths));
+
+         if (unresolvedPaths.Any())
+            throw new CannotApplyOverwriteParameterSetException(unresolvedPaths);
+
+         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+      }
+
+      private void resolveSelection(OverwriteParameterSetSelection selection, Simulation simulation, PathCache<IParameter> parameterCache,
+         List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+      {
+         var compound = simulation.Compounds.FindByName(selection.CompoundName);
+
+         selection.OverwriteParameterSet.ParameterValues.Each(parameterValue =>
+            resolveParameterValue(parameterValue, compound, selection.OverwriteParameterSet, parameterCache, resolvedValues, unresolvedPaths));
+      }
+
+      private static void resolveParameterValue(ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet, PathCache<IParameter> parameterCache,
+         List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+      {
+         var path = parameterValue.Path.PathAsString;
+         var parameter = parameterCache[path];
+         if (parameter == null)
+            unresolvedPaths.Add(path);
+         else
+            resolvedValues.Add((parameter, parameterValue, compound, overwriteParameterSet));
+      }
+
+      private static void applyValue(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)
+      {
+         parameter.Value = parameterValue.Value.Value;
+         parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
+         parameter.Origin.BuilingBlockId = compound.Id;
+         parameter.ValueOrigin.Source = ValueOriginSources.Other;
+         parameter.ValueOrigin.Description = $"{PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}'";
+      }
+   }
+}

--- a/src/PKSim.Core/Services/SimulationModelCreator.cs
+++ b/src/PKSim.Core/Services/SimulationModelCreator.cs
@@ -24,6 +24,7 @@ namespace PKSim.Core.Services
       private readonly ISimulationConfigurationValidator _simulationConfigurationValidator;
       private readonly IEntityPathResolver _entityPathResolver;
       private readonly IContainerTask _containerTask;
+      private readonly IOverwriteParameterSetApplicationTask _overwriteParameterSetApplicationTask;
 
       public SimulationModelCreator(ISimulationConfigurationTask simulationConfigurationTask,
          IModelConstructor modelConstructor,
@@ -32,7 +33,8 @@ namespace PKSim.Core.Services
          ISimulationPersistableUpdater simulationPersistableUpdater,
          ISimulationConfigurationValidator simulationConfigurationValidator,
          IEntityPathResolver entityPathResolver,
-         IContainerTask containerTask)
+         IContainerTask containerTask,
+         IOverwriteParameterSetApplicationTask overwriteParameterSetApplicationTask)
       {
          _simulationConfigurationTask = simulationConfigurationTask;
          _modelConstructor = modelConstructor;
@@ -42,6 +44,7 @@ namespace PKSim.Core.Services
          _simulationConfigurationValidator = simulationConfigurationValidator;
          _entityPathResolver = entityPathResolver;
          _containerTask = containerTask;
+         _overwriteParameterSetApplicationTask = overwriteParameterSetApplicationTask;
       }
 
       public void CreateModelFor(Simulation simulation, bool shouldValidate = true, bool shouldShowProgress = false)
@@ -107,6 +110,8 @@ namespace PKSim.Core.Services
          });
 
          _simulationPersistableUpdater.ResetPersistable(simulation);
+
+         _overwriteParameterSetApplicationTask.ApplyOverwriteParameterSetsTo(simulation);
       }
 
       private void updateFromIndividualParameter(IParameter parameterToUpdate, IParameter parameterInIndividual, Individual individual)

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
@@ -1,0 +1,202 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using PKSim.Assets;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_OverwriteParameterSetApplicationTask : ContextSpecification<OverwriteParameterSetApplicationTask>
+   {
+      protected IContainerTask _containerTask;
+      protected IndividualSimulation _simulation;
+      protected Compound _compound;
+      protected IParameter _lipophilicityParam;
+      protected IParameter _permeabilityParam;
+      protected PathCache<IParameter> _parameterCache;
+
+      protected override void Context()
+      {
+         _containerTask = A.Fake<IContainerTask>();
+
+         _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+
+         _lipophilicityParam = DomainHelperForSpecs.ConstantParameterWithValue(3.5).WithName("Lipophilicity");
+         _lipophilicityParam.BuildingBlockType = PKSimBuildingBlockType.Simulation;
+         _permeabilityParam = DomainHelperForSpecs.ConstantParameterWithValue(7.2).WithName("Permeability");
+         _permeabilityParam.BuildingBlockType = PKSimBuildingBlockType.Simulation;
+
+         var root = new Container { Name = "Sim" };
+         root.Add(_lipophilicityParam);
+         root.Add(_permeabilityParam);
+
+         _simulation = new IndividualSimulation
+         {
+            Id = "SimId",
+            Model = new OSPSuite.Core.Domain.Model { Root = root }
+         };
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId", PKSimBuildingBlockType.Compound) { BuildingBlock = _compound });
+
+         _parameterCache = new PathCacheForSpecs<IParameter>();
+         _parameterCache.Add("Organism|Aspirin|Lipophilicity", _lipophilicityParam);
+         _parameterCache.Add("Organism|Aspirin|Permeability", _permeabilityParam);
+         A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(_parameterCache);
+
+         sut = new OverwriteParameterSetApplicationTask(_containerTask);
+      }
+
+      protected OverwriteParameterSet overwriteParameterSetWith(params (string path, double value)[] values)
+      {
+         var set = new OverwriteParameterSet { Name = "MySet" };
+         foreach (var (path, value) in values)
+            set.Add(new ParameterValue { Path = path.ToObjectPath(), Value = value });
+         return set;
+      }
+   }
+
+   public class When_applying_an_overwrite_parameter_set_with_matching_paths : concern_for_OverwriteParameterSetApplicationTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var set = overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0));
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", set);
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_simulation);
+      }
+
+      [Observation]
+      public void should_apply_the_value_from_the_set_to_the_matching_simulation_parameter()
+      {
+         _lipophilicityParam.Value.ShouldBeEqualTo(5.0);
+      }
+
+      [Observation]
+      public void should_mark_the_applied_parameter_as_a_compound_parameter()
+      {
+         _lipophilicityParam.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Compound);
+      }
+
+      [Observation]
+      public void should_point_the_applied_parameter_origin_to_the_compound_building_block()
+      {
+         _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
+      }
+
+      [Observation]
+      public void should_set_the_value_origin_of_the_applied_parameter_to_the_overwrite_parameter_set()
+      {
+         _lipophilicityParam.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Other);
+         _lipophilicityParam.ValueOrigin.Description.ShouldBeEqualTo($"{PKSimConstants.ObjectTypes.OverwriteParameterSet} 'MySet'");
+      }
+
+      [Observation]
+      public void should_not_modify_parameters_that_are_not_part_of_the_set()
+      {
+         _permeabilityParam.Value.ShouldBeEqualTo(7.2);
+         _permeabilityParam.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Simulation);
+      }
+   }
+
+   public class When_no_overwrite_parameter_set_is_selected_for_the_compound : concern_for_OverwriteParameterSetApplicationTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         //"None" selection => the selected set is null
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", null);
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_simulation);
+      }
+
+      [Observation]
+      public void should_leave_all_simulation_parameters_unchanged()
+      {
+         _lipophilicityParam.Value.ShouldBeEqualTo(3.5);
+         _lipophilicityParam.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Simulation);
+      }
+   }
+
+   public class When_applying_an_overwrite_parameter_set_with_an_unresolved_path : concern_for_OverwriteParameterSetApplicationTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var set = overwriteParameterSetWith(
+            ("Organism|Aspirin|Lipophilicity", 5.0),
+            ("Organism|Aspirin|NonExistent", 9.0));
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", set);
+      }
+
+      [Observation]
+      public void should_throw_a_cannot_apply_overwrite_parameter_set_exception()
+      {
+         The.Action(() => sut.ApplyOverwriteParameterSetsTo(_simulation)).ShouldThrowAn<CannotApplyOverwriteParameterSetException>();
+      }
+
+      [Observation]
+      public void should_not_apply_any_value_when_a_path_cannot_be_resolved()
+      {
+         The.Action(() => sut.ApplyOverwriteParameterSetsTo(_simulation)).ShouldThrowAn<CannotApplyOverwriteParameterSetException>();
+         _lipophilicityParam.Value.ShouldBeEqualTo(3.5);
+         _lipophilicityParam.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Simulation);
+      }
+
+      [Observation]
+      public void the_error_message_should_identify_the_unresolved_path()
+      {
+         var exception = new CannotApplyOverwriteParameterSetException(new[] { "Organism|Aspirin|NonExistent" });
+         exception.Message.Contains("Organism|Aspirin|NonExistent").ShouldBeTrue();
+      }
+   }
+
+   public class When_applying_overwrite_parameter_sets_for_multiple_compounds : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private Compound _secondCompound;
+      private IParameter _secondCompoundParam;
+
+      protected override void Context()
+      {
+         base.Context();
+         _secondCompound = new Compound { Name = "Midazolam", Id = "CompId2" };
+         _secondCompoundParam = DomainHelperForSpecs.ConstantParameterWithValue(1.0).WithName("Solubility");
+         _secondCompoundParam.BuildingBlockType = PKSimBuildingBlockType.Simulation;
+
+         _simulation.Model.Root.Add(_secondCompoundParam);
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId2", PKSimBuildingBlockType.Compound) { BuildingBlock = _secondCompound });
+         _parameterCache.Add("Organism|Midazolam|Solubility", _secondCompoundParam);
+
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+         _simulation.AddOverwriteParameterSetSelection("Midazolam", overwriteParameterSetWith(("Organism|Midazolam|Solubility", 2.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_simulation);
+      }
+
+      [Observation]
+      public void should_apply_each_compound_set_to_its_own_parameter()
+      {
+         _lipophilicityParam.Value.ShouldBeEqualTo(5.0);
+         _secondCompoundParam.Value.ShouldBeEqualTo(2.0);
+      }
+
+      [Observation]
+      public void should_point_each_applied_parameter_origin_to_the_matching_compound()
+      {
+         _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
+         _secondCompoundParam.Origin.BuilingBlockId.ShouldBeEqualTo(_secondCompound.Id);
+      }
+   }
+}

--- a/tests/PKSim.Tests/IntegrationTests/SimulationModelCreatorSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationModelCreatorSpecs.cs
@@ -1,8 +1,12 @@
+using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core;
 using PKSim.Core.Model;
@@ -80,6 +84,89 @@ namespace PKSim.IntegrationTests
          var path = explicitFormula.FormulaUsablePathBy("M_0");
          path.ShouldNotBeNull();
          path.Last().ShouldBeEqualTo(CoreConstants.Parameters.START_AMOUNT);
+      }
+   }
+
+   public class When_creating_a_simulation_model_for_a_compound_with_a_selected_overwrite_parameter_set : ContextForSimulationIntegration<ISimulationModelCreator>
+   {
+      private Compound _compound;
+      private string _parameterPath;
+      private double _overwriteValue;
+      private IParameter _appliedParameter;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var templateIndividual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(templateIndividual, _compound, protocol).DowncastTo<IndividualSimulation>();
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+
+         //pick a real compound-dependent simulation parameter to overwrite
+         var containerTask = IoC.Resolve<IContainerTask>();
+         var compoundParameter = firstValidCompoundParameter(containerTask);
+
+         _parameterPath = compoundParameter.Key;
+         _overwriteValue = compoundParameter.Value.Value + 1.0;
+
+         var overwriteParameterSet = new OverwriteParameterSet { Name = "TestSet" };
+         overwriteParameterSet.Add(new ParameterValue { Path = _parameterPath.ToObjectPath(), Value = _overwriteValue });
+         _simulation.AddOverwriteParameterSetSelection(_compound.Name, overwriteParameterSet);
+      }
+
+      private KeyValuePair<string, IParameter> firstValidCompoundParameter(IContainerTask containerTask)
+      {
+         return containerTask.CacheAllChildren<IParameter>(_simulation.Model.Root).KeyValues
+            .First(kv => kv.Value.BuildingBlockType == PKSimBuildingBlockType.Simulation &&
+                         _simulation.CompoundNameForParameterPath(kv.Key) == _compound.Name &&
+                         !double.IsNaN(kv.Value.Value));
+      }
+
+      protected override void Because()
+      {
+         //rebuild the model so the selected overwrite parameter set is applied during construction
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+         _appliedParameter = IoC.Resolve<IContainerTask>().CacheAllChildren<IParameter>(_simulation.Model.Root)[_parameterPath];
+      }
+
+      [Observation]
+      public void should_apply_the_overwrite_parameter_set_value_to_the_matching_simulation_parameter()
+      {
+         _appliedParameter.Value.ShouldBeEqualTo(_overwriteValue);
+      }
+
+      [Observation]
+      public void should_mark_the_applied_parameter_as_a_compound_parameter()
+      {
+         _appliedParameter.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Compound);
+      }
+   }
+
+   public class When_creating_a_simulation_model_with_an_unresolvable_overwrite_parameter_set_path : ContextForSimulationIntegration<ISimulationModelCreator>
+   {
+      private Compound _compound;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var templateIndividual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(templateIndividual, _compound, protocol).DowncastTo<IndividualSimulation>();
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+
+         var overwriteParameterSet = new OverwriteParameterSet { Name = "TestSet" };
+         overwriteParameterSet.Add(new ParameterValue { Path = $"Organism|{_compound.Name}|ThisPathDoesNotExist".ToObjectPath(), Value = 1.0 });
+         _simulation.AddOverwriteParameterSetSelection(_compound.Name, overwriteParameterSet);
+      }
+
+      [Observation]
+      public void should_throw_a_cannot_apply_overwrite_parameter_set_exception_and_fail_to_create_the_simulation()
+      {
+         The.Action(() => DomainFactoryForSpecs.AddModelToSimulation(_simulation)).ShouldThrowAn<CannotApplyOverwriteParameterSetException>();
       }
    }
 }


### PR DESCRIPTION
## What

Integrates `OverwriteParameterSet` application into the simulation model construction pipeline (#3434).

After the model is constructed (i.e. after keyword replacement), `SimulationModelCreator.CreateModelFor` applies each compound's selected `OverwriteParameterSet` to the matching simulation parameters:

- Parameters are matched **by path** against the constructed model (same `IContainerTask.CacheAllChildren` path keying used by the commit flow, so paths are portable across simulations).
- Applied parameters become `BuildingBlockType = Compound` and their `Origin.BuilingBlockId` points at the compound building block, so subsequent edits follow normal compound logic (red "altered" indicator, no orange tracking).
- `"None"` selections are skipped.
- If **any** path cannot be resolved, creation aborts with `CannotApplyOverwriteParameterSetException` **before** mutating any parameter, and the message lists every unresolved path (bulleted for multiple, inline for one).

### New / changed
- `OverwriteParameterSetApplier` (`IOverwriteParameterSetApplier`) — new service, injected into `SimulationModelCreator`.
- `CannotApplyOverwriteParameterSetException` + `PKSimConstants.Error.CannotApplyOverwriteParameterSetUnresolvedPaths`.
- `SimulationModelCreator.CreateModelFor` calls the applier as the final construction step.

No OSPSuite.Core changes were required.

## Tests

- **Unit** (`OverwriteParameterSetApplierSpecs`): apply matching paths; `"None"` leaves params untouched; unresolved path throws + applies nothing (transactional) + message names the path; multiple compounds each apply to their own parameter/origin.
- **Integration** (`SimulationModelCreatorSpecs`): on a real constructed model, the selected set's value is applied and the parameter is re-tagged `Compound`; an unresolvable path aborts creation.

## Manual verification

All 8 acceptance criteria from #3434 were verified manually in the running app (values applied on creation; cross-simulation path matching; `BuildingBlockType = Compound` confirmed via the dev Parameter-Ids table; red indicator on subsequent edits; graceful error dialog that lists each unresolved path — bulleted for multiple, inline for one; `"None"` no-op; multiple compounds with distinct selections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simulation creation now automatically applies selected overwrite parameter sets.
  * Overwritten parameter values are applied to the correct compound parameters and marked accordingly.
* **Bug Fixes**
  * Improved validation for overwrite parameter paths—simulation creation fails with a clear error if any paths can’t be resolved, and no values are applied.
* **Tests**
  * Added integration and core specifications covering successful application, no-op when nothing is selected, and failure on unresolved paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->