### PR TITLE
Fixes #3584 Route startup splash progress through a splash-thread EventPublisher

### DIFF
--- a/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
+++ b/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
@@ -25,6 +25,7 @@ using PKSim.Core.Services;
 using PKSim.Infrastructure;
 using PKSim.Presentation;
 using PKSim.Presentation.Core;
+using PKSim.Presentation.Presenters.Main;
 using PKSim.Presentation.Views;
 using PKSim.UI.Views.Core;
 using IContainer = OSPSuite.Utility.Container.IContainer;
@@ -54,6 +55,9 @@ namespace PKSim.UI.BootStrapping
 
          var container = InfrastructureRegister.Initialize();
          container.RegisterImplementationOf(SynchronizationContext.Current);
+         // Register the UI thread so the EventPublisher singleton captures it (via its explicit-thread
+         // constructor) and dispatches synchronously (Send) from the UI thread rather than deferred (Post).
+         container.RegisterImplementationOf(Thread.CurrentThread);
 
          container.Register<IApplicationController, ApplicationController>(LifeStyle.Singleton);
          container.Register<PKSimApplication, PKSimApplication>(LifeStyle.Singleton);
@@ -104,9 +108,8 @@ namespace PKSim.UI.BootStrapping
 
       public void Start()
       {
-         var progressManager = IoC.Resolve<IProgressManager>();
          var container = IoC.Container;
-         using (var progress = progressManager.Create())
+         using (var progress = createSplashProgressUpdater(container))
          {
             progress.Initialize(8);
 
@@ -138,6 +141,26 @@ namespace PKSim.UI.BootStrapping
             showStatusMessage(progress, PKSimConstants.UI.StartingUserInterface);
             startStartableObject(container);
          }
+      }
+
+      //The splash runs on its own UI thread, so its progress updates must be dispatched to that thread. Bind a
+      //dedicated EventPublisher to the splash's own synchronization context and drive a ProgressUpdater through it, so
+      //the splash presenter handles the events on the splash thread - updating incrementally and without a cross-thread.
+      private static IProgressUpdater createSplashProgressUpdater(IContainer container)
+      {
+         var splashPresenter = container.Resolve<ISplashViewPresenter>();
+         var splashControl = (Control) splashPresenter.View;
+
+         // Wait until the control is created, up to a maximum of 5 seconds
+         SpinWait.SpinUntil(() => splashControl.IsHandleCreated, TimeSpan.FromSeconds(5));
+         if (!splashControl.IsHandleCreated)
+            return container.Resolve<IProgressManager>().Create();
+
+         var splashContext = splashControl.Invoke(() => SynchronizationContext.Current);
+         var splashThread = splashControl.Invoke(() => Thread.CurrentThread);
+         var splashPublisher = new EventPublisher(splashContext, splashThread, container.Resolve<IExceptionManager>());
+         splashPublisher.AddListener(splashPresenter);
+         return new PKSimProgressUpdater(splashPublisher);
       }
 
       /// <summary>

--- a/src/PKSim.UI/UserInterfaceRegister.cs
+++ b/src/PKSim.UI/UserInterfaceRegister.cs
@@ -23,8 +23,8 @@ namespace PKSim.UI
       public static void InitializeForStartup(IContainer container)
       {
          container.Register<IPKSimMainView, Shell>(LifeStyle.Singleton);
-         container.Register<ISplashView, SplashScreen>();
-         container.Register<ISplashViewPresenter, SplashViewPresenter>();
+         container.Register<ISplashView, SplashScreen>(LifeStyle.Singleton);
+         container.Register<ISplashViewPresenter, SplashViewPresenter>(LifeStyle.Singleton);
 
          var shell = container.Resolve<IPKSimMainView>().DowncastTo<Shell>();
          container.RegisterImplementationOf(shell);


### PR DESCRIPTION
Fixes #3584

The splash screen runs on a second UI thread, thus needs a special EventPublisher that dispatches events synchronously using Send rather than Post. Using Post will not show progress, but will just jump the progress to 100 when everything is done loading (due to asynchronous message pump/drain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup progress handling so the splash screen updates more smoothly during app launch.
* **Bug Fixes**
  * Added a fallback path to keep launch progress visible even if the splash screen is slow to initialize.
  * Improved UI-thread handling during startup for more reliable progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->