### PR TITLE
Fixes #3607 Register missing headless services for SnapshotExchange

### DIFF
--- a/src/PKSim.Starter/CLIApplicationStartup.cs
+++ b/src/PKSim.Starter/CLIApplicationStartup.cs
@@ -11,6 +11,7 @@ using PKSim.CLI.Core.MinimalImplementations;
 using PKSim.Core;
 using PKSim.Core.Services;
 using PKSim.Infrastructure;
+using PKSim.Infrastructure.Serialization.Xml.Serializers;
 using PKSim.Presentation;
 using System;
 using System.Threading;
@@ -57,6 +58,7 @@ public class CLIApplicationStartup : ApplicationStartup
          pkSimContainer.AddRegister(x => x.FromType<CLI.Core.CLIRegister>());
 
          pkSimContainer.Register<IInteractiveSimulationRunner, InteractiveSimulationRunner>(LifeStyle.Singleton);
+         pkSimContainer.Register<IPKSimXmlSerializerRepository, CorePKSimXmlSerializerRepository>(LifeStyle.Singleton);
          InfrastructureRegister.RegisterSerializationDependencies(pkSimContainer);
          PKSim.Presentation.Infrastructure.PresentationSerializerInitializer.AddPresentationSerializers(pkSimContainer);
          InfrastructureRegister.LoadDefaultEntities(pkSimContainer);

--- a/src/PKSim.Starter/CLIApplicationStartup.cs
+++ b/src/PKSim.Starter/CLIApplicationStartup.cs
@@ -11,7 +11,9 @@ using PKSim.CLI.Core.MinimalImplementations;
 using PKSim.Core;
 using PKSim.Core.Services;
 using PKSim.Infrastructure;
+using PKSim.Infrastructure.Serialization;
 using PKSim.Infrastructure.Serialization.Xml.Serializers;
+using PKSim.Infrastructure.Services;
 using PKSim.Presentation;
 using System;
 using System.Threading;
@@ -79,5 +81,8 @@ public class CLIApplicationStartup : ApplicationStartup
       container.Register<IHistoryManager, HistoryManager<IExecutionContext>>();
       container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, IPresentationUserSettings, CLIStarterUserSettings>(LifeStyle.Singleton);
       container.Register<ICoreWorkspace, IWorkspace, CLIWorkspace>(LifeStyle.Singleton);
+      container.Register<IWorkspacePersistor, CoreWorkspacePersistor>(LifeStyle.Singleton);
+      container.Register<IObservedDataTask, CoreObservedDataTask>();
+      container.Register<ISimulationChartsLoader, CLISimulationChartsLoader>();
    }
 }


### PR DESCRIPTION
Fixes #3607

3e6d0a9 (#3537) moved several service registrations out of `InfrastructureRegister` and into the individual bootstraps, but `PKSim.Starter.CLIApplicationStartup` was missed — so the `SnapshotExchange` entry points fail, first with "No component for supporting the service IPKSimXmlSerializerRepository" in `LoadDefaultEntities`, then on other services resolved later.

Mirror the explicit registrations the other headless bootstraps (PKSim.CLI, PKSim.R) received in that commit, with the serializer repository registered before `LoadDefaultEntities`, where it is resolved.