### PR TITLE
Fixes #3437 Merge overwrite parameter set values into ParameterValues building block on MoBi export

### DIFF
--- a/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
@@ -21,36 +21,54 @@ namespace PKSim.Core.Services
       ///    simulation, in which case no value is applied.
       /// </summary>
       void ApplyOverwriteParameterSetsTo(Simulation simulation);
+
+      /// <summary>
+      ///    Adds the values of the <see cref="OverwriteParameterSet" /> selected for each compound in the
+      ///    <paramref name="simulation" /> into <paramref name="parameterValues" /> so that they are carried over when the
+      ///    simulation is exported to MoBi. The matching simulation parameter provides the entry metadata (dimension, unit)
+      ///    and the overwrite set provides the value. An existing entry for a path is updated; otherwise a new one is created.
+      ///    Compounds whose selection is "None" are skipped.
+      /// </summary>
+      void ApplyOverwriteParameterSetsTo(ParameterValuesBuildingBlock parameterValues, Simulation simulation);
    }
 
    public class OverwriteParameterSetApplicationTask : IOverwriteParameterSetApplicationTask
    {
       private readonly IContainerTask _containerTask;
+      private readonly IEntityPathResolver _entityPathResolver;
+      private readonly IParameterValuesCreator _parameterValuesCreator;
 
-      public OverwriteParameterSetApplicationTask(IContainerTask containerTask)
+      public OverwriteParameterSetApplicationTask(IContainerTask containerTask, IEntityPathResolver entityPathResolver, IParameterValuesCreator parameterValuesCreator)
       {
          _containerTask = containerTask;
+         _entityPathResolver = entityPathResolver;
+         _parameterValuesCreator = parameterValuesCreator;
       }
 
-      public void ApplyOverwriteParameterSetsTo(Simulation simulation)
+      public void ApplyOverwriteParameterSetsTo(Simulation simulation) => resolveOverwriteValues(simulation).Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+
+      public void ApplyOverwriteParameterSetsTo(ParameterValuesBuildingBlock parameterValues, Simulation simulation) => resolveOverwriteValues(simulation).Each(x => addToParameterValues(x.parameter, x.parameterValue, parameterValues));
+
+      private List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
       {
+         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)>();
+
          var selections = simulation.OverwriteParameterSetSelections.Selections
             .Where(x => x.OverwriteParameterSet != null)
             .ToList();
 
          if (!selections.Any())
-            return;
+            return resolvedValues;
 
          var parameterCache = _containerTask.CacheAllChildren<IParameter>(simulation.Model.Root);
          var unresolvedPaths = new List<string>();
-         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)>();
 
          selections.Each(selection => resolveSelection(selection, simulation, parameterCache, resolvedValues, unresolvedPaths));
 
          if (unresolvedPaths.Any())
             throw new CannotApplyOverwriteParameterSetException(unresolvedPaths);
 
-         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+         return resolvedValues;
       }
 
       private void resolveSelection(OverwriteParameterSetSelection selection, Simulation simulation, PathCache<IParameter> parameterCache,
@@ -80,6 +98,20 @@ namespace PKSim.Core.Services
          parameter.Origin.BuilingBlockId = compound.Id;
          parameter.ValueOrigin.Source = ValueOriginSources.Other;
          parameter.ValueOrigin.Description = $"{PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}'";
+      }
+
+      private void addToParameterValues(IParameter parameter, ParameterValue overwriteValue, ParameterValuesBuildingBlock buildingBlock)
+      {
+         var objectPath = _entityPathResolver.ObjectPathFor(parameter);
+         var parameterValue = buildingBlock[objectPath];
+         if (parameterValue == null)
+         {
+            parameterValue = _parameterValuesCreator.CreateParameterValue(objectPath, parameter);
+            buildingBlock.Add(parameterValue);
+         }
+
+         parameterValue.Value = overwriteValue.Value;
+         parameterValue.Formula = null;
       }
    }
 }

--- a/src/PKSim.Infrastructure/Services/MoBiExportTask.cs
+++ b/src/PKSim.Infrastructure/Services/MoBiExportTask.cs
@@ -34,6 +34,7 @@ namespace PKSim.Infrastructure.Services
       private readonly IApplicationSettings _applicationSettings;
       private readonly IStartableProcessFactory _startableProcessFactory;
       private readonly IModelCoreSimulationSnapshotUpdater _modelCoreSimulationSnapshotUpdater;
