### PR TITLE
update core

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,10 +40,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,12 +47,12 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.136" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,12 +36,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.136" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" GeneratePathProperty="true" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,11 +17,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/tests/PKSim.Tests/Infrastructure/ChartTemplatingTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/ChartTemplatingTaskSpecs.cs
@@ -167,7 +167,7 @@ namespace PKSim.Infrastructure
       [Observation]
       public void should_add_the_new_curve_to_the_chart_with_the_settings_from_the_simulation_as_defaults()
       {
-         A.CallTo(() => _chartEditorPresenter.AddCurveForColumn(_column, _curve.CurveOptions, false)).MustHaveHappened();
+         A.CallTo(() => _chartEditorPresenter.AddCurveForColumn(_column, _curve.CurveOptions)).MustHaveHappened();
       }
    }
 
@@ -212,7 +212,7 @@ namespace PKSim.Infrastructure
       [Observation]
       public void should_add_the_new_curve_to_the_chart_with_the_settings_from_the_simulation_as_defaults()
       {
-         A.CallTo(() => _chartEditorPresenter.AddCurveForColumn(_column, _curve.CurveOptions, false)).MustHaveHappened();
+         A.CallTo(() => _chartEditorPresenter.AddCurveForColumn(_column, _curve.CurveOptions)).MustHaveHappened();
       }
    }
 }

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,10 +17,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/tests/PKSim.Tests/Presentation/IndividualSimulationComparisonPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/IndividualSimulationComparisonPresenterSpecs.cs
@@ -161,7 +161,7 @@ namespace PKSim.Presentation
       [Observation]
       public void should_create_curves_for_the_observation_columns_of_the_observed_data()
       {
-         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<bool>._)).MustHaveHappened();
+         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<string>._)).MustHaveHappened();
       }
 
       [Observation]
@@ -205,7 +205,7 @@ namespace PKSim.Presentation
       [Observation]
       public void should_create_curves_for_the_observation_columns_of_the_observed_data()
       {
-         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<bool>._)).MustHaveHappened();
+         A.CallTo(() => _chartPresenter.EditorPresenter.AddCurveForColumn(A<DataColumn>.That.Matches(c => _observedData.ObservationColumns().Contains(c)), A<CurveOptions>._, A<string>._)).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.134" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.136" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Bumps OSPSuite.Core family 13.0.134 → 13.0.136.

Two changes beyond the plain version flip, both required to build/test against the new Core:
- OSPSuite.SimModel 5.0.0.76 → 5.0.0.80 (Core 13.0.136 requires SimModel >= 5.0.0.80; NU1605 otherwise).
- `AddCurveForColumn` 3rd parameter changed from `bool` to `string linkedOutputPath` in Core; updated 4 test call sites in ChartTemplatingTaskSpecs and IndividualSimulationComparisonPresenterSpecs to match.

Build and full test suite green locally.