### PR TITLE
Return population simulations from LoadSimulationsFromSnapshot

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.131" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.131" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.131" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/Mappers/AgingDataMapper.cs
+++ b/src/PKSim.R/Mappers/AgingDataMapper.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
+using CoreAgingData = PKSim.Core.Model.AgingData;
+using RAgingData = OSPSuite.R.Domain.AgingData;
+
+namespace PKSim.R.Mappers
+{
+   public interface IAgingDataMapper : IMapper<CoreAgingData, RAgingData>
+   {
+   }
+
+   public class AgingDataMapper : IAgingDataMapper
+   {
+      /// <summary>
+      ///    Flattens PK-Sim's per-parameter aging data into the flat arrays of the R <see cref="RAgingData" />.
+      ///    Reads <see cref="CoreAgingData.AllParameterData" /> directly rather than <c>ToDataTable()</c>, which quotes the
+      ///    parameter path. Callers must guard against null or empty aging data - this mapper always returns a populated
+      ///    (never null) object.
+      /// </summary>
+      public RAgingData MapFrom(CoreAgingData agingData)
+      {
+         var individualIds = new List<int>();
+         var parameterPaths = new List<string>();
+         var times = new List<double>();
+         var values = new List<double>();
+
+         agingData.AllParameterData.Each(parameterAgingData =>
+         {
+            for (var i = 0; i < parameterAgingData.IndividualIndexes.Count; i++)
+            {
+               individualIds.Add(parameterAgingData.IndividualIndexes[i]);
+               parameterPaths.Add(parameterAgingData.ParameterPath);
+               times.Add(parameterAgingData.Times[i]);
+               values.Add(parameterAgingData.Values[i]);
+            }
+         });
+
+         return new RAgingData
+         {
+            IndividualIds = individualIds.ToArray(),
+            ParameterPaths = parameterPaths.ToArray(),
+            Times = times.ToArray(),
+            Values = values.ToArray(),
+         };
+      }
+   }
+}

--- a/src/PKSim.R/Mappers/PopulationSimulationToIndividualValuesCacheMapper.cs
+++ b/src/PKSim.R/Mappers/PopulationSimulationToIndividualValuesCacheMapper.cs
@@ -1,0 +1,38 @@
+using OSPSuite.Core.Domain.Populations;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
+using PopulationSimulation = PKSim.Core.Model.PopulationSimulation;
+
+namespace PKSim.R.Mappers
+{
+   public interface IPopulationSimulationToIndividualValuesCacheMapper : IMapper<PopulationSimulation, IndividualValuesCache>
+   {
+   }
+
+   public class PopulationSimulationToIndividualValuesCacheMapper : IPopulationSimulationToIndividualValuesCacheMapper
+   {
+      private readonly IEntityPathResolver _entityPathResolver;
+
+      public PopulationSimulationToIndividualValuesCacheMapper(IEntityPathResolver entityPathResolver)
+      {
+         _entityPathResolver = entityPathResolver;
+      }
+
+      /// <summary>
+      ///    Builds the full per-individual cache for a population simulation: the base population values plus the
+      ///    simulation-level advanced parameters merged in (mirroring PopulationExportTask.CreatePopulationDataFor).
+      /// </summary>
+      public IndividualValuesCache MapFrom(PopulationSimulation populationSimulation)
+      {
+         var individualValuesCache = populationSimulation.Population.IndividualValuesCache.Clone();
+         populationSimulation.AllAdvancedParameters(_entityPathResolver).Each(advancedParameter =>
+         {
+            var parameterPath = _entityPathResolver.PathFor(advancedParameter);
+            individualValuesCache.SetValues(parameterPath, populationSimulation.AllValuesFor(parameterPath));
+         });
+
+         return individualValuesCache;
+      }
+   }
+}

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.131" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.R/RRegister.cs
+++ b/src/PKSim.R/RRegister.cs
@@ -7,6 +7,7 @@ using PKSim.Core.Services;
 using PKSim.Infrastructure.Serialization;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Infrastructure.Services;