+      private readonly IOverwriteParameterSetApplicationTask _overwriteParameterSetApplicationTask;
 
       public MoBiExportTask(
          ISimulationConfigurationTask simulationConfigurationTask,
@@ -48,7 +49,8 @@ namespace PKSim.Infrastructure.Services
          IJournalRetriever journalRetriever,
          IApplicationSettings applicationSettings,
          IStartableProcessFactory startableProcessFactory,
-         IModelCoreSimulationSnapshotUpdater modelCoreSimulationSnapshotUpdater)
+         IModelCoreSimulationSnapshotUpdater modelCoreSimulationSnapshotUpdater,
+         IOverwriteParameterSetApplicationTask overwriteParameterSetApplicationTask)
       {
          _simulationConfigurationTask = simulationConfigurationTask;
          _simulationMapper = simulationMapper;
@@ -63,6 +65,7 @@ namespace PKSim.Infrastructure.Services
          _applicationSettings = applicationSettings;
          _startableProcessFactory = startableProcessFactory;
          _modelCoreSimulationSnapshotUpdater = modelCoreSimulationSnapshotUpdater;
+         _overwriteParameterSetApplicationTask = overwriteParameterSetApplicationTask;
       }
 
       public void StartWith(Simulation simulation)
@@ -122,6 +125,8 @@ namespace PKSim.Infrastructure.Services
             throw new PKSimException(PKSimConstants.Error.CannotExportAnImportedSimulation);
 
          var configuration = _simulationConfigurationTask.CreateFor(simulation, shouldValidate: true, createAgingDataInSimulation: false);
