### PR TITLE
Allow re-use of an administration protocol for multiple compounds

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -446,7 +446,6 @@ namespace PKSim.Assets
          public const string AtLeastOneCompoundMustBeSelected = "At least one compound must be selected.";
          public const string AtLeastOneFileRequiredToStartPopulationImport = "At least one file is required to perform the population import.";
          public const string AtLeastOneProtocolRequiredToCreateSimulation = "Select at least one protocol for the administered compound(s).";
-         public const string AProtocolCanOnlyBeUsedOnceInASimulation = "Each administered compound must have a unique administration protocol.";
          public const string CanOnlyCompareTwoObjectsAtATime = "Object comparison is only available for two objects at the same time.";
          public const string AdvancedCommitNotAvailable = "Advanced commit is not supported.";
          public const string KeywordsAndReplacementsSizeDiffer = "Keywords and replacementValues do not have the same length!";

--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -134,17 +134,39 @@ namespace PKSim.Core.Services
 
       private void createApplications(IReadOnlyList<CompoundProperties> compoundPropertiesList)
       {
-         compoundPropertiesList.Each(addProtocol);
+         var administeredProperties = compoundPropertiesList.Where(x => x.ProtocolProperties.Protocol != null).ToList();
+         var sharedProtocolNames = sharedProtocolNamesFrom(administeredProperties);
+
+         administeredProperties.Each(compoundProperties =>
+         {
+            var protocol = compoundProperties.ProtocolProperties.Protocol;
+            var eventGroupName = eventGroupNameFor(protocol.Name, compoundProperties.Compound.Name, sharedProtocolNames);
+            addProtocol(compoundProperties, eventGroupName);
+         });
       }
 
