### PR TITLE
Fixes #3620 Refresh the protocol chart when the protocol mode changes

### DIFF
--- a/src/PKSim.Presentation/Presenters/Protocols/CreateProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/CreateProtocolPresenter.cs
@@ -117,6 +117,8 @@ namespace PKSim.Presentation.Presenters.Protocols
          activeProtocolPresenter.EditProtocol(Protocol);
          _view.UpdateEditControl(activeProtocolView);
          updateControls();
+         //the protocol was swapped: the chart still shows the previous protocol and has to be plotted again
+         refreshPlot();
       }
 
       public override void ViewChanged()

--- a/tests/PKSim.Tests/Presentation/CreateProtocolPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/CreateProtocolPresenterSpecs.cs
@@ -16,12 +16,12 @@ namespace PKSim.Presentation
    {
       private ICreateProtocolView _view;
       private IBuildingBlockPropertiesMapper _propertiesMapper;
-      private IProtocolFactory _protocolFactory;
+      protected IProtocolFactory _protocolFactory;
       private ISimpleProtocolPresenter _simpleProtocolPresenter;
       private IProtocolToProtocolPropertiesDTOMapper _propertiesDTOMapper;
       private IAdvancedProtocolPresenter _advancedProtocolPresenter;
       protected IProtocolUpdater _protocolUpdater;
-      private IProtocolChartPresenter _protocolChartPresenter;
+      protected IProtocolChartPresenter _protocolChartPresenter;
       private ISubPresenterItemManager<IProtocolItemPresenter> _subPresenterManager;
       protected IDialogCreator _dialogCreator;
 
@@ -102,6 +102,54 @@ namespace PKSim.Presentation
       public void should_return_true()
       {
          sut.SwitchModeConfirm(ProtocolMode.Advanced).ShouldBeTrue();
+      }
+   }
+
+   public class When_the_create_protocol_presenter_is_switching_the_protocol_mode_to_advanced : concern_for_CreateProtocolPresenter
+   {
+      private Protocol _advancedProtocol;
+
+      protected override void Context()
+      {
+         base.Context();
+         _advancedProtocol = new AdvancedProtocol();
+         A.CallTo(() => _protocolFactory.Create(ProtocolMode.Advanced)).Returns(_advancedProtocol);
+      }
+
+      protected override void Because()
+      {
+         sut.ProtocolMode = ProtocolMode.Advanced;
+      }
+
+      [Observation]
+      public void should_plot_the_newly_created_protocol()
+      {
+         A.CallTo(() => _protocolChartPresenter.PlotProtocol(_advancedProtocol)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_create_protocol_presenter_is_switching_the_protocol_mode_back_to_simple : concern_for_CreateProtocolPresenter
+   {
+      private Protocol _simpleProtocol;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _protocolFactory.Create(ProtocolMode.Advanced)).Returns(new AdvancedProtocol());
+         _simpleProtocol = new SimpleProtocol();
+         A.CallTo(() => _protocolFactory.Create(ProtocolMode.Simple)).Returns(_simpleProtocol);
+         sut.ProtocolMode = ProtocolMode.Advanced;
+      }
+
+      protected override void Because()
+      {
+         sut.ProtocolMode = ProtocolMode.Simple;
+      }
+
+      [Observation]
+      public void should_plot_the_newly_created_protocol()
+      {
+         A.CallTo(() => _protocolChartPresenter.PlotProtocol(_simpleProtocol)).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #3620

## Problem
Switching the protocol mode from **Advanced** to **Simple** left the previous (advanced) graph on screen.

## Cause
`CreateProtocolPresenter.ProtocolMode` creates a brand new protocol and swaps it in via `updateView()`, but never re-plots the chart. Simple → Advanced *appeared* to work only by accident: binding the advanced schema grid raises `StatusChanged`, which triggers `refreshPlot()`. The simple protocol view raises nothing, so Advanced → Simple kept showing the stale chart.

## Fix
`updateView()` now calls `refreshPlot()` after the protocol has been swapped, so both directions plot the newly created protocol.

## Tests
Two new specs in `CreateProtocolPresenterSpecs` cover both switch directions; both fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the protocol chart immediately when switching between protocol modes.
  * Ensured the chart displays the newly selected Simple or Advanced protocol without requiring another refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->