### PR TITLE
Fixes #3492 Add descriptions to the simulation Events tab and protocol event placeholders

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1915,6 +1915,8 @@ namespace PKSim.Assets
          public static readonly string Soluble = "Soluble";
          public static readonly string Insoluble = "Insoluble";
          public static readonly string AddEvent = "Add Event";
+         public static readonly string SimulationEventsConfigurationDescription = "Administration-related events (e.g. meal events) are best defined directly in the administration protocol. Use this tab for events that are not related to an administration (e.g. gallbladder or urinary bladder emptying).";
+         public static readonly string SimulationProtocolEventDescription = "These events are defined by the administration protocol. Select the event to use for each placeholder.";
          public static readonly string AddObserverSet = "Add Observers";
          public static readonly string ExportLogToFile = "Export project conversion log to file...";
          public static readonly string SaveLog = "Save Log...";

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolPresenter.cs
@@ -80,6 +80,7 @@ namespace PKSim.Presentation.Presenters.Simulations
          _protocolProperties.Protocol = SelectedProtocol;
          _simulationCompoundProtocolFormulationPresenter.EditSimulation(_simulation, Compound);
          _simulationCompoundProtocolEventPresenter.EditSimulation(_simulation, Compound);
+         _view.EventDescriptionVisible = _simulationCompoundProtocolEventPresenter.EventVisible;
       }
 
       public void UpdateSelectedFormulation(Formulation templateFormulation)

--- a/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
+++ b/src/PKSim.Presentation/Views/Simulations/ISimulationCompoundProtocolView.cs
@@ -10,5 +10,6 @@ namespace PKSim.Presentation.Views.Simulations
       void AddFormulationMappingView(IView view);
       void AddEventMappingView(IView view);
       bool AllowEmptyProtocolSelection { get;set; }
+      bool EventDescriptionVisible { get; set; }
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.Designer.cs
@@ -32,9 +32,11 @@
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
          this.panelFormulation = new DevExpress.XtraEditors.PanelControl();
          this.panelEvent = new DevExpress.XtraEditors.PanelControl();
+         this.lblEventDescription = new DevExpress.XtraEditors.LabelControl();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemFormulation = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemEvent = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemEventDescription = new DevExpress.XtraLayout.LayoutControlItem();
          this.panelControl1 = new DevExpress.XtraEditors.PanelControl();
          this.layoutItemProtocol = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
@@ -45,6 +47,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEventDescription)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).BeginInit();
          this.SuspendLayout();
@@ -55,11 +58,12 @@
          this.layoutControl.Controls.Add(this.panelControl1);
          this.layoutControl.Controls.Add(this.panelFormulation);
          this.layoutControl.Controls.Add(this.panelEvent);
+         this.layoutControl.Controls.Add(this.lblEventDescription);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
          this.layoutControl.Root = this.layoutControlGroup;
-         this.layoutControl.Size = new System.Drawing.Size(374, 199);
+         this.layoutControl.Size = new System.Drawing.Size(374, 229);
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl1";
          //
@@ -77,6 +81,15 @@
          this.panelEvent.Size = new System.Drawing.Size(370, 77);
          this.panelEvent.TabIndex = 16;
          //
+         // lblEventDescription
+         //
+         this.lblEventDescription.Location = new System.Drawing.Point(2, 118);
+         this.lblEventDescription.Name = "lblEventDescription";
+         this.lblEventDescription.Size = new System.Drawing.Size(63, 13);
+         this.lblEventDescription.StyleController = this.layoutControl;
+         this.lblEventDescription.TabIndex = 17;
+         this.lblEventDescription.Text = "lblEventDescription";
+         //
          // layoutControlGroup
          //
          this.layoutControlGroup.CustomizationFormText = "layoutControlGroup1";
@@ -84,11 +97,12 @@
          this.layoutControlGroup.GroupBordersVisible = false;
          this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemFormulation,
+            this.layoutItemEventDescription,
             this.layoutItemEvent,
             this.layoutItemProtocol});
          this.layoutControlGroup.Name = "layoutControlGroup";
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
-         this.layoutControlGroup.Size = new System.Drawing.Size(374, 199);
+         this.layoutControlGroup.Size = new System.Drawing.Size(374, 229);
          this.layoutControlGroup.Text = "layoutControlGroup1";
          this.layoutControlGroup.TextVisible = false;
          //
