### PR TITLE
Reduce PK-Sim startup time

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.132" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/IStartableWarmup.cs
+++ b/src/PKSim.Core/Services/IStartableWarmup.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using OSPSuite.Utility;
+
+namespace PKSim.Core.Services
+{
+   /// <summary>
+   ///    Warms up a set of <see cref="IStartable" /> repositories on a dedicated background thread so their
+   ///    (DB-backed) loading overlaps the main window construction instead of blocking startup.
+   /// </summary>
+   public interface IStartableWarmup
+   {
+      /// <summary>
+      ///    Starts warming up the given <paramref name="startables" /> on a background thread and returns immediately.
+      /// </summary>
+      void Begin(IReadOnlyList<IStartable> startables);
+
+      /// <summary>
+      ///    Blocks until the warm-up started by <see cref="Begin" /> has completed, rethrowing any exception it raised.
+      ///    A no-op when no warm-up was started.
+      /// </summary>
+      void AwaitCompletion();
+   }
+}

--- a/src/PKSim.Infrastructure/InfrastructureRegister.cs
+++ b/src/PKSim.Infrastructure/InfrastructureRegister.cs
@@ -171,6 +171,7 @@ namespace PKSim.Infrastructure
 
             scan.ExcludeType<CommandMetaDataRepository>();
             scan.ExcludeType<DefaultIndividualRetriever>();
+            scan.ExcludeType<StartableWarmup>(); //registered explicitly as singleton below
             scan.ExcludeType<SessionManager>();
             scan.ExcludeType<TemplateDatabase>();
             scan.ExcludeType<GeneExpressionDatabase>();
@@ -216,6 +217,7 @@ namespace PKSim.Infrastructure
 
          registerMarkdownBuilders(container);
 
+         container.Register<IStartableWarmup, StartableWarmup>(LifeStyle.Singleton);
          container.Register<IProjectRetriever, PKSimProjectRetriever>();
          container.Register<IObservedDataConfiguration, ImportObservedDataTask>();
          container.Register<IFlatContainerIdToContainerMapperSpecification, FlatContainerIdToFormulationMapper>();

--- a/src/PKSim.Infrastructure/ORM/Repositories/ValueOriginRepository.cs
+++ b/src/PKSim.Infrastructure/ORM/Repositories/ValueOriginRepository.cs
@@ -19,6 +19,7 @@ namespace PKSim.Infrastructure.ORM.Repositories
       };
 
       private readonly Cache<int, ValueOrigin> _allValueOrigins = new Cache<int, ValueOrigin>(onMissingKey: x => _defaultValueOrigin);
