### PR TITLE
Fixes #3482 Renaming compound implications for OverwriteParameterSet

### DIFF
--- a/src/PKSim.Core/Model/OverwriteParameterSet.cs
+++ b/src/PKSim.Core/Model/OverwriteParameterSet.cs
@@ -77,6 +77,21 @@ namespace PKSim.Core.Model
       public ParameterValue ParameterValueByPath(string parameterPath) =>
          _parameterValues[parameterPath.ToObjectPath()];
 
+      /// <summary>
+      ///    Replaces all path entries equal to <paramref name="oldCompoundName" /> with <paramref name="newCompoundName" />
+      ///    in the paths of all parameter values.
+      /// </summary>
+      public void ChangeCompoundName(string oldCompoundName, string newCompoundName)
+      {
+         var parameterValues = _parameterValues.ToList();
+         _parameterValues.Clear();
+         parameterValues.Each(parameterValue =>
+         {
+            parameterValue.Path = new ObjectPath(parameterValue.Path.Select(entry => string.Equals(entry, oldCompoundName) ? newCompoundName : entry));
+            Add(parameterValue);
+         });
+      }
+
       public override void UpdatePropertiesFrom(IUpdatable source, ICloneManager cloneManager)
       {
          base.UpdatePropertiesFrom(source, cloneManager);

--- a/src/PKSim.Core/Services/IBuildingBlockTask.cs
+++ b/src/PKSim.Core/Services/IBuildingBlockTask.cs
@@ -66,6 +66,12 @@ namespace PKSim.Core.Services
 
       IPKSimCommand DeleteCommand<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IPKSimBuildingBlock;
       void RemovePresenterSettings<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IPKSimBuildingBlock;
+
+      /// <summary>
+      ///    Replaces <paramref name="oldCompoundName" /> with <paramref name="newCompoundName" /> in the parameter paths of
+      ///    all <see cref="OverwriteParameterSet" />s of <paramref name="buildingBlock" /> if it is a <see cref="Compound" />.
+      /// </summary>
+      void ChangeCompoundNameInOverwriteParameterSets(IPKSimBuildingBlock buildingBlock, string oldCompoundName, string newCompoundName);
    }
 
    public interface IBuildingBlockTask<TBuildingBlock> where TBuildingBlock : IPKSimBuildingBlock

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Collections;
@@ -16,7 +17,7 @@ using PKSim.Presentation.Views.Compounds;
 
 namespace PKSim.Presentation.Presenters.Compounds;
 
-public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, IListener<OverwriteParameterSetChangedEvent>
+public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, IListener<OverwriteParameterSetChangedEvent>, IListener<RenamedEvent>
 {
    void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValue);
    void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
@@ -114,6 +115,14 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
    public void Handle(OverwriteParameterSetChangedEvent eventToHandle)
    {
       if (!Equals(eventToHandle.Compound, _compound))
+         return;
+
+      rebindView();
+   }
+
+   public void Handle(RenamedEvent eventToHandle)
+   {
+      if (!Equals(eventToHandle.RenamedObject, _compound))
          return;
 
       rebindView();

--- a/src/PKSim.Presentation/Services/BuildingBlockTask.cs
+++ b/src/PKSim.Presentation/Services/BuildingBlockTask.cs
@@ -79,12 +79,22 @@ namespace PKSim.Presentation.Services
 
             clone.Creation.AsCloneOf(buildingBlockToClone);
 
+            ChangeCompoundNameInOverwriteParameterSets(clone, buildingBlockToClone.Name, clone.Name);
+
             var addCommand = new AddBuildingBlockToProjectCommand(clone, _executionContext).Run(_executionContext);
             var entityType = _entityTask.TypeFor(buildingBlockToClone);
             addCommand.Description = PKSimConstants.Command.CloneEntity(entityType, buildingBlockToClone.Name, clone.Name);
 
             AddCommandToHistory(addCommand);
          }
+      }
+
+      public void ChangeCompoundNameInOverwriteParameterSets(IPKSimBuildingBlock buildingBlock, string oldCompoundName, string newCompoundName)
+      {
+         if (!(buildingBlock is Compound compound) || string.Equals(oldCompoundName, newCompoundName))
+            return;
+
+         compound.OverwriteParameterSets.Each(x => x.ChangeCompoundName(oldCompoundName, newCompoundName));
       }
 
       private ICloneBuildingBlockPresenter getCloneBuildingBlockPresenter(IPKSimBuildingBlock buildingBlockToClone)

--- a/src/PKSim.Presentation/Services/RenameBuildingBlockTask.cs
+++ b/src/PKSim.Presentation/Services/RenameBuildingBlockTask.cs
@@ -120,6 +120,7 @@ namespace PKSim.Presentation.Services
          //Perform rename of molecule in expression profile first as it relies on the old name still being present
          renameMoleculeNameInExpressionProfile(templateBuildingBlock, newName);
          renameUsageOfBuildingBlockInObservedData(templateBuildingBlock, newName);
+         _buildingBlockTask.ChangeCompoundNameInOverwriteParameterSets(templateBuildingBlock, templateBuildingBlock.Name, newName);
 
          //update the name
          templateBuildingBlock.Name = newName;

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetSpecs.cs
@@ -155,6 +155,42 @@ namespace PKSim.Core
       }
    }
 