+         // the configuration has only one module configuration, which has SelectedParameterValues by construction
+         _overwriteParameterSetApplicationTask.ApplyOverwriteParameterSetsTo(configuration.ModuleConfigurations.First().SelectedParameterValues, simulation);
          var moBiSimulation = _simulationMapper.MapFrom(simulation, configuration, shouldCloneModel: true);
          updateRepresentationInfo(moBiSimulation);
          updateFormulaIdIn(moBiSimulation);

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -13,6 +14,8 @@ namespace PKSim.Core
    public abstract class concern_for_OverwriteParameterSetApplicationTask : ContextSpecification<OverwriteParameterSetApplicationTask>
    {
       protected IContainerTask _containerTask;
+      protected IEntityPathResolver _entityPathResolver;
+      protected IParameterValuesCreator _parameterValuesCreator;
       protected IndividualSimulation _simulation;
       protected Compound _compound;
       protected IParameter _lipophilicityParam;
@@ -22,6 +25,8 @@ namespace PKSim.Core
       protected override void Context()
       {
          _containerTask = A.Fake<IContainerTask>();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+         _parameterValuesCreator = A.Fake<IParameterValuesCreator>();
 
          _compound = new Compound { Name = "Aspirin", Id = "CompId" };
 
@@ -46,7 +51,12 @@ namespace PKSim.Core
          _parameterCache.Add("Organism|Aspirin|Permeability", _permeabilityParam);
          A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(_parameterCache);
 
-         sut = new OverwriteParameterSetApplicationTask(_containerTask);
+         A.CallTo(() => _entityPathResolver.ObjectPathFor(_lipophilicityParam, false)).Returns("Organism|Aspirin|Lipophilicity".ToObjectPath());
+         A.CallTo(() => _entityPathResolver.ObjectPathFor(_permeabilityParam, false)).Returns("Organism|Aspirin|Permeability".ToObjectPath());
+         A.CallTo(() => _parameterValuesCreator.CreateParameterValue(A<ObjectPath>._, A<IParameter>._))
+            .ReturnsLazily((ObjectPath path, IParameter p) => new ParameterValue { Path = path, Value = p.Value });
+
+         sut = new OverwriteParameterSetApplicationTask(_containerTask, _entityPathResolver, _parameterValuesCreator);
       }
 
       protected OverwriteParameterSet overwriteParameterSetWith(params (string path, double value)[] values)
@@ -197,6 +207,157 @@ namespace PKSim.Core
       {
          _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
          _secondCompoundParam.Origin.BuilingBlockId.ShouldBeEqualTo(_secondCompound.Id);
+      }
+   }
+
+   public class When_writing_an_overwrite_parameter_set_into_a_parameter_values_building_block : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private ParameterValuesBuildingBlock _parameterValues;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValues = new ParameterValuesBuildingBlock();
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_parameterValues, _simulation);
+      }
+
+      [Observation]
+      public void should_add_an_entry_for_the_overwritten_parameter_with_the_overwrite_value()
+      {
+         var entry = _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()];
+         entry.ShouldNotBeNull();
+         entry.Value.ShouldBeEqualTo(5.0);
+      }
+
+      [Observation]
+      public void should_write_the_entry_as_value_only_without_a_formula()
+      {
+         _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()].Formula.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_not_add_entries_for_parameters_that_are_not_part_of_the_set()
+      {
+         _parameterValues["Organism|Aspirin|Permeability".ToObjectPath()].ShouldBeNull();
+      }
+   }
+
+   public class When_writing_an_overwrite_parameter_set_over_an_existing_formula_based_entry : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private ParameterValuesBuildingBlock _parameterValues;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValues = new ParameterValuesBuildingBlock();
+         _parameterValues.Add(new ParameterValue { Path = "Organism|Aspirin|Lipophilicity".ToObjectPath(), Formula = _lipophilicityParam.Formula });
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_parameterValues, _simulation);
+      }
+
+      [Observation]
+      public void should_set_the_overwrite_value_on_the_existing_entry()
+      {
+         _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()].Value.ShouldBeEqualTo(5.0);
+      }
+
+      [Observation]
+      public void should_clear_the_existing_formula_so_the_entry_is_value_only()
+      {
+         _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()].Formula.ShouldBeNull();
+      }
+   }
+
+   public class When_writing_an_overwrite_parameter_set_into_a_building_block_that_already_contains_the_path : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private ParameterValuesBuildingBlock _parameterValues;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValues = new ParameterValuesBuildingBlock();
+         _parameterValues.Add(new ParameterValue { Path = "Organism|Aspirin|Lipophilicity".ToObjectPath(), Value = 1.0 });
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_parameterValues, _simulation);
+      }
+
+      [Observation]
+      public void should_update_the_existing_entry_rather_than_add_a_duplicate()
+      {
+         _parameterValues.Count().ShouldBeEqualTo(1);
+         _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()].Value.ShouldBeEqualTo(5.0);
+      }
+   }
+
+   public class When_writing_into_a_building_block_and_no_overwrite_parameter_set_is_selected : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private ParameterValuesBuildingBlock _parameterValues;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValues = new ParameterValuesBuildingBlock();
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", null);
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_parameterValues, _simulation);
+      }
+
+      [Observation]
+      public void should_leave_the_parameter_values_building_block_empty()
+      {
+         _parameterValues.Count().ShouldBeEqualTo(0);
+      }
+   }
+
+   public class When_writing_overwrite_parameter_sets_for_multiple_compounds_into_a_building_block : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private ParameterValuesBuildingBlock _parameterValues;
+      private Compound _secondCompound;
+      private IParameter _secondCompoundParam;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterValues = new ParameterValuesBuildingBlock();
+         _secondCompound = new Compound { Name = "Midazolam", Id = "CompId2" };
+         _secondCompoundParam = DomainHelperForSpecs.ConstantParameterWithValue(1.0).WithName("Solubility");
+         _secondCompoundParam.BuildingBlockType = PKSimBuildingBlockType.Simulation;
+
+         _simulation.Model.Root.Add(_secondCompoundParam);
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId2", PKSimBuildingBlockType.Compound) { BuildingBlock = _secondCompound });
+         _parameterCache.Add("Organism|Midazolam|Solubility", _secondCompoundParam);
+         A.CallTo(() => _entityPathResolver.ObjectPathFor(_secondCompoundParam, false)).Returns("Organism|Midazolam|Solubility".ToObjectPath());
+
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+         _simulation.AddOverwriteParameterSetSelection("Midazolam", overwriteParameterSetWith(("Organism|Midazolam|Solubility", 2.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_parameterValues, _simulation);
+      }
+
+      [Observation]
+      public void should_add_an_entry_for_each_compound_parameter_with_its_overwrite_value()
+      {
+         _parameterValues["Organism|Aspirin|Lipophilicity".ToObjectPath()].Value.ShouldBeEqualTo(5.0);
+         _parameterValues["Organism|Midazolam|Solubility".ToObjectPath()].Value.ShouldBeEqualTo(2.0);
       }
    }
 }