@@ -101,10 +115,20 @@
          this.layoutItemFormulation.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemFormulation.TextVisible = false;
          //
+         // layoutItemEventDescription
+         //
+         this.layoutItemEventDescription.Control = this.lblEventDescription;
+         this.layoutItemEventDescription.Location = new System.Drawing.Point(0, 118);
+         this.layoutItemEventDescription.Name = "layoutItemEventDescription";
+         this.layoutItemEventDescription.Size = new System.Drawing.Size(374, 30);
+         this.layoutItemEventDescription.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemEventDescription.TextToControlDistance = 0;
+         this.layoutItemEventDescription.TextVisible = false;
+         //
          // layoutItemEvent
          //
          this.layoutItemEvent.Control = this.panelEvent;
-         this.layoutItemEvent.Location = new System.Drawing.Point(0, 118);
+         this.layoutItemEvent.Location = new System.Drawing.Point(0, 148);
          this.layoutItemEvent.Name = "layoutItemEvent";
          this.layoutItemEvent.Size = new System.Drawing.Size(374, 81);
          this.layoutItemEvent.TextSize = new System.Drawing.Size(0, 0);
@@ -131,7 +155,7 @@
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Controls.Add(this.layoutControl);
          this.Name = "SimulationCompoundProtocolView";
-         this.Size = new System.Drawing.Size(374, 199);
+         this.Size = new System.Drawing.Size(374, 229);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
@@ -140,6 +164,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulation)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemEvent)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemEventDescription)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelControl1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemProtocol)).EndInit();
          this.ResumeLayout(false);
@@ -156,5 +181,7 @@
       private DevExpress.XtraLayout.LayoutControlItem layoutItemEvent;
       private DevExpress.XtraEditors.PanelControl panelControl1;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemProtocol;
+      private DevExpress.XtraEditors.LabelControl lblEventDescription;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemEventDescription;
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationCompoundProtocolView.cs
@@ -1,9 +1,12 @@
 using System;
 using DevExpress.XtraLayout;
+using DevExpress.XtraLayout.Utils;
 using OSPSuite.DataBinding;
 using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
+using PKSim.Assets;
 using PKSim.Presentation.DTO.Simulations;
 using PKSim.Presentation.Presenters.Simulations;
 using PKSim.Presentation.Views.Simulations;
@@ -35,6 +38,13 @@ namespace PKSim.UI.Views.Simulations
          RegisterValidationFor(_screenBinder, NotifyViewChanged);
       }
 
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         lblEventDescription.AsDescription();
+         lblEventDescription.Text = PKSimConstants.UI.SimulationProtocolEventDescription.FormatForDescription();
+      }
+
       public override bool HasError => _screenBinder.HasError;
 
       public void AttachPresenter(ISimulationCompoundProtocolPresenter presenter)
@@ -63,6 +73,12 @@ namespace PKSim.UI.Views.Simulations
       {
          set => _uxProtocolSelection.AllowEmptySelection = value;
          get => _uxProtocolSelection.AllowEmptySelection;
+      }
+
+      public bool EventDescriptionVisible
+      {
+         get => LayoutVisibilityConvertor.ToBoolean(layoutItemEventDescription.Visibility);
+         set => layoutItemEventDescription.Visibility = LayoutVisibilityConvertor.FromBoolean(value);
       }
 
       protected override void AdjustLayoutItemSize(LayoutControlItem layoutControlItem, LayoutControl layoutControl, IResizableView view, int height)

--- a/src/PKSim.UI/Views/Simulations/SimulationEventsConfigurationView.Designer.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationEventsConfigurationView.Designer.cs
@@ -33,9 +33,11 @@
          this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
          this.gridView = new PKSim.UI.Views.Core.UxGridView();
          this.btnAddEvent = new DevExpress.XtraEditors.SimpleButton();
+         this.lblDescription = new DevExpress.XtraEditors.LabelControl();
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemAddEvent = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemGrid = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemDescription = new DevExpress.XtraLayout.LayoutControlItem();
          this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