+using PKSim.R.Mappers;
 using PKSim.R.Services;
 
 namespace PKSim.R
@@ -23,6 +24,9 @@ namespace PKSim.R
 
             //Register Services
             scan.IncludeNamespaceContainingType<IOntogenyFactorsRetriever>();
+
+            //Register Mappers
+            scan.IncludeNamespaceContainingType<IAgingDataMapper>();
 
             scan.WithConvention<PKSimRegistrationConvention>();
          });

--- a/src/PKSim.R/Services/SnapshotTask.cs
+++ b/src/PKSim.R/Services/SnapshotTask.cs
@@ -6,8 +6,11 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.R.Domain;
 using PKSim.Core.Services;
+using PKSim.R.Mappers;
 using CoreSnapshotTask = PKSim.Core.Snapshots.Services.ISnapshotTask;
 using CoreSimulation = PKSim.Core.Model.Simulation;
+using CoreAgingData = PKSim.Core.Model.AgingData;
+using PopulationSimulation = PKSim.Core.Model.PopulationSimulation;
 
 namespace PKSim.R.Services
 {
@@ -37,16 +40,22 @@ namespace PKSim.R.Services
       private readonly IBatchRunner<SnapshotRunOptions> _snapshotRunner;
       private readonly ISimulationConfigurationTask _simulationConfigurationTask;
       private readonly ISimulationToModelCoreSimulationMapper _modelCoreSimulationMapper;
+      private readonly IPopulationSimulationToIndividualValuesCacheMapper _populationCacheMapper;
+      private readonly IAgingDataMapper _agingDataMapper;
 
-      public SnapshotTask(CoreSnapshotTask snapshotTask, 
+      public SnapshotTask(CoreSnapshotTask snapshotTask,
          IBatchRunner<SnapshotRunOptions> snapshotRunner,
-         ISimulationConfigurationTask simulationConfigurationTask, 
-         ISimulationToModelCoreSimulationMapper modelCoreSimulationMapper)
+         ISimulationConfigurationTask simulationConfigurationTask,
+         ISimulationToModelCoreSimulationMapper modelCoreSimulationMapper,
+         IPopulationSimulationToIndividualValuesCacheMapper populationCacheMapper,
+         IAgingDataMapper agingDataMapper)
       {
          _snapshotTask = snapshotTask;
          _snapshotRunner = snapshotRunner;
          _simulationConfigurationTask = simulationConfigurationTask;
          _modelCoreSimulationMapper = modelCoreSimulationMapper;
+         _populationCacheMapper = populationCacheMapper;
+         _agingDataMapper = agingDataMapper;
       }
 
       public Simulation[] LoadSimulationsFromSnapshot(string snapshotFile, params string[] simulationNames)
@@ -61,7 +70,22 @@ namespace PKSim.R.Services
             ? allSimulations
             : allSimulations.Where(x => simulationNames.Contains(x.Name));
 
-         return matched.Select(x => new Simulation(coreSimulationFrom(x))).ToArray();
+         return matched.Select(simulationFrom).ToArray();
+      }
+
+      private Simulation simulationFrom(CoreSimulation simulation)
+      {
+         var rSimulation = new Simulation(coreSimulationFrom(simulation));
+
+         if (simulation is PopulationSimulation populationSimulation)
+         {
+            rSimulation.IndividualValuesCache = _populationCacheMapper.MapFrom(populationSimulation);
+
+            if (shouldExportAgingData(populationSimulation.AgingData))
+               rSimulation.AgingData = _agingDataMapper.MapFrom(populationSimulation.AgingData);
+         }
+
+         return rSimulation;
       }
 
       private IModelCoreSimulation coreSimulationFrom(CoreSimulation simulation)