-      private void addProtocol(CompoundProperties compoundProperties)
+      private static string eventGroupNameFor(string protocolName, string compoundName, IReadOnlyList<string> sharedProtocolNames)
+      {
+         return sharedProtocolNames.Contains(protocolName)
+            ? Constants.CompositeNameFor(protocolName, compoundName)
+            : protocolName;
+      }
+
+      private static IReadOnlyList<string> sharedProtocolNamesFrom(IReadOnlyList<CompoundProperties> administeredProperties)
+      {
+         return administeredProperties
+            .GroupBy(x => x.ProtocolProperties.Protocol.Name)
+            .Where(x => x.Count() > 1)
+            .Select(x => x.Key)
+            .ToList();
+      }
+
+      private void addProtocol(CompoundProperties compoundProperties, string eventGroupName)
       {
          var protocol = compoundProperties.ProtocolProperties.Protocol;
-         if (protocol == null)
-            return;
 
          var eventGroup = _objectBaseFactory.Create<EventGroupBuilder>()
-            .WithName(protocol.Name);
+            .WithName(eventGroupName);
 
          eventGroup.SourceCriteria.Add(new MatchTagCondition(CoreConstants.Tags.EVENTS));
 

--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -134,31 +134,74 @@ namespace PKSim.Core.Services
 
       private void createApplications(IReadOnlyList<CompoundProperties> compoundPropertiesList)
       {
-         var administeredProperties = compoundPropertiesList.Where(x => x.ProtocolProperties.Protocol != null).ToList();
-         var sharedProtocolNames = sharedProtocolNamesFrom(administeredProperties);
-
-         administeredProperties.Each(compoundProperties =>
-         {
-            var protocol = compoundProperties.ProtocolProperties.Protocol;
-            var eventGroupName = eventGroupNameFor(protocol.Name, compoundProperties.Compound.Name, sharedProtocolNames);
-            addProtocol(compoundProperties, eventGroupName);
-         });
-      }
-
-      private static string eventGroupNameFor(string protocolName, string compoundName, IReadOnlyList<string> sharedProtocolNames)
-      {
-         return sharedProtocolNames.Contains(protocolName)
-            ? Constants.CompositeNameFor(protocolName, compoundName)
-            : protocolName;
-      }
-
-      private static IReadOnlyList<string> sharedProtocolNamesFrom(IReadOnlyList<CompoundProperties> administeredProperties)
-      {
-         return administeredProperties
-            .GroupBy(x => x.ProtocolProperties.Protocol.Name)
-            .Where(x => x.Count() > 1)
-            .Select(x => x.Key)
+         var administrations = compoundPropertiesList
+            .Where(x => x.ProtocolProperties.Protocol != null)
+            .Select(x => new AdministrationContext(x))
             .ToList();
+
+         assignUniqueEventGroupNames(administrations);
+
+         administrations.Each(x => addProtocol(x.CompoundProperties, x.EventGroupName));
+      }
+
+
+      private static void assignUniqueEventGroupNames(IReadOnlyList<AdministrationContext> administrations)
+      {
+         var sharedProtocolNames = protocolNamesUsedByMoreThanOneCompound(administrations);
+
+         // assign event group names. For non shared, use the protocol names, for shared, use a composite name with the compound name
+         createEventGroupNamesForProtocols(administrations, sharedProtocolNames);
+         
+         // if a non-shared protocol event group has the same name as a shared composite, add the compound name to the non-shared
+         adjustNonSharedProtocolNames(administrations, sharedProtocolNames);
+
+         // there could still be name collisions. Use indexes to guarantee uniqueness
+         var usedNames = new HashSet<string>();
+         administrations.Each(x => x.EventGroupName = indexedNameFrom(x.EventGroupName, usedNames));
+      }
+
+      private static void adjustNonSharedProtocolNames(IReadOnlyList<AdministrationContext> administrations, ICollection<string> sharedProtocolNames)
+      {
+         administrations
+            .Where(x => protocolIsNotShared(sharedProtocolNames, x) && eventGroupNameIsDuplicated(administrations, x.EventGroupName))
+            .ToList()
+            .Each(x => x.EventGroupName = x.CompositeName);
+      }
+
+      private static bool protocolIsNotShared(ICollection<string> sharedProtocolNames, AdministrationContext x) => 
+         !sharedProtocolNames.Contains(x.ProtocolName);
+
+      private static void createEventGroupNamesForProtocols(IEnumerable<AdministrationContext> administrations, ICollection<string> sharedProtocolNames) =>
+         administrations.Each(x => x.EventGroupName = sharedProtocolNames.Contains(x.ProtocolName) ? x.CompositeName : x.ProtocolName);
+
+      private static ICollection<string> protocolNamesUsedByMoreThanOneCompound(IEnumerable<AdministrationContext> administrations) =>
+         new HashSet<string>(administrations.GroupBy(x => x.ProtocolName).Where(x => x.Count() > 1).Select(x => x.Key));
+
+      private static bool eventGroupNameIsDuplicated(IEnumerable<AdministrationContext> administrations, string eventGroupName) =>
+         administrations.Count(x => string.Equals(x.EventGroupName, eventGroupName)) > 1;
+
+      private static string indexedNameFrom(string name, ISet<string> usedNames)
+      {
+         var uniqueName = name;
+         var index = 2;
+         while (!usedNames.Add(uniqueName))
+            uniqueName = $"{name}_{index++}";
+
+         return uniqueName;
+      }
+
+      //Associates an administered compound with the event group name that will represent its protocol in the model.
+      private class AdministrationContext
+      {
+         public AdministrationContext(CompoundProperties compoundProperties)
+         {
+            CompoundProperties = compoundProperties;
+         }
+
+         public CompoundProperties CompoundProperties { get; }
+         public string ProtocolName => CompoundProperties.ProtocolProperties.Protocol.Name;
+         public string CompositeName => Constants.CompositeNameFor(ProtocolName, CompoundProperties.Compound.Name);
+         public string EventGroupName { get; set; }
       }
 
       private void addProtocol(CompoundProperties compoundProperties, string eventGroupName)

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolCollectorPresenter.cs
@@ -112,11 +112,6 @@ namespace PKSim.Presentation.Presenters.Simulations
             _hasWarnings = true;
             _view.Warning = PKSimConstants.Error.AtLeastOneProtocolRequiredToCreateSimulation;
          }