--- a/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
@@ -36,6 +36,7 @@ namespace PKSim.Infrastructure
       protected IApplicationSettings _applicationSettings;
       protected IStartableProcessFactory _startableProcessFactory;
       protected IModelCoreSimulationSnapshotUpdater _modelCoreSimulationSnapshotUpdater;
+      protected IOverwriteParameterSetApplicationTask _overwriteParameterSetApplicationTask;
       protected Simulation _sim;
       private IModelCoreSimulation _modelCoreSimulation;
 
@@ -54,7 +55,15 @@ namespace PKSim.Infrastructure
          _applicationSettings = A.Fake<IApplicationSettings>();
          _startableProcessFactory = A.Fake<IStartableProcessFactory>();
          _modelCoreSimulationSnapshotUpdater = A.Fake<IModelCoreSimulationSnapshotUpdater>();
+         _overwriteParameterSetApplicationTask = A.Fake<IOverwriteParameterSetApplicationTask>();
          _sim = A.Fake<Simulation>();
+
+         var exportConfiguration = new SimulationConfiguration();
+         exportConfiguration.AddModuleConfiguration(new ModuleConfiguration(new Module())
+         {
+            SelectedParameterValues = new ParameterValuesBuildingBlock()
+         });
+         A.CallTo(() => _simulationConfigurationTask.CreateFor(A<Simulation>._, A<bool>._, A<bool>._)).Returns(exportConfiguration);
 
          _modelCoreSimulation = new ModelCoreSimulation
          {
@@ -70,7 +79,7 @@ namespace PKSim.Infrastructure
          A.CallTo(() => _simulationMapper.MapFrom(_sim, A<SimulationConfiguration>._, true)).Returns(_modelCoreSimulation);
 
          sut = new MoBiExportTask(_simulationConfigurationTask, _simulationMapper, _representationInfoRepository,
-            _configuration, _lazyLoadTask, _dialogCreator, _simulationPersistor, _projectRetriever, _objectIdResetter, _journalRetriever, _applicationSettings, _startableProcessFactory, _modelCoreSimulationSnapshotUpdater);
+            _configuration, _lazyLoadTask, _dialogCreator, _simulationPersistor, _projectRetriever, _objectIdResetter, _journalRetriever, _applicationSettings, _startableProcessFactory, _modelCoreSimulationSnapshotUpdater, _overwriteParameterSetApplicationTask);
       }
    }
 

--- a/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
@@ -150,6 +150,12 @@ namespace PKSim.Infrastructure
       {
          A.CallTo(() => _objectIdResetter.ResetIdFor(_simulationTransfer.Simulation)).MustHaveHappened();
       }
+
+      [Observation]
+      public void should_apply_the_overwrite_parameter_sets_into_the_configuration_parameter_values()
+      {
+         A.CallTo(() => _overwriteParameterSetApplicationTask.ApplyOverwriteParameterSetsTo(A<ParameterValuesBuildingBlock>._, _sim)).MustHaveHappened();
+      }
    }
 
    public class When_exporting_a_simulation_to_MoBi_and_the_application_was_installed_using_the_setup : concern_for_MoBiExportTask


### PR DESCRIPTION
Overwrite parameter sets are applied to the model as `Compound`-type parameters, so they were left out of the `ParameterValues` building block on MoBi export and lost on import.

This writes the selected overwrite values into the `ParameterValues` building block during MoBi export, as value-only entries. No MoBi UI changes.

Fixes #3437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overwrite parameter sets are now applied to parameter values during MoBi exports.
  * Exported parameters reflect selected overwrite values, including values for multiple compounds.
  * Existing formula-based parameter entries are replaced with explicit overwrite values.

* **Bug Fixes**
  * Prevented duplicate parameter entries when an exported path already exists.
  * Unresolved parameter paths continue to report an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->