@@ -69,6 +93,9 @@ namespace PKSim.R.Services
          var simulationConfiguration = _simulationConfigurationTask.CreateFor(simulation, shouldValidate: true, createAgingDataInSimulation: false);
          return _modelCoreSimulationMapper.MapFrom(simulation, simulationConfiguration, shouldCloneModel: false);
       }
+
+      private static bool shouldExportAgingData(CoreAgingData agingData) =>
+         agingData != null && agingData.AllParameterData.Any(x => x.IndividualIndexes.Count > 0);
 
       public void RunSnapshot(string inputFolder, string outputFolder, bool runSimulations = true,
          SnapshotExportMode exportMode = SnapshotExportMode.Snapshot, params string[] folders)

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/AgingDataMapperSpecs.cs
+++ b/tests/PKSim.R.Tests/AgingDataMapperSpecs.cs
@@ -1,0 +1,71 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.R.Mappers;
+using CoreAgingData = PKSim.Core.Model.AgingData;
+using RAgingData = OSPSuite.R.Domain.AgingData;
+
+namespace PKSim.R
+{
+   public abstract class concern_for_AgingDataMapper : ContextSpecification<IAgingDataMapper>
+   {
+      protected override void Context()
+      {
+         sut = new AgingDataMapper();
+      }
+   }
+
+   public class When_mapping_core_aging_data_to_the_r_aging_data : concern_for_AgingDataMapper
+   {
+      private CoreAgingData _agingData;
+      private RAgingData _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _agingData = new CoreAgingData();
+         _agingData.Add(individualIndex: 0, parameterPath: "Organism|Liver|Volume", time: 10, value: 100);
+         _agingData.Add(individualIndex: 0, parameterPath: "Organism|Liver|Volume", time: 20, value: 110);
+         _agingData.Add(individualIndex: 5, parameterPath: "Organism|Liver|Volume", time: 10, value: 200);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_agingData);
+      }
+
+      [Observation]
+      public void should_flatten_every_aging_row_into_the_parallel_arrays()
+      {
+         _result.IndividualIds.ShouldOnlyContainInOrder(0, 0, 5);
+         _result.ParameterPaths.ShouldOnlyContainInOrder("Organism|Liver|Volume", "Organism|Liver|Volume", "Organism|Liver|Volume");
+         _result.Times.ShouldOnlyContainInOrder(10.0, 20.0, 10.0);
+         _result.Values.ShouldOnlyContainInOrder(100.0, 110.0, 200.0);
+      }
+   }
+
+   public class When_mapping_core_aging_data_spanning_multiple_parameters : concern_for_AgingDataMapper
+   {
+      private CoreAgingData _agingData;
+      private RAgingData _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _agingData = new CoreAgingData();
+         _agingData.Add(individualIndex: 0, parameterPath: "PathA", time: 1, value: 10);
+         _agingData.Add(individualIndex: 1, parameterPath: "PathB", time: 2, value: 20);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_agingData);
+      }
+
+      [Observation]
+      public void should_include_the_rows_of_every_parameter()
+      {
+         _result.IndividualIds.Length.ShouldBeEqualTo(2);
+         _result.ParameterPaths.ShouldContain("PathA", "PathB");
+      }
+   }
+}