-         else if (protocols.Distinct().Count() != protocols.Count)
-         {
-            _hasWarnings = true;
-            _view.Warning = PKSimConstants.Error.AProtocolCanOnlyBeUsedOnceInASimulation;
-         }
          else
          {
             _hasWarnings = false;

--- a/tests/PKSim.Tests/IntegrationTests/EventBuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/EventBuildingBlockCreatorSpecs.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+
+namespace PKSim.IntegrationTests
+{
+   public abstract class concern_for_EventBuildingBlockCreator : ContextForSimulationIntegration<IEventBuildingBlockCreator, Simulation>
+   {
+      protected Individual _individual;
+      protected EventGroupBuildingBlock _result;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CreateFor(_simulation);
+      }
+
+      protected IReadOnlyList<string> AdministeredMoleculesIn(string eventGroupName)
+      {
+         return _result.FindByName(eventGroupName).GetAllChildren<ApplicationBuilder>().Select(x => x.MoleculeName).ToList();
+      }
+   }
+
+   public class When_creating_the_event_building_block_for_a_single_administered_compound : concern_for_EventBuildingBlockCreator
+   {
+      private Compound _compound;
+      private Protocol _protocol;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _compound = DomainFactoryForSpecs.CreateStandardCompound().WithName("C1");
+         _protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol);
+      }
+
+      [Observation]
+      public void should_name_the_event_group_after_the_protocol()
+      {
+         _result.Select(x => x.Name).ShouldOnlyContain(_protocol.Name);
+      }
+
+      [Observation]
+      public void should_administer_the_compound_in_the_event_group()
+      {
+         AdministeredMoleculesIn(_protocol.Name).ShouldOnlyContain(_compound.Name);
+      }
+   }
+
+   public class When_creating_the_event_building_block_for_two_compounds_with_distinct_protocols : concern_for_EventBuildingBlockCreator
+   {
+      private Compound _compound1;
+      private Compound _compound2;
+      private Protocol _protocol1;
+      private Protocol _protocol2;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _compound1 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C1");
+         _compound2 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C2");
+         _protocol1 = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName("P1");
+         _protocol2 = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName("P2");
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, new[] { _compound1, _compound2 }, new[] { _protocol1, _protocol2 });
+      }
+
+      [Observation]
+      public void should_name_each_event_group_after_its_own_protocol()
+      {
+         _result.Select(x => x.Name).ShouldOnlyContain(_protocol1.Name, _protocol2.Name);
+      }
+   }
+
+   public class When_creating_the_event_building_block_for_two_compounds_sharing_a_protocol : concern_for_EventBuildingBlockCreator
+   {
+      private Compound _compound1;
+      private Compound _compound2;
+      private Protocol _sharedProtocol;
+      private string _eventGroupName1;
+      private string _eventGroupName2;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _compound1 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C1");
+         _compound2 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C2");
+         _sharedProtocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _eventGroupName1 = Constants.CompositeNameFor(_sharedProtocol.Name, _compound1.Name);
+         _eventGroupName2 = Constants.CompositeNameFor(_sharedProtocol.Name, _compound2.Name);
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, new[] { _compound1, _compound2 }, new[] { _sharedProtocol, _sharedProtocol });
+      }
+
+      [Observation]
+      public void should_create_one_event_group_for_each_administered_compound()
+      {
+         _result.Count().ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_make_the_event_group_names_unique_by_combining_the_protocol_and_the_compound_name()
+      {
+         _result.Select(x => x.Name).ShouldOnlyContain(_eventGroupName1, _eventGroupName2);
+      }
+
+      [Observation]
+      public void each_event_group_should_administer_only_its_own_compound()
+      {
+         AdministeredMoleculesIn(_eventGroupName1).ShouldOnlyContain(_compound1.Name);
+         AdministeredMoleculesIn(_eventGroupName2).ShouldOnlyContain(_compound2.Name);
+      }
+   }
+}

--- a/tests/PKSim.Tests/IntegrationTests/EventBuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/EventBuildingBlockCreatorSpecs.cs
@@ -120,4 +120,70 @@ namespace PKSim.IntegrationTests
          AdministeredMoleculesIn(_eventGroupName2).ShouldOnlyContain(_compound2.Name);
       }
    }
