### PR TITLE
Fixes #3621 Simple Protocol: Infusion Time not take into consideration for graph

### DIFF
--- a/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Protocols/SimpleProtocolPresenter.cs
@@ -40,6 +40,7 @@ namespace PKSim.Presentation.Presenters.Protocols
          _dynamicParameterPresenter.IsSimpleEditor = true;
          _dynamicParameterPresenter.ValueOriginVisible = false;
          _dynamicParameterPresenter.HeaderVisible = false;
+         _dynamicParameterPresenter.ParameterChanged += _ => OnStatusChanged();
          _view.AddDynamicParameterView(_dynamicParameterPresenter.View);
       }
 

--- a/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
+++ b/src/PKSim.UI/Views/Protocols/ProtocolChartView.cs
@@ -33,6 +33,7 @@ namespace PKSim.UI.Views.Protocols
          _imageListRetriever = imageListRetriever;
          InitializeComponent();
          chart.ObjectHotTracked += chartObjectHotTracked;
+         chart.CustomDrawSeries += chartCustomDrawSeries;
          chart.Images = _imageListRetriever.AllImages16x16;
          chart.CrosshairEnabled = DefaultBoolean.False;
          _toolTipController.Initialize(imageListRetriever);
@@ -175,6 +176,26 @@ namespace PKSim.UI.Views.Protocols
       private static double endTimeFor(DataRow row, IProtocolChartData dataToPlot) => (double)row[dataToPlot.XValue2];
       private static double doseFor(DataRow row, IProtocolChartData dataToPlot) => (double)row[dataToPlot.YValue];
       private static object tagFor(DataRow row, IProtocolChartData dataToPlot) => row[dataToPlot.SchemaItemName];
+
+      /// <summary>
+      ///    The default legend glyph for an area series is a triangle shaped miniature of the area; draw a square
+      ///    filled with the series color instead.
+      /// </summary>
+      private void chartCustomDrawSeries(object sender, CustomDrawSeriesEventArgs e)
+      {
+         if (!(e.Series.View is AreaSeriesView areaView))
+            return;
+
+         var marker = new Bitmap(e.LegendMarkerSize.Width, e.LegendMarkerSize.Height);
+         using (var g = Graphics.FromImage(marker))
+         using (var brush = new SolidBrush(Color.FromArgb(byte.MaxValue - areaView.Transparency, areaView.Color)))
+         {
+            g.FillRectangle(brush, 0, 0, marker.Width, marker.Height);
+         }
+
+         e.LegendMarkerImage = marker;
+         e.DisposeLegendMarkerImage = true;
+      }
 
       private void chartObjectHotTracked(object sender, HotTrackEventArgs e)
       {

--- a/tests/PKSim.Tests/Presentation/SimpleProtocolPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimpleProtocolPresenterSpecs.cs
@@ -114,6 +114,28 @@ namespace PKSim.Presentation
    }
 
 
+   public class When_a_dynamic_parameter_of_the_simple_protocol_was_changed : concern_for_SimpleProtocolPresenter
+   {
+      private bool _statusChangedRaised;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.StatusChanged += (o, e) => _statusChangedRaised = true;
+      }
+
+      protected override void Because()
+      {
+         _dynamicParameterPresenter.ParameterChanged += Raise.FreeForm.With(A.Fake<IParameter>());
+      }
+
+      [Observation]
+      public void should_notify_a_status_change_so_that_the_protocol_chart_is_refreshed()
+      {
+         _statusChangedRaised.ShouldBeTrue();
+      }
+   }
+
    public class When_retrieving_all_possible_organs_available_for_a_user_defined_application : concern_for_SimpleProtocolPresenter
    {
       private IEnumerable<string> _organs;


### PR DESCRIPTION
Fixes #3621

- Simple protocol: infusion time edits now refresh the chart, so infusions render as an area spanning start to start + infusion time (the edit goes through the embedded dynamic parameter presenter, which previously bypassed the presenter's `StatusChanged` and never triggered a replot).
- Legend marker for infusion (area) series is now a square filled with the series color and transparency instead of the default triangle glyph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol status now updates when dynamic parameter values change.
  * Protocol chart legends now display filled color markers for area series, with transparency applied consistently.

* **Tests**
  * Added coverage to verify status updates after dynamic parameter changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->