@@ -45,12 +47,14 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemAddEvent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDescription)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
          this.SuspendLayout();
          // 
          // layoutControl
          // 
          this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.lblDescription);
          this.layoutControl.Controls.Add(this.gridControl);
          this.layoutControl.Controls.Add(this.btnAddEvent);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -88,13 +92,23 @@
          this.btnAddEvent.StyleController = this.layoutControl;
          this.btnAddEvent.TabIndex = 4;
          this.btnAddEvent.Text = "btnCreateEvent";
-         // 
+         //
+         // lblDescription
+         //
+         this.lblDescription.Location = new System.Drawing.Point(12, 12);
+         this.lblDescription.Name = "lblDescription";
+         this.lblDescription.Size = new System.Drawing.Size(63, 13);
+         this.lblDescription.StyleController = this.layoutControl;
+         this.lblDescription.TabIndex = 6;
+         this.lblDescription.Text = "lblDescription";
+         //
          // layoutControlGroup1
-         // 
+         //
          this.layoutControlGroup1.CustomizationFormText = "layoutControlGroup1";
          this.layoutControlGroup1.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
          this.layoutControlGroup1.GroupBordersVisible = false;
          this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemDescription,
             this.layoutItemAddEvent,
             this.layoutItemGrid,
             this.emptySpaceItem1});
@@ -105,38 +119,50 @@
          this.layoutControlGroup1.TextVisible = false;
          // 
          // layoutItemAddEvent
-         // 
+         //
          this.layoutItemAddEvent.Control = this.btnAddEvent;
          this.layoutItemAddEvent.CustomizationFormText = "layoutItemAddEvent";
-         this.layoutItemAddEvent.Location = new System.Drawing.Point(10, 0);
+         this.layoutItemAddEvent.Location = new System.Drawing.Point(10, 34);
          this.layoutItemAddEvent.Name = "layoutItemAddEvent";
          this.layoutItemAddEvent.Size = new System.Drawing.Size(401, 26);
          this.layoutItemAddEvent.Text = "layoutItemAddEvent";
          this.layoutItemAddEvent.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemAddEvent.TextToControlDistance = 0;
          this.layoutItemAddEvent.TextVisible = false;
-         // 
+         //
          // layoutItemGrid
-         // 
+         //
          this.layoutItemGrid.Control = this.gridControl;
          this.layoutItemGrid.CustomizationFormText = "layoutItemGrid";
-         this.layoutItemGrid.Location = new System.Drawing.Point(0, 26);
+         this.layoutItemGrid.Location = new System.Drawing.Point(0, 60);
          this.layoutItemGrid.Name = "layoutItemGrid";
-         this.layoutItemGrid.Size = new System.Drawing.Size(411, 400);
+         this.layoutItemGrid.Size = new System.Drawing.Size(411, 366);
          this.layoutItemGrid.Text = "layoutItemGrid";
          this.layoutItemGrid.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemGrid.TextToControlDistance = 0;
          this.layoutItemGrid.TextVisible = false;
-         // 
+         //
+         // layoutItemDescription
+         //
+         this.layoutItemDescription.Control = this.lblDescription;
+         this.layoutItemDescription.CustomizationFormText = "layoutItemDescription";
+         this.layoutItemDescription.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemDescription.Name = "layoutItemDescription";
+         this.layoutItemDescription.Size = new System.Drawing.Size(411, 34);
+         this.layoutItemDescription.Text = "layoutItemDescription";
+         this.layoutItemDescription.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemDescription.TextToControlDistance = 0;
+         this.layoutItemDescription.TextVisible = false;
+         //
          // emptySpaceItem1
-         // 
+         //
          this.emptySpaceItem1.CustomizationFormText = "emptySpaceItem1";
-         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 0);
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 34);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
          this.emptySpaceItem1.Size = new System.Drawing.Size(10, 26);
          this.emptySpaceItem1.Text = "emptySpaceItem1";
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
-         // 
+         //
          // SimulationEventsConfigurationView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -152,6 +178,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemAddEvent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemGrid)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDescription)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
          this.ResumeLayout(false);
 