+      private bool _started;
 
       public ValueOriginRepository(IFlatValueOriginRepository flatValueOriginRepository, IFlatValueOriginToValueOriginMapper valueOriginMapper)
       {
@@ -34,7 +35,9 @@ namespace PKSim.Infrastructure.ORM.Repositories
 
       public void Start()
       {
+         if (_started) return;
          _flatValueOriginRepository.All().Each(x => { _allValueOrigins[x.Id] = _valueOriginMapper.MapFrom(x); });
+         _started = true;
       }
 
       public ValueOrigin ValueOriginFor(IParameter parameter)

--- a/src/PKSim.Infrastructure/ORM/Repositories/ValueOriginRepository.cs
+++ b/src/PKSim.Infrastructure/ORM/Repositories/ValueOriginRepository.cs
@@ -7,7 +7,7 @@ using PKSim.Infrastructure.ORM.Mappers;
 
 namespace PKSim.Infrastructure.ORM.Repositories
 {
-   public class ValueOriginRepository : IValueOriginRepository
+   public class ValueOriginRepository : StartableRepository<ValueOrigin>, IValueOriginRepository
    {
       private readonly IFlatValueOriginRepository _flatValueOriginRepository;
       private readonly IFlatValueOriginToValueOriginMapper _valueOriginMapper;
@@ -19,7 +19,6 @@ namespace PKSim.Infrastructure.ORM.Repositories
       };
 
       private readonly Cache<int, ValueOrigin> _allValueOrigins = new Cache<int, ValueOrigin>(onMissingKey: x => _defaultValueOrigin);
-      private bool _started;
 
       public ValueOriginRepository(IFlatValueOriginRepository flatValueOriginRepository, IFlatValueOriginToValueOriginMapper valueOriginMapper)
       {
@@ -27,17 +26,15 @@ namespace PKSim.Infrastructure.ORM.Repositories
          _valueOriginMapper = valueOriginMapper;
       }
 
-      public IEnumerable<ValueOrigin> All()
+      public override IEnumerable<ValueOrigin> All()
       {
          Start();
          return _allValueOrigins;
       }
 
-      public void Start()
+      protected override void DoStart()
       {
-         if (_started) return;
          _flatValueOriginRepository.All().Each(x => { _allValueOrigins[x.Id] = _valueOriginMapper.MapFrom(x); });
-         _started = true;
       }
 
       public ValueOrigin ValueOriginFor(IParameter parameter)

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.132" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Infrastructure/Services/StartableWarmup.cs
+++ b/src/PKSim.Infrastructure/Services/StartableWarmup.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core.Services;
+
+namespace PKSim.Infrastructure.Services
+{
+   public class StartableWarmup : IStartableWarmup
+   {
+      private Task _warmupTask;
+
+      public void Begin(IReadOnlyList<IStartable> startables)
+      {
+         _warmupTask = Task.Factory.StartNew(
+            () =>
+            {
+               //DB values are mapped using the current culture; match the culture InfrastructureRegister sets for the UI thread.
+               Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+               Thread.CurrentThread.CurrentUICulture = new CultureInfo("en");
+               startables.Each(x => x.Start());
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+      }
+
+      public void AwaitCompletion()
+      {
+         var task = _warmupTask;
+         if (task == null)
+            return;
+
+         _warmupTask = null;
+         //GetResult rethrows the original warm-up exception (unwrapped) on the calling (UI) thread.
+         task.GetAwaiter().GetResult();
+      }
+   }
+}

--- a/src/PKSim.Presentation/Core/JournalPageEditorActivator.cs
+++ b/src/PKSim.Presentation/Core/JournalPageEditorActivator.cs
@@ -27,9 +27,11 @@ namespace PKSim.Presentation.Core
       public void Handle(EditJournalPageStartedEvent eventToHandle)
       {
          if (_activated) return;
-         _activated = true;
 
          _container.Resolve<IJournalPageEditorFormPresenter>();
+         //set only after a successful resolve (so a failed resolve retries on the next edit), but before
+         //re-publishing so the re-dispatched event does not re-enter this activator
+         _activated = true;
          //re-publish because the presenters created above were not yet subscribed when this event was published
          _eventPublisher.PublishEvent(eventToHandle);
          _eventPublisher.RemoveListener(this);

--- a/src/PKSim.Presentation/Core/JournalPageEditorActivator.cs
+++ b/src/PKSim.Presentation/Core/JournalPageEditorActivator.cs
@@ -1,0 +1,38 @@
+using OSPSuite.Core.Journal;
+using OSPSuite.Presentation.Presenters.Journal;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+
+namespace PKSim.Presentation.Core
+{
+   public interface IJournalPageEditorActivator : IListener<EditJournalPageStartedEvent>
+   {
+   }
+
+   /// <summary>
+   ///    Creates the journal page editor on first use because it constructs expensive DevExpress components.
+   /// </summary>
+   public class JournalPageEditorActivator : IJournalPageEditorActivator
+   {
+      private readonly IContainer _container;
+      private readonly IEventPublisher _eventPublisher;
+      private bool _activated;
+
+      public JournalPageEditorActivator(IContainer container, IEventPublisher eventPublisher)
+      {
+         _container = container;
+         _eventPublisher = eventPublisher;
+      }
+
+      public void Handle(EditJournalPageStartedEvent eventToHandle)
+      {
+         if (_activated) return;
+         _activated = true;
+
+         _container.Resolve<IJournalPageEditorFormPresenter>();
+         //re-publish because the presenters created above were not yet subscribed when this event was published
+         _eventPublisher.PublishEvent(eventToHandle);
+         _eventPublisher.RemoveListener(this);
+      }
+   }
+}

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/PresenterRegister.cs
+++ b/src/PKSim.Presentation/PresenterRegister.cs
@@ -109,6 +109,9 @@ namespace PKSim.Presentation
 
          container.Register<IFormatterFactory, FormatterFactory>();
 
+         //Activates the journal page editor on first use
+         container.Register<IJournalPageEditorActivator, JournalPageEditorActivator>(LifeStyle.Singleton);
+
          //Presentation-aware overrides for Infrastructure services
          container.Register<IPKSimXmlSerializerRepository, PKSimXmlSerializerRepository>(LifeStyle.Singleton);
          container.Register<IWorkspace, IWithWorkspaceLayout, ICoreWorkspace, OSPSuite.Core.IWorkspace, Workspace>(LifeStyle.Singleton);
@@ -126,6 +129,9 @@ namespace PKSim.Presentation
          scan.ExcludeType<CloseSubjectPresenterInvoker>();
          scan.ExcludeType<ButtonGroupRepository>();
          scan.ExcludeType<MenuBarItemRepository>();
+
+         //Registered explicitly as singleton in RegisterInContainer
+         scan.ExcludeType<JournalPageEditorActivator>();
 
          //This objects were already registered in Bootstrap
          scan.ExcludeType<ApplicationController>();

--- a/src/PKSim.Presentation/Presenters/Main/PKSimMainViewPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/PKSimMainViewPresenter.cs
@@ -34,6 +34,7 @@ namespace PKSim.Presentation.Presenters.Main
       private readonly IPKSimConfiguration _configuration;
       private readonly IPostLaunchChecker _postLaunchChecker;
       private readonly IVersionChecker _versionChecker;
+      private readonly IStartableWarmup _startableWarmup;
       public StartOptions StartOptions { get; set; }
 
       public PKSimMainViewPresenter(IPKSimMainView mainView,
@@ -45,7 +46,8 @@ namespace PKSim.Presentation.Presenters.Main
          IProjectTask projectTask,
          IPKSimConfiguration configuration,
          IPostLaunchChecker postLaunchChecker,
-         IVersionChecker versionChecker
+         IVersionChecker versionChecker,
+         IStartableWarmup startableWarmup
       )
          : base(mainView, eventPublisher, contextMenuFactory)
       {
@@ -56,6 +58,7 @@ namespace PKSim.Presentation.Presenters.Main
          _configuration = configuration;
          _postLaunchChecker = postLaunchChecker;
          _versionChecker = versionChecker;
+         _startableWarmup = startableWarmup;
       }
 
       public override void Initialize()
@@ -80,6 +83,10 @@ namespace PKSim.Presentation.Presenters.Main
 
       public override void Run()
       {
+         //The repository warm-up runs on a background thread during window construction; make sure it has finished
+         //before the first DB access (project load below).
+         _startableWarmup.AwaitCompletion();
+
          _projectTask.Run(StartOptions);
 
          _postLaunchChecker.PerformPostLaunchCheckAsync();

--- a/src/PKSim.Presentation/Repositories/MenuBarItemRepository.cs
+++ b/src/PKSim.Presentation/Repositories/MenuBarItemRepository.cs
@@ -480,7 +480,13 @@ namespace PKSim.Presentation.Repositories
          yield return JournalMenuBarButtons.JournalView(MenuBarItemIds.JournalView, _container);
          yield return JournalMenuBarButtons.CreateJournalPage(MenuBarItemIds.CreateJournalPage, _container);
          yield return JournalMenuBarButtons.SelectJournal(MenuBarItemIds.SelectJournal, _container);
-         yield return JournalMenuBarButtons.JournalEditorView(MenuBarItemIds.JournalEditorView, _container);
+         //Initialize JournalEditorVisibiliyUICommand on demand because it constructs expensive DevExpress components
+         yield return CreateMenuButton.WithCaption(Captions.Journal.JournalEditorView)
+            .WithId(MenuBarItemIds.JournalEditorView)
+            .WithDescription(Captions.Journal.JournalEditorViewDescription)
+            .WithActionCommand(() => _container.Resolve<JournalEditorVisibiliyUICommand>().Execute())
+            .WithIcon(ApplicationIcons.PageEdit);
+
          yield return CommonMenuBarButtons.JournalDiagramView(MenuBarItemIds.JournalDiagramView, _container);
          yield return JournalMenuBarButtons.SearchJournal(MenuBarItemIds.SearchJournal, _container);
          yield return CommonMenuBarButtons.LoadFavoritesFromFile(MenuBarItemIds.LoadFavorites, _container);

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.132" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
+++ b/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
@@ -172,6 +172,7 @@ namespace PKSim.UI.BootStrapping
          //Create one instance of the invokers so that the object is available in the application
          //since the object is not created anywhere and is only used as event listener
          container.Resolve<ICloseSubjectPresenterInvoker>();
+         container.Resolve<IJournalPageEditorActivator>();
 
          var mainPresenter = container.Resolve<IMainViewPresenter>();
          container.RegisterImplementationOf((IChangePropagator)mainPresenter);

--- a/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
+++ b/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
@@ -25,6 +25,7 @@ using PKSim.Core.Services;
 using PKSim.Infrastructure;
 using PKSim.Presentation;
 using PKSim.Presentation.Core;
+using PKSim.Presentation.Infrastructure.Services;
 using PKSim.Presentation.Presenters.Main;
 using PKSim.Presentation.Views;
 using PKSim.UI.Views.Core;
@@ -181,8 +182,16 @@ namespace PKSim.UI.BootStrapping
 
       private void startStartableObject(IContainer container)
       {
-         var rep = container.ResolveAll<IStartable>().ToList();
-         rep.Each(item => item.Start());
+         //Resolve all startables on the UI thread (Castle Windsor resolution stays single-threaded), then warm the
+         //DB-backed repositories on a background thread so their loading overlaps the main window construction.
+         var startables = container.ResolveAll<IStartable>().ToList();
+
+         //Settings are read while the main window is built (e.g. layout restore, comparison settings), so they must
+         //be loaded synchronously before construction; only the (DB-backed) repositories are deferred.
+         var synchronousStartables = startables.OfType<SettingsLoader>().ToList();
+         synchronousStartables.Each(item => item.Start());
+
+         container.Resolve<IStartableWarmup>().Begin(startables.Except(synchronousStartables).ToList());
       }
 
       public static void RegisterCommands(IContainer container)

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Presentation/JournalPageEditorActivatorSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/JournalPageEditorActivatorSpecs.cs
@@ -1,0 +1,79 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Journal;
+using OSPSuite.Presentation.Presenters.Journal;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+using PKSim.Presentation.Core;
+
+namespace PKSim.Presentation
+{
+   public abstract class concern_for_JournalPageEditorActivator : ContextSpecification<IJournalPageEditorActivator>
+   {
+      protected IContainer _container;
+      protected IEventPublisher _eventPublisher;
+      protected EditJournalPageStartedEvent _event;
+
+      protected override void Context()
+      {
+         _container = A.Fake<IContainer>();
+         _eventPublisher = A.Fake<IEventPublisher>();
+         _event = new EditJournalPageStartedEvent(new JournalPage(), showEditor: true);
+         sut = new JournalPageEditorActivator(_container, _eventPublisher);
+      }
+   }
+
+   public class When_the_journal_page_editor_activator_handles_the_first_edit_journal_page_started_event : concern_for_JournalPageEditorActivator
+   {
+      protected override void Because()
+      {
+         sut.Handle(_event);
+      }
+
+      [Observation]
+      public void should_create_the_journal_page_editor_form_presenter()
+      {
+         A.CallTo(() => _container.Resolve<IJournalPageEditorFormPresenter>()).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_republish_the_event_so_that_the_newly_subscribed_presenters_can_handle_it()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(_event)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_unsubscribe_itself_from_the_event_publisher()
+      {
+         A.CallTo(() => _eventPublisher.RemoveListener(sut)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_journal_page_editor_activator_handles_a_subsequent_edit_journal_page_started_event : concern_for_JournalPageEditorActivator
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Handle(_event);
+         Fake.ClearRecordedCalls(_container);
+         Fake.ClearRecordedCalls(_eventPublisher);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new EditJournalPageStartedEvent(new JournalPage(), showEditor: false));
+      }
+
+      [Observation]
+      public void should_not_create_the_editor_form_presenter_again()
+      {
+         A.CallTo(() => _container.Resolve<IJournalPageEditorFormPresenter>()).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_republish_the_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<EditJournalPageStartedEvent>._)).MustNotHaveHappened();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/PKSimMainViewPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/PKSimMainViewPresenterSpecs.cs
@@ -32,6 +32,7 @@ namespace PKSim.Presentation
       private ITabbedMdiChildViewContextMenuFactory _contextMenuFactory;
       protected IPKSimConfiguration _configuration;
       protected IPostLaunchChecker _postLaunchChecker;
+      protected IStartableWarmup _startableWarmup;
 
       protected override void Context()
       {
@@ -45,8 +46,9 @@ namespace PKSim.Presentation
          _contextMenuFactory = A.Fake<ITabbedMdiChildViewContextMenuFactory>();
          _configuration = A.Fake<IPKSimConfiguration>();
          _postLaunchChecker = A.Fake<IPostLaunchChecker>();
+         _startableWarmup = A.Fake<IStartableWarmup>();
          A.CallTo(() => _configuration.ProductDisplayName).Returns("AA");
-         sut = new PKSimMainViewPresenter(_view, _eventPublisher, _contextMenuFactory, _presenterRepository, _exitCommand, _userSettings, _projectTask, _configuration, _postLaunchChecker, _versionChecker);
+         sut = new PKSimMainViewPresenter(_view, _eventPublisher, _contextMenuFactory, _presenterRepository, _exitCommand, _userSettings, _projectTask, _configuration, _postLaunchChecker, _versionChecker, _startableWarmup);
       }
    }
 

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.132" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.131" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.132" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #1472

Reduces PK-Sim startup time. Four independent changes (~5 s combined, cold Debug):

| Fix | In this PR | Saving |
|---|---|---|
| `ValueOriginRepository.Start` guard (stop re-mapping value origins on every lookup) | yes | ~1.0 s |
| Background (parallel) repository warm-up overlapping window construction | yes | ~1.0 s |
| Journal page editor built on first use instead of at startup | yes | ~1.9 s |
| Skin gallery populated on demand (via OSPSuite.Core 13.0.132, #2902) | package bump | ~1.4 s |

Draft — opened alongside the MoBi counterpart (Open-Systems-Pharmacology/MoBi#2430) and depends on the published OSPSuite.Core 13.0.132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application startup now warms repositories concurrently in the background after settings are loaded, improving initial responsiveness.
  * Launch now waits for the warm-up to complete before the first database access.
  * Journal editor UI is created on first use and activated via the edit-start event.
* **Bug Fixes**
  * Prevents repeated initialization of the value-origin cache.
  * Journal editor menu command is now created lazily.
* **Tests**
  * Added/updated coverage for journal editor activation and warm-up/presenter startup behavior.
* **Chores**
  * Updated OSPSuite dependencies to version 13.0.132.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->