+   public class When_changing_the_compound_name : concern_for_OverwriteParameterSet
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Add(new ParameterValue { Path = "OLD|Lipophilicity".ToObjectPath(), Value = 1.0 });
+         sut.Add(new ParameterValue { Path = "Organism|Liver|OLD|Concentration".ToObjectPath(), Value = 2.0 });
+         sut.Add(new ParameterValue { Path = "Organism|Weight".ToObjectPath(), Value = 3.0 });
+      }
+
+      protected override void Because()
+      {
+         sut.ChangeCompoundName("OLD", "NEW");
+      }
+
+      [Observation]
+      public void should_replace_the_compound_name_in_all_parameter_value_paths()
+      {
+         sut.ParameterValueByPath("NEW|Lipophilicity").Value.ShouldBeEqualTo(1.0);
+         sut.ParameterValueByPath("Organism|Liver|NEW|Concentration").Value.ShouldBeEqualTo(2.0);
+      }
+
+      [Observation]
+      public void should_not_change_paths_that_do_not_contain_the_compound_name()
+      {
+         sut.ParameterValueByPath("Organism|Weight").Value.ShouldBeEqualTo(3.0);
+      }
+
+      [Observation]
+      public void should_no_longer_return_parameter_values_for_the_old_paths()
+      {
+         sut.ParameterValueByPath("OLD|Lipophilicity").ShouldBeNull();
+         sut.ParameterValueByPath("Organism|Liver|OLD|Concentration").ShouldBeNull();
+      }
+   }
+
    public class When_updating_properties_from_another_overwrite_parameter_set : concern_for_OverwriteParameterSet
    {
       private OverwriteParameterSet _source;

--- a/tests/PKSim.Tests/Presentation/BuildingBlockTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockTaskSpecs.cs
@@ -154,6 +154,37 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_cloning_a_compound_with_overwrite_parameter_sets : concern_for_BuildingBlockTask
+   {
+      private Compound _compound;
+      private Compound _clonedCompound;
+      private OverwriteParameterSet _clonedSet;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _compound = new Compound().WithName("OLD");
+         _clonedCompound = new Compound().WithName("NEW");
+         _clonedSet = new OverwriteParameterSet { Name = "Set" };
+         _clonedSet.Add(new OSPSuite.Core.Domain.Builder.ParameterValue { Path = "OLD|Lipophilicity".ToObjectPath(), Value = 1.0 });
+         _clonedCompound.AddOverwriteParameterSet(_clonedSet);
+         A.CallTo(() => _clonePresenter.CreateCloneFor(_compound)).Returns(_clonedCompound);
+      }
+
+      protected override Task Because()
+      {
+         sut.Clone(_compound);
+         return _completed;
+      }
+
+      [Observation]
+      public void should_replace_the_original_compound_name_with_the_clone_name_in_the_paths_of_all_overwrite_parameter_sets()
+      {
+         _clonedSet.ParameterValueByPath("NEW|Lipophilicity").ShouldNotBeNull();
+         _clonedSet.ParameterValueByPath("OLD|Lipophilicity").ShouldBeNull();
+      }
+   }
+
    public class When_asked_to_delete_a_building_block_that_is_not_used_in_any_simulation_and_the_user_cancels_the_action : concern_for_BuildingBlockTask
    {
       private string _buildingBlockType;

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using PKSim.Assets;
 using PKSim.Core.Events;
@@ -327,6 +328,36 @@ namespace PKSim.Presentation
       {
          Fake.ClearRecordedCalls(_view);
          sut.Handle(new OverwriteParameterSetChangedEvent(new Compound { Name = "OtherCompound" }, _overwriteParameterSet));
+      }
+
+      [Observation]
+      public void should_not_rebind_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<OverwriteParameterSetDTO>>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_handling_a_renamed_event_for_the_edited_compound : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      protected override void Because()
+      {
+         Fake.ClearRecordedCalls(_view);
+         sut.Handle(new RenamedEvent(_compound));
+      }
+
+      [Observation]
+      public void should_rebind_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<OverwriteParameterSetDTO>>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_handling_a_renamed_event_for_another_object : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      protected override void Because()
+      {
+         Fake.ClearRecordedCalls(_view);
+         sut.Handle(new RenamedEvent(new Compound { Name = "OtherCompound" }));
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Presentation/RenameBuildingBlockTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/RenameBuildingBlockTaskSpecs.cs
@@ -284,6 +284,29 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_renaming_a_compound_with_overwrite_parameter_sets : concern_for_RenameBuildingBlockTask
+   {
+      private Compound _compound;
+
+      protected override void Context()
+      {
+         base.Context();
+         _compound = new Compound().WithName("OLD");
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(A.Fake<IProject>());
+      }
+
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_compound, "NEW");
+      }
+
+      [Observation]
+      public void should_update_the_compound_name_in_the_paths_of_all_overwrite_parameter_sets_before_the_rename()
+      {
+         A.CallTo(() => _buildingBlockTask.ChangeCompoundNameInOverwriteParameterSets(_compound, "OLD", "NEW")).MustHaveHappened();
+      }
+   }
+
    public class When_renaming_an_expression_profile_molecule : concern_for_RenameBuildingBlockTask
    {
       private ExpressionProfile _expressionProfile;


### PR DESCRIPTION
Fixes #3482

Renaming a compound during clone, import, or an explicit rename should update the paths of all the parameter overwrites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated overwrite parameter paths when a compound is renamed.
  * Preserved overwrite parameter values during compound cloning while replacing the original compound name.
  * Refreshed overwrite parameter views when the currently edited compound is renamed.
* **Tests**
  * Added coverage for compound renaming, cloning, and view refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->