@@ -167,5 +194,7 @@
       private DevExpress.XtraLayout.LayoutControlItem layoutItemGrid;
       private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
       private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private DevExpress.XtraEditors.LabelControl lblDescription;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemDescription;
    }
 }

--- a/src/PKSim.UI/Views/Simulations/SimulationEventsConfigurationView.cs
+++ b/src/PKSim.UI/Views/Simulations/SimulationEventsConfigurationView.cs
@@ -13,6 +13,7 @@ using PKSim.Presentation.Views.Simulations;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.DTO;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Core;
 using OSPSuite.UI.Extensions;
@@ -133,6 +134,8 @@ namespace PKSim.UI.Views.Simulations
          base.InitializeResources();
          btnAddEvent.InitWithImage(ApplicationIcons.Add, PKSimConstants.UI.AddEvent);
          layoutItemAddEvent.AdjustButtonSize(layoutControl);
+         lblDescription.AsDescription();
+         lblDescription.Text = PKSimConstants.UI.SimulationEventsConfigurationDescription.FormatForDescription();
       }
 
       public void AttachPresenter(ISimulationEventsConfigurationPresenter presenter)

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolPresenterSpecs.cs
@@ -112,6 +112,56 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_editing_a_simulation_whose_protocol_defines_event_placeholders : concern_for_SimulationCompoundProtocolPresenter
+   {
+      private Simulation _simulation;
+      private Compound _compound;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<Simulation>();
+         _compound = A.Fake<Compound>();
+         A.CallTo(() => _simulationCompoundProtocolEventPresenter.EventVisible).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_show_the_event_description_in_the_view()
+      {
+         A.CallToSet(() => _view.EventDescriptionVisible).To(true).MustHaveHappened();
+      }
+   }
+
+   public class When_editing_a_simulation_whose_protocol_does_not_define_event_placeholders : concern_for_SimulationCompoundProtocolPresenter
+   {
+      private Simulation _simulation;
+      private Compound _compound;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<Simulation>();
+         _compound = A.Fake<Compound>();
+         A.CallTo(() => _simulationCompoundProtocolEventPresenter.EventVisible).Returns(false);
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_hide_the_event_description_in_the_view()
+      {
+         A.CallToSet(() => _view.EventDescriptionVisible).To(false).MustHaveHappened();
+      }
+   }
+
    public class When_the_simulation_application_presenter_is_asked_to_create_the_application_for_the_simulation : concern_for_SimulationCompoundProtocolPresenter
    {
       private Simulation _simulation;


### PR DESCRIPTION
## Summary

Now that events can be defined through an administration (event) protocol, the Events tab in the simulation can be confusing. Following the discussion in #3492, this adds guidance text (it does **not** disable the Events tab or the *Add Event* button — non-administration events like gallbladder/urinary bladder emptying are still added there).

Two info texts are added:

- **Events tab** (`SimulationEventsConfigurationView`): *"Administration-related events (e.g. meal events) are best defined directly in the administration protocol. Use this tab for events that are not related to an administration (e.g. gallbladder or urinary bladder emptying)."*
- **Administration tab** (`SimulationCompoundProtocolView`, above the event placeholder grid): *"These events are defined by the administration protocol. Select the event to use for each placeholder."* — shown only when the selected protocol actually defines event placeholders.

## Changes

- `PKSimConstants` — two new UI strings.
- `SimulationEventsConfigurationView` (+ Designer) — description label at the top of the Events tab.
- `SimulationCompoundProtocolView` (+ Designer), `ISimulationCompoundProtocolView`, `SimulationCompoundProtocolPresenter` — description label above the event placeholder mapping, toggled via `EventDescriptionVisible` based on the event presenter's `EventVisible`.

## Tests

- Added presenter specs verifying the placeholder description is shown/hidden in step with event placeholder visibility.
- `SimulationCompoundProtocol*` presenter specs pass (12/12). (Text-only view changes have no presenter logic and are not unit-tested, per the project testing conventions.)

Targets the `feature/event_protocol` branch.

<img width="672" height="795" alt="image" src="https://github.com/user-attachments/assets/615a0054-cd93-4d82-9f7d-df40ef868149" />