--- a/tests/PKSim.R.Tests/Data/Atazanavir-IndAndPop.json
+++ b/tests/PKSim.R.Tests/Data/Atazanavir-IndAndPop.json
@@ -1,0 +1,662 @@
+{
+   "Name": "Atazanavir-IndAndPop",
+   "Version": 81,
+   "ExpressionProfiles": [
+      {
+         "Type": "Enzyme",
+         "Species": "Human",
+         "Molecule": "CYP3A4",
+         "Category": "Acosta2007",
+         "Parameters": [
+            {
+               "Path": "CYP3A4|Reference concentration",
+               "Value": 4.32,
+               "Unit": "\u00c2\u00b5mol/l",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "CYP3A4|t1/2 (intestine)",
+               "Value": 1380.0,
+               "Unit": "min",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "CYP3A4|t1/2 (liver)",
+               "Value": 22.0,
+               "Unit": "h",
+               "ValueOrigin": {
+                  "Source": "Unknown"
+               }
+            },
+            {
+               "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0041682898325,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.00078691079081,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0053603428126,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+               "Value": 1.0,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+               "Value": 1.0,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.00042695753798,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+               "Value": 0.0727697702,
+               "ValueOrigin": {}
+            }
+         ],
+         "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
+         "Ontogeny": {
+            "Name": "CYP3A4"
+         }
+      }
+   ],
+   "Individuals": [
+      {
+         "Name": "Acosta2007",
+         "Seed": 8908561,
+         "OriginData": {
+            "CalculationMethods": [
+               "SurfaceAreaPlsInt_VAR1",
+               "Body surface area - Mosteller"
+            ],
+            "Species": "Human",
+            "Population": "WhiteAmerican_NHANES_1997",
+            "Gender": "MALE",
+            "Age": {
+               "Value": 34.0,
+               "Unit": "year(s)"
+            },
+            "Weight": {
+               "Value": 78.0,
+               "Unit": "kg"
+            }
+         },
+         "ExpressionProfiles": [
+            "CYP3A4|Human|Acosta2007"
+         ]
+      }
+   ],
+   "Compounds": [
+      {
+         "Name": "Alfentanil",
+         "IsSmallMolecule": true,
+         "PlasmaProteinBindingPartner": "Glycoprotein",
+         "Lipophilicity": [
+            {
+               "Name": "Fit",
+               "Parameters": [
+                  {
+                     "Name": "Lipophilicity",
+                     "Value": 1.8463211883,
+                     "Unit": "Log Units",
+                     "ValueOrigin": {
+                        "Source": "ParameterIdentification",
+                        "Method": "ParameterIdentification",
+                        "Description": "Value updated from 'Parameter Identification 4' on 2019-09-06 11:28"
+                     }
+                  }
+               ]
+            }
+         ],
+         "FractionUnbound": [
+            {
+               "Name": "Healthy",
+               "Species": "Human",
+               "Parameters": [
+                  {
+                     "Name": "Fraction unbound (plasma, reference value)",
+                     "Value": 0.1,
+                     "ValueOrigin": {
+                        "Source": "ParameterIdentification",
+                        "Method": "ParameterIdentification",
+                        "Description": "Value updated from 'Parameter Identification 4' on 2019-09-06 11:28"
+                     }
+                  }
+               ]
+            }
+         ],
+         "Solubility": [
+            {
+               "Name": "Baneyx 2014",
+               "Parameters": [
+                  {
+                     "Name": "Solubility at reference pH",
+                     "Value": 992.0,
+                     "Unit": "mg/l",
+                     "ValueOrigin": {
+                        "Source": "Publication",
+                        "Description": "Hanke 2018"
+                     }
+                  },
+                  {
+                     "Name": "Reference pH",
+                     "Value": 6.5,
+                     "ValueOrigin": {
+                        "Source": "Publication",
+                        "Description": "Hanke 2018"
+                     }
+                  }
+               ]
+            }
+         ],
+         "IntestinalPermeability": [
+            {
+               "Name": "Optimized",
+               "Parameters": [
+                  {
+                     "Name": "Specific intestinal permeability (transcellular)",
+                     "Value": 0.00057373577138,
+                     "Unit": "cm/min",
+                     "ValueOrigin": {
+                        "Source": "ParameterIdentification",
+                        "Method": "ParameterIdentification",
+                        "Description": "Value updated from 'Parameter Identification 4' on 2019-09-06 11:28"
+                     }
+                  }
+               ]
+            }
+         ],
+         "Permeability": [
+            {
+               "Name": "Optimized",
+               "Parameters": [
+                  {
+                     "Name": "Permeability",
+                     "Value": 0.0068752756625,
+                     "Unit": "cm/min",
+                     "ValueOrigin": {
+                        "Source": "ParameterIdentification",
+                        "Method": "ParameterIdentification",
+                        "Description": "Value updated from 'Parameter Identification 4' on 2019-09-06 11:28"
+                     }
+                  }
+               ]
+            }
+         ],
+         "PkaTypes": [
+            {
+               "Type": "Base",
+               "Pka": 6.5,
+               "ValueOrigin": {
+                  "Source": "Publication",
+                  "Description": "Hanke 2018"
+               }
+            }
+         ],
+         "Processes": [
+            {
+               "InternalName": "MetabolizationIntrinsic_FirstOrder",
+               "DataSource": "1st order CL",
+               "Species": "Human",
+               "Molecule": "CYP3A4",
+               "Parameters": [
+                  {
+                     "Name": "Intrinsic clearance",
+                     "Value": 0.5272297928,
+                     "Unit": "l/min",
+                     "ValueOrigin": {
+                        "Source": "ParameterIdentification",
+                        "Method": "ParameterIdentification",
+                        "Description": "Value updated from 'Parameter Identification 4' on 2019-09-06 11:28"
+                     }
+                  }
+               ]
+            },
+            {
+               "InternalName": "GlomerularFiltration",
+               "DataSource": "GFR",
+               "Species": "Human",
+               "Parameters": [
+                  {
+                     "Name": "GFR fraction",
+                     "Value": 0.06,
+                     "ValueOrigin": {
+                        "Source": "Publication",
+                        "Description": "Hanke 2018"
+                     }
+                  }
+               ]
+            }
+         ],
+         "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+         ],
+         "Parameters": [
+            {
+               "Name": "Molecular weight",
+               "Value": 416.52,
+               "Unit": "g/mol",
+               "ValueOrigin": {
+                  "Source": "Publication",
+                  "Description": "Drugbank"
+               }
+            }
+         ]
+      }
+   ],
+   "Formulations": [
+      {
+         "Name": "Coumadin (Warfarin, Weibull release function)",
+         "FormulationType": "Formulation_Tablet_Weibull",
+         "Parameters": [
+            {
+               "Name": "Dissolution time (50% dissolved)",
+               "Value": 7.9,
+               "Unit": "min",
+               "ValueOrigin": {}
+            },
+            {
+               "Name": "Lag time",
+               "Value": 0.0,
+               "Unit": "min",
+               "ValueOrigin": {}
+            },
+            {
+               "Name": "Dissolution shape",
+               "Value": 0.92,
+               "ValueOrigin": {}
+            },
+            {
+               "Name": "Use as suspension",
+               "Value": 0.0,
+               "ValueOrigin": {}
+            }
+         ],
+         "Description": "Version 1.1"
+      }
+   ],
+   "Protocols": [
+      {
+         "Name": "Rifampicin, po, 600 mg, 7 d",
+         "ApplicationType": "Oral",
+         "DosingInterval": "DI_24",
+         "Parameters": [
+            {
+               "Name": "Start time",
+               "Value": 0.0,
+               "Unit": "h",
+               "ValueOrigin": {}
+            },
+            {
+               "Name": "InputDose",
+               "Value": 600.0,
+               "Unit": "mg",
+               "ValueOrigin": {}
+            },
+            {
+               "Name": "End time",
+               "Value": 168.0,
+               "Unit": "h",
+               "ValueOrigin": {
+                  "Source": "Unknown"
+               }
+            },
+            {
+               "Name": "Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            }
+         ],
+         "Description": "Version 1.1"
+      }
+   ],
+   "Simulations": [
+      {
+         "Name": "test",
+         "Model": "4Comp",
+         "Solver": {},
+         "OutputSchema": [
+            {
+               "Parameters": [
+                  {
+                     "Name": "Start time",
+                     "Value": 0.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "End time",
+                     "Value": 2.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "Resolution",
+                     "Value": 20.0,
+                     "Unit": "pts/h",
+                     "ValueOrigin": {}
+                  }
+               ]
+            },
+            {
+               "Parameters": [
+                  {
+                     "Name": "Start time",
+                     "Value": 2.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "End time",
+                     "Value": 192.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "Resolution",
+                     "Value": 4.0,
+                     "Unit": "pts/h",
+                     "ValueOrigin": {}
+                  }
+               ]
+            }
+         ],
+         "Parameters": [
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            }
+         ],
+         "Individual": "Acosta2007",
+         "Compounds": [
+            {
+               "Name": "Alfentanil",
+               "CalculationMethods": [
+                  "Cellular partition coefficient method - Rodgers and Rowland",
+                  "Cellular permeability - PK-Sim Standard"
+               ],
+               "Alternatives": [
+                  {
+                     "AlternativeName": "Optimized",
+                     "GroupName": "COMPOUND_PERMEABILITY"
+                  },
+                  {
+                     "AlternativeName": "Optimized",
+                     "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+                  }
+               ],
+               "Processes": [
+                  {
+                     "Name": "CYP3A4-1st order CL",
+                     "MoleculeName": "CYP3A4"
+                  },
+                  {
+                     "Name": "Glomerular Filtration-GFR",
+                     "SystemicProcessType": "GFR"
+                  }
+               ],
+               "Protocol": {
+                  "Name": "Rifampicin, po, 600 mg, 7 d",
+                  "Formulations": [
+                     {
+                        "Name": "Coumadin (Warfarin, Weibull release function)",
+                        "Key": "Formulation"
+                     }
+                  ]
+               }
+            }
+         ],
+         "HasResults": false
+      },
+      {
+         "Name": "Population Simulation - IV",
+         "Model": "4Comp",
+         "Solver": {},
+         "OutputSchema": [
+            {
+               "Parameters": [
+                  {
+                     "Name": "Start time",
+                     "Value": 0.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "End time",
+                     "Value": 2.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "Resolution",
+                     "Value": 20.0,
+                     "Unit": "pts/h",
+                     "ValueOrigin": {}
+                  }
+               ]
+            },
+            {
+               "Parameters": [
+                  {
+                     "Name": "Start time",
+                     "Value": 2.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "End time",
+                     "Value": 192.0,
+                     "Unit": "h",
+                     "ValueOrigin": {}
+                  },
+                  {
+                     "Name": "Resolution",
+                     "Value": 4.0,
+                     "Unit": "pts/h",
+                     "ValueOrigin": {}
+                  }
+               ]
+            }
+         ],
+         "Parameters": [
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            },
+            {
+               "Path": "Events|Rifampicin, po, 600 mg, 7 d|Coumadin (Warfarin, Weibull release function)|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+               "Value": 3.5,
+               "Unit": "ml/kg",
+               "ValueOrigin": {}
+            }
+         ],
+         "Compounds": [
+            {
+               "Name": "Alfentanil",
+               "CalculationMethods": [
+                  "Cellular partition coefficient method - Rodgers and Rowland",
+                  "Cellular permeability - PK-Sim Standard"
+               ],
+               "Alternatives": [
+                  {
+                     "AlternativeName": "Optimized",
+                     "GroupName": "COMPOUND_PERMEABILITY"
+                  },
+                  {
+                     "AlternativeName": "Optimized",
+                     "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+                  }
+               ],
+               "Processes": [
+                  {
+                     "Name": "CYP3A4-1st order CL",
+                     "MoleculeName": "CYP3A4"
+                  },
+                  {
+                     "Name": "Glomerular Filtration-GFR",
+                     "SystemicProcessType": "GFR"
+                  }
+               ],
+               "Protocol": {
+                  "Name": "Rifampicin, po, 600 mg, 7 d",
+                  "Formulations": [
+                     {
+                        "Name": "Coumadin (Warfarin, Weibull release function)",
+                        "Key": "Formulation"
+                     }
+                  ]
+               }
+            }
+         ],
+         "HasResults": false,
+         "Population": "Acosta_Pop",
+         "AllowAging": true
+      }
+   ],
+   "Populations": [
+      {
+         "Name": "Acosta_Pop",
+         "Seed": 1234,
+         "Settings": {
+            "NumberOfIndividuals": 6,
+            "ProportionOfFemales": 0,
+            "Age": {
+               "Min": 5.0,
+               "Max": 15.0,
+               "Unit": "year(s)"
+            },
+            "Individual": {
+               "Name": "Acosta2007",
+               "Seed": 8908561,
+               "OriginData": {
+                  "CalculationMethods": [
+                     "SurfaceAreaPlsInt_VAR1",
+                     "Body surface area - Mosteller"
+                  ],
+                  "Species": "Human",
+                  "Population": "WhiteAmerican_NHANES_1997",
+                  "Gender": "MALE",
+                  "Age": {
+                     "Value": 34.0,
+                     "Unit": "year(s)"
+                  },
+                  "Weight": {
+                     "Value": 78.0,
+                     "Unit": "kg"
+                  }
+               },
+               "ExpressionProfiles": [
+                  "CYP3A4|Human|Acosta2007"
+               ]
+            }
+         }
+      }
+   ]
+}

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.R.Tests/PopulationSimulationToIndividualValuesCacheMapperSpecs.cs
+++ b/tests/PKSim.R.Tests/PopulationSimulationToIndividualValuesCacheMapperSpecs.cs
@@ -1,0 +1,96 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Populations;
+using OSPSuite.Core.Domain.Services;
+using PKSim.Core.Model;
+using PKSim.R.Mappers;
+
+namespace PKSim.R
+{
+   public abstract class concern_for_PopulationSimulationToIndividualValuesCacheMapper : ContextSpecification<IPopulationSimulationToIndividualValuesCacheMapper>
+   {
+      protected IEntityPathResolver _entityPathResolver;
+      protected PopulationSimulation _populationSimulation;
+      protected IndividualValuesCache _basePopulationCache;
+
+      protected override void Context()
+      {
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+
+         _basePopulationCache = new IndividualValuesCache();
+         _basePopulationCache.SetValues("Organism|Weight", new[] { 70.0, 75.0, 80.0 });
+
+         var population = A.Fake<Population>();
+         A.CallTo(() => population.IndividualValuesCache).Returns(_basePopulationCache);
+
+         _populationSimulation = A.Fake<PopulationSimulation>();
+         A.CallTo(() => _populationSimulation.Population).Returns(population);
+
+         sut = new PopulationSimulationToIndividualValuesCacheMapper(_entityPathResolver);
+      }
+   }
+
+   public class When_mapping_a_population_simulation_carrying_advanced_parameters : concern_for_PopulationSimulationToIndividualValuesCacheMapper
+   {
+      private IndividualValuesCache _result;
+      private IParameter _advancedParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _advancedParameter = A.Fake<IParameter>();
+         A.CallTo(() => _entityPathResolver.PathFor(_advancedParameter)).Returns("Organism|Liver|CL");
+         A.CallTo(() => _populationSimulation.AllAdvancedParameters(_entityPathResolver)).Returns(new[] { _advancedParameter });
+         A.CallTo(() => _populationSimulation.AllValuesFor("Organism|Liver|CL")).Returns(new[] { 1.0, 2.0, 3.0 });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_populationSimulation);
+      }
+
+      [Observation]
+      public void should_carry_the_base_population_parameters()
+      {
+         _result.Has("Organism|Weight").ShouldBeTrue();
+         _result.ValuesFor("Organism|Weight").ShouldOnlyContainInOrder(70.0, 75.0, 80.0);
+      }
+
+      [Observation]
+      public void should_merge_the_advanced_parameter_values_into_the_cache()
+      {
+         _result.Has("Organism|Liver|CL").ShouldBeTrue();
+         _result.ValuesFor("Organism|Liver|CL").ShouldOnlyContainInOrder(1.0, 2.0, 3.0);
+      }
+
+      [Observation]
+      public void should_return_a_clone_and_leave_the_source_population_cache_untouched()
+      {
+         _basePopulationCache.Has("Organism|Liver|CL").ShouldBeFalse();
+      }
+   }
+
+   public class When_mapping_a_population_simulation_without_advanced_parameters : concern_for_PopulationSimulationToIndividualValuesCacheMapper
+   {
+      private IndividualValuesCache _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _populationSimulation.AllAdvancedParameters(_entityPathResolver)).Returns(new IParameter[] { });
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_populationSimulation);
+      }
+
+      [Observation]
+      public void should_return_the_base_population_cache_only()
+      {
+         _result.AllParameterPaths().ShouldOnlyContain("Organism|Weight");
+      }
+   }
+}