+
+   //Protocol "A" is shared by C1 and C2 (event groups "A-C1" and "A-C2"), while a different single-use protocol
+   //is literally named "A-C1". Its bare name would collide with the composite, so it is combined with its compound too.
+   public class When_creating_the_event_building_block_for_a_protocol_named_like_the_composite_of_a_shared_protocol : concern_for_EventBuildingBlockCreator
+   {
+      private Compound _compound1;
+      private Compound _compound2;
+      private Compound _compound3;
+      private Protocol _sharedProtocol;
+      private Protocol _collidingProtocol;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _compound1 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C1");
+         _compound2 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C2");
+         _compound3 = DomainFactoryForSpecs.CreateStandardCompound().WithName("C3");
+         _sharedProtocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName("A");
+         _collidingProtocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName(Constants.CompositeNameFor("A", "C1"));
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual,
+            new[] { _compound1, _compound2, _compound3 },
+            new[] { _sharedProtocol, _sharedProtocol, _collidingProtocol });
+      }
+
+      [Observation]
+      public void should_disambiguate_the_colliding_bare_name_by_combining_it_with_its_compound()
+      {
+         _result.Select(x => x.Name).ShouldOnlyContain(
+            Constants.CompositeNameFor("A", "C1"),
+            Constants.CompositeNameFor("A", "C2"),
+            Constants.CompositeNameFor(_collidingProtocol.Name, "C3"));
+      }
+   }
+
+   //Two different shared protocols produce the same composite name (protocol "A" + compound "B-C" and
+   //protocol "A-B" + compound "C" both yield "A-B-C"), so the residual collision is resolved with a suffix.
+   public class When_creating_the_event_building_block_for_compounds_whose_composite_names_collide : concern_for_EventBuildingBlockCreator
+   {
+      private Protocol _protocolA;
+      private Protocol _protocolAB;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var compoundBC = DomainFactoryForSpecs.CreateStandardCompound().WithName("B-C");
+         var compoundX = DomainFactoryForSpecs.CreateStandardCompound().WithName("X");
+         var compoundC = DomainFactoryForSpecs.CreateStandardCompound().WithName("C");
+         var compoundY = DomainFactoryForSpecs.CreateStandardCompound().WithName("Y");
+         _protocolA = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName("A");
+         _protocolAB = DomainFactoryForSpecs.CreateStandardIVBolusProtocol().WithName("A-B");
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual,
+            new[] { compoundBC, compoundX, compoundC, compoundY },
+            new[] { _protocolA, _protocolA, _protocolAB, _protocolAB });
+      }
+
+      [Observation]
+      public void should_resolve_the_residual_composite_collision_with_a_numeric_suffix()
+      {
+         var duplicatedComposite = Constants.CompositeNameFor("A", "B-C"); //== CompositeNameFor("A-B", "C")
+         _result.Select(x => x.Name).ShouldOnlyContain(
+            duplicatedComposite,
+            $"{duplicatedComposite}_2",
+            Constants.CompositeNameFor("A", "X"),
+            Constants.CompositeNameFor("A-B", "Y"));
+      }
+   }
 }

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolCollectorPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolCollectorPresenterSpecs.cs
@@ -100,11 +100,11 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_return_false_if_two_selected_protocols_are_the_same()
+      public void should_return_true_if_two_selected_protocols_are_the_same()
       {
          A.CallTo(() => _subPresenter2.SelectedProtocol).Returns(_subPresenter1.SelectedProtocol);
          sut.EditSimulation(_simulation, CreationMode.New);
-         sut.CanClose.ShouldBeFalse();
+         sut.CanClose.ShouldBeTrue();
       }
 
       [Observation]
@@ -128,12 +128,11 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_show_a_warning_if_two_protocols_are_the_same()
+      public void should_not_show_a_warning_if_two_protocols_are_the_same()
       {
          A.CallTo(() => _subPresenter2.SelectedProtocol).Returns(_subPresenter1.SelectedProtocol);
          sut.EditSimulation(_simulation, CreationMode.New);
-         _view.WarningVisible.ShouldBeTrue();
-         _view.Warning.ShouldBeEqualTo(PKSimConstants.Error.AProtocolCanOnlyBeUsedOnceInASimulation);
+         _view.WarningVisible.ShouldBeFalse();
       }
 
       [Observation]
@@ -219,7 +218,7 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_update_the_selected_protocol_in_the_approriate_presenter()
+      public void should_update_the_selected_protocol_in_the_appropriate_presenter()
       {
          A.CallTo(() => _subPresenter1.ProtocolSelectionChanged(_templateProtocol)).MustHaveHappened();
       }


### PR DESCRIPTION
Allows the same administration protocol to be selected for more than one compound in a simulation.

Previously this was blocked in the simulation wizard (`SimulationCompoundProtocolCollectorPresenter`) with the warning *"Each administered compound must have a unique administration protocol."* The restriction existed because each compound's applications are built into an event group named after the protocol — so a shared protocol produced two event groups with the same name (colliding container/model paths).

Original naming remains when not shared
<img width="395" height="249" alt="image" src="https://github.com/user-attachments/assets/f0842b37-fc22-4ef0-96c2-8fb1ec83ada6" />


Shared
<img width="438" height="357" alt="image" src="https://github.com/user-attachments/assets/bb1308f4-cd52-45db-8406-ff5f92194c73" />


Fixes #3603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulations can now use the same administration protocol for multiple compounds.
  - Event groups are automatically named to remain unique and clearly associated with each compound.

- **Bug Fixes**
  - Removed duplicate-protocol validation warnings during compound protocol selection.
  - Corrected event-group naming when protocol and compound combinations could otherwise collide.

- **Tests**
  - Expanded coverage for shared protocols, naming conflicts, and duplicate selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->