### PR TITLE
Fixes #3458 Support overwrite parameter sets in population simulations

### DIFF
--- a/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
@@ -16,6 +16,9 @@ namespace PKSim.Core.Services
       ///    <paramref name="simulation" /> to the matching simulation parameters (matched by path). Affected parameters
       ///    become <see cref="PKSimBuildingBlockType.Compound" /> so that subsequent changes follow normal compound
       ///    parameter logic, and their value origin is set to identify the originating overwrite parameter set.
+      ///    Overwritten parameters are also flagged <see cref="IParameter.CanBeVariedInPopulation" />=false so that a
+      ///    population simulation keeps the overwritten value fixed; any advanced parameter already defined for such a
+      ///    path in a <see cref="PopulationSimulation" /> is removed so it cannot override the value at run time.
       ///    Compounds whose selection is "None" are skipped.
       ///    Throws a <see cref="CannotApplyOverwriteParameterSetException" /> if any path cannot be resolved in the
       ///    simulation, in which case no value is applied.
@@ -45,11 +48,33 @@ namespace PKSim.Core.Services
          _parameterValuesCreator = parameterValuesCreator;
       }
 
-      public void ApplyOverwriteParameterSetsTo(Simulation simulation) => resolveOverwriteValues(simulation).Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+      public void ApplyOverwriteParameterSetsTo(Simulation simulation)
+      {
+         var resolvedValues = resolveOverwriteValues(simulation);
+         applyValues(resolvedValues);
+         removeAdvancedParametersFor(simulation, resolvedValues);
+      }
+
+      private static void applyValues(IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues) =>
+         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+
+      private void removeAdvancedParametersFor(Simulation simulation,
+         IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues)
+      {
+         if (simulation is not PopulationSimulation populationSimulation)
+            return;
+
+         resolvedValues.Each(x =>
+         {
+            var advancedParameter = populationSimulation.AdvancedParameterFor(_entityPathResolver, x.parameter);
+            if (advancedParameter != null)
+               populationSimulation.RemoveAdvancedParameter(advancedParameter);
+         });
+      }
 
       public void ApplyOverwriteParameterSetsTo(ParameterValuesBuildingBlock parameterValues, Simulation simulation) => resolveOverwriteValues(simulation).Each(x => addToParameterValues(x.parameter, x.parameterValue, parameterValues));
 
-      private List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
+      private IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
       {
          var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)>();
 
@@ -98,6 +123,7 @@ namespace PKSim.Core.Services
          parameter.Origin.BuilingBlockId = compound.Id;
          parameter.ValueOrigin.Source = ValueOriginSources.Other;
          parameter.ValueOrigin.Description = $"{PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}'";
+         parameter.CanBeVariedInPopulation = false;
       }
 
       private void addToParameterValues(IParameter parameter, ParameterValue overwriteValue, ParameterValuesBuildingBlock buildingBlock)

--- a/src/PKSim.Presentation/Presenters/ContextMenus/UsedCompoundInSimulationContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/UsedCompoundInSimulationContextMenu.cs
@@ -23,7 +23,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
             yield return item;
          }
 
-         if (_simulation.HasUncommittedChangesForCompound(templateBuildingBlock.Name))
+         if (_simulation is IndividualSimulation && _simulation.HasUncommittedChangesForCompound(templateBuildingBlock.Name))
             yield return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.CommitSimulationParametersToCompounds)
                .WithCommitSimulationParametersCommandFor(_simulation, templateBuildingBlock)
                .WithIcon(ApplicationIcons.Commit);

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
@@ -73,6 +73,7 @@ namespace PKSim.Core
       protected override void Context()
       {
          base.Context();
+         _lipophilicityParam.CanBeVariedInPopulation = true;
          var set = overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0));
          _simulation.AddOverwriteParameterSetSelection("Aspirin", set);
       }
@@ -86,6 +87,12 @@ namespace PKSim.Core
       public void should_apply_the_value_from_the_set_to_the_matching_simulation_parameter()
       {
          _lipophilicityParam.Value.ShouldBeEqualTo(5.0);
+      }
+
+      [Observation]
+      public void should_lock_the_applied_parameter_against_population_variation()
+      {
+         _lipophilicityParam.CanBeVariedInPopulation.ShouldBeFalse();
       }
 
       [Observation]
@@ -207,6 +214,67 @@ namespace PKSim.Core
       {
          _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
          _secondCompoundParam.Origin.BuilingBlockId.ShouldBeEqualTo(_secondCompound.Id);
+      }
+   }
+
+   public class When_applying_an_overwrite_parameter_set_to_a_population_simulation_that_varies_the_overwritten_parameter : concern_for_OverwriteParameterSetApplicationTask
+   {
+      private PopulationSimulation _populationSimulation;
+      private IParameter _variedParameter;
+      private AdvancedParameter _advancedParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _variedParameter = DomainHelperForSpecs.ConstantParameterWithValue(3.5).WithName("Lipophilicity");
+         _variedParameter.BuildingBlockType = PKSimBuildingBlockType.Simulation;
+         _variedParameter.CanBeVariedInPopulation = true;
+
+         var root = new Container { Name = "PopSim" };
+         root.Add(_variedParameter);
+
+         _populationSimulation = new PopulationSimulation
+         {
+            Id = "PopId",
+            Model = new OSPSuite.Core.Domain.Model { Root = root }
+         };
+         _populationSimulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId", PKSimBuildingBlockType.Compound) { BuildingBlock = _compound });
+
+         var advancedParameters = new AdvancedParameterCollection();
+         _advancedParameter = new AdvancedParameter { ParameterPath = "Organism|Aspirin|Lipophilicity" };
+         advancedParameters.AddAdvancedParameter(_advancedParameter);
+         _populationSimulation.SetAdvancedParameters(advancedParameters);
+
+         var populationCache = new PathCacheForSpecs<IParameter>();
+         populationCache.Add("Organism|Aspirin|Lipophilicity", _variedParameter);
+         A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(populationCache);
+         A.CallTo(() => _entityPathResolver.PathFor(_variedParameter)).Returns("Organism|Aspirin|Lipophilicity");
+
+         _populationSimulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_populationSimulation);
+      }
+
+      [Observation]
+      public void should_apply_the_overwrite_value_to_the_matching_simulation_parameter()
+      {
+         _variedParameter.Value.ShouldBeEqualTo(5.0);
+      }
+
+      [Observation]
+      public void should_lock_the_applied_parameter_against_population_variation()
+      {
+         _variedParameter.CanBeVariedInPopulation.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_remove_the_advanced_parameter_previously_defined_for_the_overwritten_path()
+      {
+         _populationSimulation.AdvancedParameters.Contains(_advancedParameter).ShouldBeFalse();
       }
    }
 


### PR DESCRIPTION
Fixes #3458

Supports using overwrite parameters in a population sim and preventing them from being committed to the bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overwrite-applied parameters are now locked against population variation.
  * Any existing advanced parameters for overwritten parameter paths in population simulations are removed to prevent runtime overrides.
  * The “Commit simulation parameters to compounds” option now shows only for individual simulations with pending changes for the target compound.

* **Tests**
  * Added/updated coverage to verify parameter locking and advanced-parameter removal in population simulations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->