--- a/tests/PKSim.R.Tests/SnapshotTaskSpecs.cs
+++ b/tests/PKSim.R.Tests/SnapshotTaskSpecs.cs
@@ -57,6 +57,63 @@ namespace PKSim.R
       }
    }
 
+   public class When_loading_a_population_simulation_from_a_snapshot : concern_for_SnapshotTask
+   {
+      private Simulation[] _simulations;
+      private Simulation _populationSimulation;
+      private Simulation _individualSimulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _snapshotFile = DomainHelperForSpecs.DataFilePathFor("Atazanavir-IndAndPop.json");
+      }
+
+      protected override void Because()
+      {
+         _simulations = sut.LoadSimulationsFromSnapshot(_snapshotFile);
+         _populationSimulation = _simulations.Single(x => x.IsPopulation);
+         _individualSimulation = _simulations.Single(x => !x.IsPopulation);
+      }
+
+      [Observation]
+      public void should_return_both_the_individual_and_the_population_simulation()
+      {
+         _simulations.Length.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_carry_the_complete_population_on_the_population_simulation()
+      {
+         var cache = _populationSimulation.IndividualValuesCache;
+         cache.ShouldNotBeNull();
+         cache.Count.ShouldBeEqualTo(6);
+
+         var parameterPaths = cache.AllParameterPaths();
+         parameterPaths.Length.ShouldBeGreaterThan(0);
+
+         //every varied parameter carries one value per individual: the whole cache was carried, not truncated or empty
+         parameterPaths.All(path => cache.ValuesFor(path).Count == cache.Count).ShouldBeTrue();
+
+         //real population data was carried: at least one parameter actually varies across the individuals
+         parameterPaths.Any(path => cache.ValuesFor(path).Distinct().Count() > 1).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_carry_aging_data_on_the_population_simulation()
+      {
+         _populationSimulation.AgingData.ShouldNotBeNull();
+         _populationSimulation.AgingData.IndividualIds.Length.ShouldBeGreaterThan(0);
+      }
+
+      [Observation]
+      public void should_leave_the_individual_simulation_without_population_or_aging_data()
+      {
+         _individualSimulation.IndividualValuesCache.ShouldBeNull();
+         _individualSimulation.AgingData.ShouldBeNull();
+      }
+   }
+
    public class When_loading_simulations_filtered_by_an_existing_simulation_name : concern_for_SnapshotTask
    {
       private Simulation[] _simulations;

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.131" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.131" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.130" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.131" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #3592.

`LoadSimulationsFromSnapshot()` now returns population simulations. `SnapshotTask` carries each population simulation's `IndividualValuesCache` (base population values + simulation-level advanced parameters) and `AgingData` onto the R `Simulation`, via two mappers (`PopulationSimulationToIndividualValuesCacheMapper`, `AgingDataMapper`). Individual simulations are unchanged.

Also bumps OSPSuite.* to 13.0.131, which carries the Core wrapper properties + `RunSimulations` this depends on (#2896 / #2897).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting population simulation details, including per-individual values and aging data, when loading from snapshots.
  * Improved R data export so aging information is flattened into a format that’s easier to consume.

* **Bug Fixes**
  * Population simulations now retain complete individual-level data after snapshot import, while individual simulations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->