### PR TITLE
Fixes #3627 Scheduled coverage workflow broken after .NET 10 retarget

### DIFF
--- a/dotcover.xml
+++ b/dotcover.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CoverageParams>
   <TargetArguments>
-    tests\PKSim.R.Tests\bin\Debug\net8\PKSim.R.Tests.dll
-    tests\PKSim.Tests\bin\Debug\net8.0-windows\PKSim.Tests.dll
-    tests\PKSim.UI.Tests\bin\Debug\net8.0-windows\PKSim.UI.Tests.dll
+    tests\PKSim.R.Tests\bin\Debug\net10.0\PKSim.R.Tests.dll
+    tests\PKSim.Tests\bin\Debug\net10.0-windows\PKSim.Tests.dll
+    tests\PKSim.UI.Tests\bin\Debug\net10.0-windows\PKSim.UI.Tests.dll
   </TargetArguments>
   <TargetWorkingDir>./</TargetWorkingDir>
  


### PR DESCRIPTION
Fixes #3627

The scheduled **Code Coverage v13** workflow fails because `dotcover.xml` still lists the pre-.NET-10 test output paths, so NUnit finds zero test assemblies ([failing run](https://github.com/Open-Systems-Pharmacology/PK-Sim/actions/runs/29554083441)).

This updates the three `<TargetArguments>` entries to the output folders the CI build actually produces (verified against the build log of the failing run):

- `PKSim.R.Tests` → `net10.0`
- `PKSim.Tests`, `PKSim.UI.Tests` → `net10.0-windows`

Same fix as OSPSuite.Core (Open-Systems-Pharmacology/OSPSuite.Core#2909) and MoBi (fixed directly on `develop` on 2026-07-17).

Note: coverage will only pass once the shared `dotCover` action can run .NET 10 assemblies — companion PR Open-Systems-Pharmacology/Workflows#244 bumps `NUnit.ConsoleRunner` (3.19.2 has no .NET 10 agent) and the dotCover CLI. After both merge, this can be verified via `workflow_dispatch` on coverage.yml.