### PR TITLE
Fixes #1435 Add subfolders for building blocks

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -2571,6 +2571,7 @@ namespace PKSim.Assets
       public static class Classifications
       {
          public static readonly string Species = ObjectTypes.Species;
+         public static readonly string Molecule = ObjectTypes.Molecule;
          public static readonly string Compound = ObjectTypes.Compound;
          public static readonly string AdministrationProtocol = ObjectTypes.AdministrationProtocol;
          public static readonly string Individual = ObjectTypes.Individual;

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.138" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.Core/Model/ClassifiableCompound.cs
+++ b/src/PKSim.Core/Model/ClassifiableCompound.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableCompound : Classifiable<Compound>
+{
+   public ClassifiableCompound() : base(ClassificationType.Compound)
+   {
+   }
+
+   public Compound Compound => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableEvent.cs
+++ b/src/PKSim.Core/Model/ClassifiableEvent.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableEvent : Classifiable<PKSimEvent>
+{
+   public ClassifiableEvent() : base(ClassificationType.Event)
+   {
+   }
+
+   public PKSimEvent Event => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableExpressionProfile.cs
+++ b/src/PKSim.Core/Model/ClassifiableExpressionProfile.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableExpressionProfile : Classifiable<ExpressionProfile>
+{
+   public ClassifiableExpressionProfile() : base(ClassificationType.ExpressionProfile)
+   {
+   }
+
+   public ExpressionProfile ExpressionProfile => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableFormulation.cs
+++ b/src/PKSim.Core/Model/ClassifiableFormulation.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableFormulation : Classifiable<Formulation>
+{
+   public ClassifiableFormulation() : base(ClassificationType.Formulation)
+   {
+   }
+
+   public Formulation Formulation => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableIndividual.cs
+++ b/src/PKSim.Core/Model/ClassifiableIndividual.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableIndividual : Classifiable<Individual>
+{
+   public ClassifiableIndividual() : base(ClassificationType.Individual)
+   {
+   }
+
+   public Individual Individual => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableObserverSet.cs
+++ b/src/PKSim.Core/Model/ClassifiableObserverSet.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableObserverSet : Classifiable<ObserverSet>
+{
+   public ClassifiableObserverSet() : base(ClassificationType.ObserverSet)
+   {
+   }
+
+   public ObserverSet ObserverSet => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiablePopulation.cs
+++ b/src/PKSim.Core/Model/ClassifiablePopulation.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiablePopulation : Classifiable<Population>
+{
+   public ClassifiablePopulation() : base(ClassificationType.Population)
+   {
+   }
+
+   public Population Population => Subject;
+}

--- a/src/PKSim.Core/Model/ClassifiableProtocol.cs
+++ b/src/PKSim.Core/Model/ClassifiableProtocol.cs
@@ -1,0 +1,12 @@
+using OSPSuite.Core.Domain;
+
+namespace PKSim.Core.Model;
+
+public class ClassifiableProtocol : Classifiable<Protocol>
+{
+   public ClassifiableProtocol() : base(ClassificationType.Protocol)
+   {
+   }
+
+   public Protocol Protocol => Subject;
+}

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.138" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -89,6 +89,14 @@ namespace PKSim.Core.Snapshots.Mappers
          snapshot.SimulationClassifications = await MapClassifications<ClassifiableSimulation>(project);
          snapshot.ParameterIdentificationClassifications = await MapClassifications<ClassifiableParameterIdentification>(project);
          snapshot.QualificationPlanClassifications = await MapClassifications<ClassifiableQualificationPlan>(project);
+         snapshot.CompoundClassifications = await MapClassifications<ClassifiableCompound>(project);
+         snapshot.FormulationClassifications = await MapClassifications<ClassifiableFormulation>(project);
+         snapshot.IndividualClassifications = await MapClassifications<ClassifiableIndividual>(project);
+         snapshot.PopulationClassifications = await MapClassifications<ClassifiablePopulation>(project);
+         snapshot.ProtocolClassifications = await MapClassifications<ClassifiableProtocol>(project);
+         snapshot.EventClassifications = await MapClassifications<ClassifiableEvent>(project);
+         snapshot.ObserverSetClassifications = await MapClassifications<ClassifiableObserverSet>(project);
+         snapshot.ExpressionProfileClassifications = await MapClassifications<ClassifiableExpressionProfile>(project);
          return snapshot;
       }
 
@@ -277,6 +285,22 @@ namespace PKSim.Core.Snapshots.Mappers
                snapshot.ParameterIdentificationClassifications, snapshotContext, project.AllParameterIdentifications),
             _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableQualificationPlan, OSPSuite.Core.Domain.QualificationPlan>(
                snapshot.QualificationPlanClassifications, snapshotContext, project.AllQualificationPlans),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableCompound, Model.Compound>(
+               snapshot.CompoundClassifications, snapshotContext, project.All<Model.Compound>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableFormulation, Model.Formulation>(
+               snapshot.FormulationClassifications, snapshotContext, project.All<Model.Formulation>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableIndividual, Model.Individual>(
+               snapshot.IndividualClassifications, snapshotContext, project.All<Model.Individual>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiablePopulation, Model.Population>(
+               snapshot.PopulationClassifications, snapshotContext, project.All<Model.Population>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableProtocol, Model.Protocol>(
+               snapshot.ProtocolClassifications, snapshotContext, project.All<Model.Protocol>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableEvent, PKSimEvent>(
+               snapshot.EventClassifications, snapshotContext, project.All<PKSimEvent>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableObserverSet, Model.ObserverSet>(
+               snapshot.ObserverSetClassifications, snapshotContext, project.All<Model.ObserverSet>()),
+            _classificationSnapshotTask.UpdateProjectClassifications<ClassifiableExpressionProfile, Model.ExpressionProfile>(
+               snapshot.ExpressionProfileClassifications, snapshotContext, project.All<Model.ExpressionProfile>()),
          };
 
          return Task.WhenAll(tasks);

--- a/src/PKSim.Core/Snapshots/Project.cs
+++ b/src/PKSim.Core/Snapshots/Project.cs
@@ -32,6 +32,14 @@ namespace PKSim.Core.Snapshots
       public Classification[] SimulationClassifications { get; set; }
       public Classification[] ParameterIdentificationClassifications { get; set; }
       public Classification[] QualificationPlanClassifications { get; set; }
+      public Classification[] CompoundClassifications { get; set; }
+      public Classification[] FormulationClassifications { get; set; }
+      public Classification[] IndividualClassifications { get; set; }
+      public Classification[] PopulationClassifications { get; set; }
+      public Classification[] ProtocolClassifications { get; set; }
+      public Classification[] EventClassifications { get; set; }
+      public Classification[] ObserverSetClassifications { get; set; }
+      public Classification[] ExpressionProfileClassifications { get; set; }
 
       public IReadOnlyList<IBuildingBlockSnapshot> BuildingBlocksByType(PKSimBuildingBlockType buildingBlockType)
       {

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.138" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ClassifiableXmlSerializer.cs
+++ b/src/PKSim.Infrastructure/Serialization/Xml/Serializers/ClassifiableXmlSerializer.cs
@@ -18,4 +18,44 @@ namespace PKSim.Infrastructure.Serialization.Xml.Serializers
    {
 
    }
+
+   public class ClassifiableCompoundXmlSerializer : ClassifiableXmlSerializer<ClassifiableCompound, Compound>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableFormulationXmlSerializer : ClassifiableXmlSerializer<ClassifiableFormulation, Formulation>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableIndividualXmlSerializer : ClassifiableXmlSerializer<ClassifiableIndividual, Individual>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiablePopulationXmlSerializer : ClassifiableXmlSerializer<ClassifiablePopulation, Population>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableProtocolXmlSerializer : ClassifiableXmlSerializer<ClassifiableProtocol, Protocol>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableEventXmlSerializer : ClassifiableXmlSerializer<ClassifiableEvent, PKSimEvent>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableObserverSetXmlSerializer : ClassifiableXmlSerializer<ClassifiableObserverSet, ObserverSet>, IPKSimXmlSerializer
+   {
+
+   }
+
+   public class ClassifiableExpressionProfileXmlSerializer : ClassifiableXmlSerializer<ClassifiableExpressionProfile, ExpressionProfile>, IPKSimXmlSerializer
+   {
+
+   }
 }

--- a/src/PKSim.Presentation/Mappers/PKSimClassificationTypeToRootNodeTypeMapper.cs
+++ b/src/PKSim.Presentation/Mappers/PKSimClassificationTypeToRootNodeTypeMapper.cs
@@ -1,0 +1,34 @@
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Mappers;
+using OSPSuite.Presentation.Presenters.Nodes;
+using PKSim.Presentation.Nodes;
+
+namespace PKSim.Presentation.Mappers;
+
+public class PKSimClassificationTypeToRootNodeTypeMapper : ClassificationTypeToRootNodeTypeMapper
+{
+   public override RootNodeType MapFrom(ClassificationType classificationType)
+   {
+      switch (classificationType)
+      {
+         case ClassificationType.Compound:
+            return PKSimRootNodeTypes.CompoundFolder;
+         case ClassificationType.Formulation:
+            return PKSimRootNodeTypes.FormulationFolder;
+         case ClassificationType.Individual:
+            return PKSimRootNodeTypes.IndividualFolder;
+         case ClassificationType.Population:
+            return PKSimRootNodeTypes.PopulationFolder;
+         case ClassificationType.Protocol:
+            return PKSimRootNodeTypes.ProtocolFolder;
+         case ClassificationType.Event:
+            return PKSimRootNodeTypes.EventFolder;
+         case ClassificationType.ObserverSet:
+            return PKSimRootNodeTypes.ObserverSetFolder;
+         case ClassificationType.ExpressionProfile:
+            return PKSimRootNodeTypes.ExpressionProfileFolder;
+         default:
+            return base.MapFrom(classificationType);
+      }
+   }
+}

--- a/src/PKSim.Presentation/Nodes/RootNodeType.cs
+++ b/src/PKSim.Presentation/Nodes/RootNodeType.cs
@@ -1,5 +1,6 @@
 using PKSim.Assets;
 using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Presenters.Nodes;
 
 namespace PKSim.Presentation.Nodes
@@ -10,14 +11,14 @@ namespace PKSim.Presentation.Nodes
       public static readonly RootNodeType InhibitionProcess = new RootNodeType(PKSimConstants.UI.Inhibition, ApplicationIcons.Inhibition);
       public static readonly RootNodeType InductionProcess = new RootNodeType(PKSimConstants.UI.Induction, ApplicationIcons.Induction);
       public static readonly RootNodeType Distribution = new RootNodeType(PKSimConstants.UI.Distribution, ApplicationIcons.Distribution);
-      public static readonly RootNodeType IndividualFolder = new RootNodeType(PKSimConstants.UI.IndividualFolder, ApplicationIcons.IndividualFolder);
-      public static readonly RootNodeType CompoundFolder = new RootNodeType(PKSimConstants.UI.CompoundFolder, ApplicationIcons.CompoundFolder);
-      public static readonly RootNodeType ProtocolFolder = new RootNodeType(PKSimConstants.UI.AdministrationProtocolFolder, ApplicationIcons.ProtocolFolder);
-      public static readonly RootNodeType FormulationFolder = new RootNodeType(PKSimConstants.UI.FormulationFolder, ApplicationIcons.FormulationFolder);
-      public static readonly RootNodeType PopulationFolder = new RootNodeType(PKSimConstants.UI.PopulationFolder, ApplicationIcons.PopulationFolder);
-      public static readonly RootNodeType EventFolder = new RootNodeType(PKSimConstants.UI.EventFolder, ApplicationIcons.EventFolder);
-      public static readonly RootNodeType ObserverSetFolder = new RootNodeType(PKSimConstants.UI.ObserverSetFolder, ApplicationIcons.ObserverFolder);
-      public static readonly RootNodeType ExpressionProfileFolder = new RootNodeType(PKSimConstants.UI.ExpressionProfileFolder, ApplicationIcons.ExpressionProfileFolder);
+      public static readonly RootNodeType IndividualFolder = new RootNodeType(PKSimConstants.UI.IndividualFolder, ApplicationIcons.IndividualFolder, ClassificationType.Individual);
+      public static readonly RootNodeType CompoundFolder = new RootNodeType(PKSimConstants.UI.CompoundFolder, ApplicationIcons.CompoundFolder, ClassificationType.Compound);
+      public static readonly RootNodeType ProtocolFolder = new RootNodeType(PKSimConstants.UI.AdministrationProtocolFolder, ApplicationIcons.ProtocolFolder, ClassificationType.Protocol);
+      public static readonly RootNodeType FormulationFolder = new RootNodeType(PKSimConstants.UI.FormulationFolder, ApplicationIcons.FormulationFolder, ClassificationType.Formulation);
+      public static readonly RootNodeType PopulationFolder = new RootNodeType(PKSimConstants.UI.PopulationFolder, ApplicationIcons.PopulationFolder, ClassificationType.Population);
+      public static readonly RootNodeType EventFolder = new RootNodeType(PKSimConstants.UI.EventFolder, ApplicationIcons.EventFolder, ClassificationType.Event);
+      public static readonly RootNodeType ObserverSetFolder = new RootNodeType(PKSimConstants.UI.ObserverSetFolder, ApplicationIcons.ObserverFolder, ClassificationType.ObserverSet);
+      public static readonly RootNodeType ExpressionProfileFolder = new RootNodeType(PKSimConstants.UI.ExpressionProfileFolder, ApplicationIcons.ExpressionProfileFolder, ClassificationType.ExpressionProfile);
       public static readonly RootNodeType IndividualMetabolizingEnzymes = new RootNodeType(PKSimConstants.UI.MetabolizingEnzymes, ApplicationIcons.Enzyme);
       public static readonly RootNodeType IndividualProteinBindingPartners = new RootNodeType(PKSimConstants.UI.ProteinBindingPartners, ApplicationIcons.Protein);
       public static readonly RootNodeType IndividualTransportProteins = new RootNodeType(PKSimConstants.UI.TransportProteins, ApplicationIcons.Transporter);

--- a/src/PKSim.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/PKSim.Presentation/Nodes/TreeNodeFactory.cs
@@ -18,6 +18,7 @@ namespace PKSim.Presentation.Nodes
       ITreeNode CreateFor(Simulation simulation, UsedBuildingBlock usedBuildingBlock);
       ITreeNode CreateFor(UsedObservedData usedObservedData);
       ITreeNode CreateFor(ClassifiableSimulation simulation);
+      ITreeNode CreateForClassifiableBuildingBlock<TClassifiable>(TClassifiable classifiable) where TClassifiable : class, IClassifiableWrapper;
       ITreeNode CreateFor(PartialProcess partialProcess);
       ITreeNode CreateFor(SystemicProcess systemicProcess);
       ITreeNode CreateFor(ModelProperties modelProperties);
@@ -54,6 +55,9 @@ namespace PKSim.Presentation.Nodes
       public ITreeNode CreateFor(ClassifiableComparison classifiableComparison) => new ComparisonNode(classifiableComparison);
 
       public ITreeNode CreateFor(ClassifiableSimulation simulation) => new SimulationNode(simulation);
+
+      public ITreeNode CreateForClassifiableBuildingBlock<TClassifiable>(TClassifiable classifiable) where TClassifiable : class, IClassifiableWrapper
+         => new ObjectWithIdAndNameNode<TClassifiable>(classifiable);
 
       public ITreeNode CreateFor(Simulation simulation, UsedBuildingBlock usedBuildingBlock)
       {

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockFolderContextMenu.cs
@@ -1,25 +1,46 @@
-﻿using System.Linq;
+using System.Linq;
+using OSPSuite.Assets;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public abstract class BuildingBlockFolderContextMenu<TBuildingBlock> : ContextMenu where TBuildingBlock : class, IPKSimBuildingBlock
    {
-      protected BuildingBlockFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container, params MenuBarItemId[] staticMenus) : base(container)
+      protected BuildingBlockFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container, params MenuBarItemId[] staticMenus) : base(container)
       {
          staticMenus.Each(menu => _view.AddMenuItem(repository[menu]));
 
          _view.AddMenuItem(GenericMenu.LoadBuildingBlockFromSnapshot<TBuildingBlock>(container));
 
-         var allBuildingBlocks = buildingBlockRepository.All<TBuildingBlock>();
-         if (!allBuildingBlocks.Any())
-            return;
+         _view.AddMenuItem(ClassificationCommonContextMenuItems.CreateClassificationUnderMenu(treeNode, presenter).AsGroupStarter());
+
+         var groupMenu = createGroupByMenu(treeNode, presenter);
+         if (groupMenu.AllItems().Any())
+            _view.AddMenuItem(groupMenu);
+
+         _view.AddMenuItem(ClassificationCommonContextMenuItems.RemoveClassificationFolderMainMenu(treeNode, presenter).AsGroupStarter());
+      }
+
+      private static IMenuBarSubMenu createGroupByMenu(ITreeNode<RootNodeType> treeNode, IExplorerPresenter presenter)
+      {
+         var groupMenu = CreateSubMenu.WithCaption(MenuNames.GroupBy);
+
+         presenter.AvailableClassificationCategories(treeNode)
+            .Each(classification => groupMenu.AddItem(
+               CreateMenuButton.WithCaption(classification.ClassificationName)
+                  .WithIcon(classification.Icon)
+                  .WithActionCommand(() => presenter.AddToClassificationTree(treeNode, classification.ClassificationName))));
+
+         return groupMenu;
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockFolderContextMenu.cs
@@ -37,7 +37,6 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          presenter.AvailableClassificationCategories(treeNode)
             .Each(classification => groupMenu.AddItem(
                CreateMenuButton.WithCaption(classification.ClassificationName)
-                  .WithIcon(classification.Icon)
                   .WithActionCommand(() => presenter.AddToClassificationTree(treeNode, classification.ClassificationName))));
 
          return groupMenu;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockGroupingFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockGroupingFolderContextMenu.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Nodes;
+using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Utility.Container.IContainer;
+
+namespace PKSim.Presentation.Presenters.ContextMenus;
+
+internal class BuildingBlockGroupingFolderContextMenu : ExplorerClassificationNodeContextMenu
+{
+   public BuildingBlockGroupingFolderContextMenu(ClassificationNode objectRequestingContextMenu, IExplorerPresenter presenter, IContainer container)
+      : base(objectRequestingContextMenu, presenter, container)
+   {
+   }
+}
+
+/// <summary>
+///    Provides the right-click menu for the classification (subfolder) nodes created under any of the building
+///    block folders. One factory handles all building block classification types.
+/// </summary>
+public class BuildingBlockGroupingFolderTreeNodeContextMenuFactory :
+   IContextMenuSpecificationFactory<ITreeNode>,
+   IContextMenuSpecificationFactory<IViewItem>
+{
+   private readonly IContainer _container;
+
+   private static readonly HashSet<ClassificationType> _buildingBlockClassificationTypes = new HashSet<ClassificationType>
+   {
+      ClassificationType.Compound,
+      ClassificationType.Formulation,
+      ClassificationType.Individual,
+      ClassificationType.Population,
+      ClassificationType.Protocol,
+      ClassificationType.Event,
+      ClassificationType.ObserverSet,
+      ClassificationType.ExpressionProfile
+   };
+
+   public BuildingBlockGroupingFolderTreeNodeContextMenuFactory(IContainer container)
+   {
+      _container = container;
+   }
+
+   public IContextMenu CreateFor(ITreeNode treeNode, IPresenterWithContextMenu<ITreeNode> presenter) => createFor(treeNode, presenter);
+
+   public bool IsSatisfiedBy(ITreeNode treeNode, IPresenterWithContextMenu<ITreeNode> presenter) => isSatisfiedBy(treeNode, presenter);
+
+   public IContextMenu CreateFor(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter) => createFor(viewItem, presenter);
+
+   public bool IsSatisfiedBy(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter) => isSatisfiedBy(viewItem, presenter);
+
+   private IContextMenu createFor(object nodeRequestingContextMenu, IPresenter presenter) =>
+      new BuildingBlockGroupingFolderContextMenu(nodeRequestingContextMenu.DowncastTo<ClassificationNode>(), presenter.DowncastTo<IExplorerPresenter>(), _container);
+
+   private static bool isSatisfiedBy(object nodeRequestingContextMenu, IPresenter presenter)
+   {
+      if (!nodeRequestingContextMenu.IsAnImplementationOf<ClassificationNode>())
+         return false;
+
+      var node = nodeRequestingContextMenu.DowncastTo<ClassificationNode>();
+      return _buildingBlockClassificationTypes.Contains(node.Tag.ClassificationType) && presenter.IsAnImplementationOf<IExplorerPresenter>();
+   }
+}

--- a/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockNodeContextMenuFactory.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/BuildingBlockNodeContextMenuFactory.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using PKSim.Core.Model;
+
+namespace PKSim.Presentation.Presenters.ContextMenus;
+
+public abstract class BuildingBlockNodeContextMenuFactory<TBuildingBlock> : IContextMenuSpecificationFactory<ITreeNode>
+   where TBuildingBlock : class, IPKSimBuildingBlock
+{
+   public IContextMenu CreateFor(ITreeNode treeNode, IPresenterWithContextMenu<ITreeNode> presenter) =>
+      CreateFor(BuildingBlockFrom(treeNode), presenter);
+
+   public abstract IContextMenu CreateFor(TBuildingBlock buildingBlock, IPresenterWithContextMenu<ITreeNode> presenter);
+
+   public bool IsSatisfiedBy(ITreeNode treeNode, IPresenterWithContextMenu<ITreeNode> presenter) => BuildingBlockFrom(treeNode) != null;
+
+   protected static TBuildingBlock BuildingBlockFrom(ITreeNode treeNode)
+   {
+      var tag = treeNode.TagAsObject;
+      var subject = (tag as IClassifiableWrapper)?.WrappedObject ?? tag;
+      return subject as TBuildingBlock;
+   }
+}
+
+public abstract class MultipleBuildingBlockNodeContextMenuFactory<TBuildingBlock> : MultipleNodeContextMenuFactory<TBuildingBlock>
+{
+   protected override IReadOnlyList<TBuildingBlock> AllTagsFor(IReadOnlyList<ITreeNode> treeNodes) =>
+      treeNodes.Select(subjectFor).Where(x => x != null).OfType<TBuildingBlock>().ToList();
+
+   private static object subjectFor(ITreeNode treeNode)
+   {
+      var tag = treeNode.TagAsObject;
+      return (tag as IClassifiableWrapper)?.WrappedObject ?? tag;
+   }
+}

--- a/src/PKSim.Presentation/Presenters/ContextMenus/CompoundContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/CompoundContextMenu.cs
@@ -36,7 +36,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class CompoundTreeNodeContextMenuFactory : NodeContextMenuFactory<Compound>
+   public class CompoundTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<Compound>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/CompoundFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/CompoundFolderContextMenu.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Presentation.Nodes;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
@@ -8,32 +7,31 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class CompoundFolderContextMenu : BuildingBlockFolderContextMenu<Compound>
    {
-      public CompoundFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewCompound, MenuBarItemIds.LoadCompound)
+      public CompoundFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewCompound, MenuBarItemIds.LoadCompound)
       {
       }
    }
 
    public class CompoundFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public CompoundFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public CompoundFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.CompoundFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new CompoundFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new CompoundFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/EventContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/EventContextMenu.cs
@@ -22,7 +22,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class EventTreeNodeContextMenuFactory : NodeContextMenuFactory<PKSimEvent>
+   public class EventTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<PKSimEvent>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/EventFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/EventFolderContextMenu.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Presentation.Nodes;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
@@ -8,32 +7,31 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class EventFolderContextMenu : BuildingBlockFolderContextMenu<PKSimEvent>
    {
-      public EventFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewEvent, MenuBarItemIds.LoadEvent)
+      public EventFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewEvent, MenuBarItemIds.LoadEvent)
       {
       }
    }
 
    public class EventFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public EventFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public EventFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.EventFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new EventFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new EventFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileContextMenu.cs
@@ -40,7 +40,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class ExpressionProfileTreeNodeContextMenuFactory : NodeContextMenuFactory<ExpressionProfile>
+   public class ExpressionProfileTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<ExpressionProfile>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ExpressionProfileFolderContextMenu.cs
@@ -1,11 +1,11 @@
-﻿using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 
@@ -13,27 +13,25 @@ namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class ExpressionProfileFolderContextMenu : BuildingBlockFolderContextMenu<ExpressionProfile>
    {
-      public ExpressionProfileFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewExpressionProfile, MenuBarItemIds.LoadExpressionProfile)
+      public ExpressionProfileFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewExpressionProfile, MenuBarItemIds.LoadExpressionProfile)
       {
       }
    }
 
    public class ExpressionProfileFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public ExpressionProfileFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public ExpressionProfileFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.ExpressionProfileFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new ExpressionProfileFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new ExpressionProfileFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/FormulationContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/FormulationContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class FormulationTreeNodeContextMenuFactory : NodeContextMenuFactory<Formulation>
+   public class FormulationTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<Formulation>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/FormulationFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/FormulationFolderContextMenu.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Presentation.Nodes;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
@@ -8,32 +7,31 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class FormulationFolderContextMenu : BuildingBlockFolderContextMenu<Formulation>
    {
-      public FormulationFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewFormulation, MenuBarItemIds.LoadFormulationFromTemplate)
+      public FormulationFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewFormulation, MenuBarItemIds.LoadFormulationFromTemplate)
       {
       }
    }
 
    public class FormulationFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public FormulationFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public FormulationFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.FormulationFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new FormulationFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new FormulationFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ImportPopulationContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ImportPopulationContextMenu.cs
@@ -14,7 +14,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class ImportPopulationTreeNodeContextMenuFactory : NodeContextMenuFactory<ImportPopulation>
+   public class ImportPopulationTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<ImportPopulation>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/IndividualContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/IndividualContextMenu.cs
@@ -61,7 +61,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class IndividualTreeNodeContextMenuFactory : NodeContextMenuFactory<Individual>
+   public class IndividualTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<Individual>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/IndividualFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/IndividualFolderContextMenu.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Presentation.Nodes;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
@@ -8,32 +7,31 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class IndividualFolderContextMenu : BuildingBlockFolderContextMenu<Individual>
    {
-      public IndividualFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewIndividual, MenuBarItemIds.LoadIndividual)
+      public IndividualFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewIndividual, MenuBarItemIds.LoadIndividual)
       {
       }
    }
 
    public class IndividualFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public IndividualFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public IndividualFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.IndividualFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new IndividualFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new IndividualFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleCompoundNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleCompoundNodeContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleCompoundNodeContextMenuFactory : MultipleNodeContextMenuFactory<Compound>
+   public class MultipleCompoundNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<Compound>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleEventNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleEventNodeContextMenu.cs
@@ -19,7 +19,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleEventNodeContextMenuFactory : MultipleNodeContextMenuFactory<PKSimEvent>
+   public class MultipleEventNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<PKSimEvent>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleExpressionProfileNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleExpressionProfileNodeContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleExpressionProfileNodeContextMenuFactory : MultipleNodeContextMenuFactory<ExpressionProfile>
+   public class MultipleExpressionProfileNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<ExpressionProfile>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleFormulationNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleFormulationNodeContextMenu.cs
@@ -19,7 +19,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleFormulationNodeContextMenuFactory : MultipleNodeContextMenuFactory<Formulation>
+   public class MultipleFormulationNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<Formulation>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleIndividualNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleIndividualNodeContextMenu.cs
@@ -19,7 +19,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleIndividualNodeContextMenuFactory : MultipleNodeContextMenuFactory<Individual>
+   public class MultipleIndividualNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<Individual>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleObserverSetNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleObserverSetNodeContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleObserverSetNodeContextMenuFactory : MultipleNodeContextMenuFactory<ObserverSet>
+   public class MultipleObserverSetNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<ObserverSet>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultiplePopulationNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultiplePopulationNodeContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultiplePopulationNodeContextMenuFactory : MultipleNodeContextMenuFactory<Population>
+   public class MultiplePopulationNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<Population>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/MultipleProtocolNodeContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/MultipleProtocolNodeContextMenu.cs
@@ -19,7 +19,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class MultipleProtocolNodeContextMenuFactory : MultipleNodeContextMenuFactory<Protocol>
+   public class MultipleProtocolNodeContextMenuFactory : MultipleBuildingBlockNodeContextMenuFactory<Protocol>
    {
       private readonly IExecutionContext _executionContext;
       private readonly IContainer _container;

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ObserverSetContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ObserverSetContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class ObserverSetTreeNodeContextMenuFactory : NodeContextMenuFactory<ObserverSet>
+   public class ObserverSetTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<ObserverSet>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ObserverSetFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ObserverSetFolderContextMenu.cs
@@ -1,11 +1,11 @@
-﻿using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 
@@ -13,27 +13,25 @@ namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class ObserverSetFolderContextMenu : BuildingBlockFolderContextMenu<ObserverSet>
    {
-      public ObserverSetFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewObserverSet, MenuBarItemIds.LoadObserverSet)
+      public ObserverSetFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewObserverSet, MenuBarItemIds.LoadObserverSet)
       {
       }
    }
 
    public class ObserverSetFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public ObserverSetFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public ObserverSetFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.ObserverSetFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new ObserverSetFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new ObserverSetFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/PopulationFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/PopulationFolderContextMenu.cs
@@ -1,6 +1,5 @@
 using OSPSuite.Presentation.Nodes;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters;
@@ -8,32 +7,31 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class PopulationFolderContextMenu : BuildingBlockFolderContextMenu<Population>
    {
-      public PopulationFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewPopulation, MenuBarItemIds.LoadPopulation, MenuBarItemIds.ImportPopulation)
+      public PopulationFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewPopulation, MenuBarItemIds.LoadPopulation, MenuBarItemIds.ImportPopulation)
       {
       }
    }
 
    public class PopulationFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public PopulationFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public PopulationFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.PopulationFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new PopulationFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new PopulationFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ProtocolContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ProtocolContextMenu.cs
@@ -21,7 +21,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class ProtocolTreeNodeContextMenuFactory : NodeContextMenuFactory<Protocol>
+   public class ProtocolTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<Protocol>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/ContextMenus/ProtocolFolderContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/ProtocolFolderContextMenu.cs
@@ -4,8 +4,8 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Repositories;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Nodes;
 
@@ -13,27 +13,25 @@ namespace PKSim.Presentation.Presenters.ContextMenus
 {
    public class ProtocolFolderContextMenu : BuildingBlockFolderContextMenu<Protocol>
    {
-      public ProtocolFolderContextMenu(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
-         : base(repository, buildingBlockRepository, container, MenuBarItemIds.NewProtocol, MenuBarItemIds.LoadProtocol)
+      public ProtocolFolderContextMenu(ITreeNode<RootNodeType> treeNode, IMenuBarItemRepository repository, IExplorerPresenter presenter, IContainer container)
+         : base(treeNode, repository, presenter, container, MenuBarItemIds.NewProtocol, MenuBarItemIds.LoadProtocol)
       {
       }
    }
 
    public class ProtocolFolderTreeNodeContextMenuFactory : RootNodeContextMenuFactory
    {
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IContainer _container;
 
-      public ProtocolFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IBuildingBlockRepository buildingBlockRepository, IContainer container)
+      public ProtocolFolderTreeNodeContextMenuFactory(IMenuBarItemRepository repository, IContainer container)
          : base(PKSimRootNodeTypes.ProtocolFolder, repository)
       {
-         _buildingBlockRepository = buildingBlockRepository;
          _container = container;
       }
 
       public override IContextMenu CreateFor(ITreeNode<RootNodeType> treeNode, IPresenterWithContextMenu<ITreeNode> presenter)
       {
-         return new ProtocolFolderContextMenu(_repository, _buildingBlockRepository, _container);
+         return new ProtocolFolderContextMenu(treeNode, _repository, presenter.DowncastTo<IExplorerPresenter>(), _container);
       }
    }
 }

--- a/src/PKSim.Presentation/Presenters/ContextMenus/RandomPopulationContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/RandomPopulationContextMenu.cs
@@ -13,7 +13,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
       }
    }
 
-   public class RandomPopulationTreeNodeContextMenuFactory : NodeContextMenuFactory<RandomPopulation>
+   public class RandomPopulationTreeNodeContextMenuFactory : BuildingBlockNodeContextMenuFactory<RandomPopulation>
    {
       private readonly IContainer _container;
 

--- a/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
@@ -17,6 +18,7 @@ using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -89,6 +91,15 @@ namespace PKSim.Presentation.Presenters.Main
             _view.AddNode(_treeNodeFactory.CreateFor(PKSimRootNodeTypes.ObserverSetFolder));
             _view.AddNode(_treeNodeFactory.CreateFor(RootNodeTypes.ObservedDataFolder));
 
+            addClassifications(project, ClassificationType.ExpressionProfile);
+            addClassifications(project, ClassificationType.Individual);
+            addClassifications(project, ClassificationType.Population);
+            addClassifications(project, ClassificationType.Compound);
+            addClassifications(project, ClassificationType.Formulation);
+            addClassifications(project, ClassificationType.Protocol);
+            addClassifications(project, ClassificationType.Event);
+            addClassifications(project, ClassificationType.ObserverSet);
+
             var pksimProject = project.DowncastTo<PKSimProject>();
             pksimProject.All<IPKSimBuildingBlock>().Each(x => AddBuildingBlockToTree(x));
 
@@ -96,44 +107,99 @@ namespace PKSim.Presentation.Presenters.Main
          }
       }
 
-      private ITreeNode addEventToTree(PKSimEvent pkSimEvent) => addBuildingBlockToTree(pkSimEvent, PKSimRootNodeTypes.EventFolder, ApplicationIcons.Event);
+      private ITreeNode addEventToTree(PKSimEvent pkSimEvent) => addBuildingBlockToTree<PKSimEvent, ClassifiableEvent>(pkSimEvent, PKSimRootNodeTypes.EventFolder, ApplicationIcons.Event);
 
-      private ITreeNode addPopulationToTree(Population population) => addBuildingBlockToTree(population, PKSimRootNodeTypes.PopulationFolder, ApplicationIcons.Population);
+      private ITreeNode addPopulationToTree(Population population) => addBuildingBlockToTree<Population, ClassifiablePopulation>(population, PKSimRootNodeTypes.PopulationFolder, ApplicationIcons.Population);
 
-      private ITreeNode addIndividualToTree(Individual individual) => addBuildingBlockToTree(individual, PKSimRootNodeTypes.IndividualFolder, ApplicationIcons.IconByName(individual.Icon));
+      private ITreeNode addIndividualToTree(Individual individual) => addBuildingBlockToTree<Individual, ClassifiableIndividual>(individual, PKSimRootNodeTypes.IndividualFolder, ApplicationIcons.IconByName(individual.Icon));
 
-      private ITreeNode addCompoundToTree(Compound compound) => addBuildingBlockToTree(compound, PKSimRootNodeTypes.CompoundFolder, ApplicationIcons.Compound);
+      private ITreeNode addCompoundToTree(Compound compound) => addBuildingBlockToTree<Compound, ClassifiableCompound>(compound, PKSimRootNodeTypes.CompoundFolder, ApplicationIcons.Compound);
 
-      private ITreeNode addFormulationToTree(Formulation formulation) => addBuildingBlockToTree(formulation, PKSimRootNodeTypes.FormulationFolder, ApplicationIcons.Formulation);
+      private ITreeNode addFormulationToTree(Formulation formulation) => addBuildingBlockToTree<Formulation, ClassifiableFormulation>(formulation, PKSimRootNodeTypes.FormulationFolder, ApplicationIcons.Formulation);
 
-      private ITreeNode addProtocolToTree(Protocol protocol) => addBuildingBlockToTree(protocol, PKSimRootNodeTypes.ProtocolFolder, ApplicationIcons.Protocol);
+      private ITreeNode addProtocolToTree(Protocol protocol) => addBuildingBlockToTree<Protocol, ClassifiableProtocol>(protocol, PKSimRootNodeTypes.ProtocolFolder, ApplicationIcons.Protocol);
 
-      private ITreeNode addObserverSetToTree(ObserverSet observerSet) => addBuildingBlockToTree(observerSet, PKSimRootNodeTypes.ObserverSetFolder, ApplicationIcons.Observer);
+      private ITreeNode addObserverSetToTree(ObserverSet observerSet) => addBuildingBlockToTree<ObserverSet, ClassifiableObserverSet>(observerSet, PKSimRootNodeTypes.ObserverSetFolder, ApplicationIcons.Observer);
 
-      private ITreeNode addExpressionProfileToTree(ExpressionProfile expressionProfile) => addBuildingBlockToTree(expressionProfile, PKSimRootNodeTypes.ExpressionProfileFolder, ApplicationIcons.IconByName(expressionProfile.Icon));
+      private ITreeNode addExpressionProfileToTree(ExpressionProfile expressionProfile) => addBuildingBlockToTree<ExpressionProfile, ClassifiableExpressionProfile>(expressionProfile, PKSimRootNodeTypes.ExpressionProfileFolder, ApplicationIcons.IconByName(expressionProfile.Icon));
 
-      private ITreeNode addBuildingBlockToTree<TBuildingBlock>(TBuildingBlock buildingBlock, RootNodeType buildingBlockFolderType, ApplicationIcon icon) where TBuildingBlock : class, IPKSimBuildingBlock
+      private ITreeNode addBuildingBlockToTree<TBuildingBlock, TClassifiable>(TBuildingBlock buildingBlock, RootNodeType buildingBlockFolderType, ApplicationIcon icon) where TBuildingBlock : class, IPKSimBuildingBlock
+         where TClassifiable : Classifiable<TBuildingBlock>, new()
       {
-         var buildingBockFolderNode = _view.NodeByType(buildingBlockFolderType);
-
-         return _view.AddNode(_treeNodeFactory.CreateFor(buildingBlock)
-            .WithIcon(icon)
-            .Under(buildingBockFolderNode));
+         return AddSubjectToClassifyToTree<TBuildingBlock, TClassifiable>(buildingBlock,
+            classifiable => AddClassifiableToTree(classifiable, buildingBlockFolderType,
+               (classificationNode, classifiableToAdd) =>
+               {
+                  var node = _treeNodeFactory.CreateForClassifiableBuildingBlock(classifiableToAdd).WithIcon(icon);
+                  AddClassifiableNodeToView(node, classificationNode);
+                  return node;
+               }));
       }
+
+      private void addClassifications(IProject project, ClassificationType classificationType) =>
+         _classificationPresenter.AddClassificationsToTree(project.AllClassificationsByType(classificationType));
+
 
       public override void AddToClassificationTree(ITreeNode<IClassification> parentNode, string category)
       {
-         _observedDataInExplorerPresenter.GroupObservedDataByCategory(parentNode, category);
+         switch (parentNode.Tag.ClassificationType)
+         {
+            case ClassificationType.ObservedData:
+               _observedDataInExplorerPresenter.GroupObservedDataByCategory(parentNode, category);
+               break;
+            case ClassificationType.Individual:
+               _classificationPresenter.GroupClassificationsByCategory<ClassifiableIndividual>(parentNode, category, x => categoryValueForIndividual(x, category));
+               break;
+            case ClassificationType.ExpressionProfile:
+               _classificationPresenter.GroupClassificationsByCategory<ClassifiableExpressionProfile>(parentNode, category, x => categoryValueForExpressionProfile(x, category));
+               break;
+         }
+      }
+
+      private string categoryValueForIndividual(ClassifiableIndividual classifiable, string category)
+      {
+         if (string.Equals(category, PKSimConstants.Classifications.Species))
+            return classifiable.Individual.Species?.DisplayName;
+
+         return string.Empty;
+      }
+
+      private string categoryValueForExpressionProfile(ClassifiableExpressionProfile classifiable, string category)
+      {
+         if (string.Equals(category, PKSimConstants.Classifications.Molecule))
+            return classifiable.ExpressionProfile.MoleculeName;
+
+         return string.Empty;
       }
 
       public override bool RemoveDataUnderClassification(ITreeNode<IClassification> classificationNode)
       {
-         return _observedDataInExplorerPresenter.RemoveObservedDataUnder(classificationNode);
+         if (classificationNode.Tag.ClassificationType == ClassificationType.ObservedData)
+            return _observedDataInExplorerPresenter.RemoveObservedDataUnder(classificationNode);
+
+         var buildingBlocks = classificationNode.AllLeafNodes
+            .Select(x => x.TagAsObject)
+            .OfType<IClassifiableWrapper>()
+            .Select(x => x.WrappedObject)
+            .OfType<IPKSimBuildingBlock>()
+            .ToList();
+
+         return _buildingBlockTask.Delete(buildingBlocks);
       }
 
       public override IEnumerable<ClassificationTemplate> AvailableClassificationCategories(ITreeNode<IClassification> parentClassificationNode)
       {
-         return _observedDataInExplorerPresenter.AvailableObservedDataCategoriesIn(parentClassificationNode);
+         switch (parentClassificationNode.Tag.ClassificationType)
+         {
+            case ClassificationType.ObservedData:
+               return _observedDataInExplorerPresenter.AvailableObservedDataCategoriesIn(parentClassificationNode);
+            case ClassificationType.Individual:
+               return new[] {new ClassificationTemplate(PKSimConstants.Classifications.Species, ApplicationIcons.Individual)};
+            case ClassificationType.ExpressionProfile:
+               return new[] {new ClassificationTemplate(PKSimConstants.Classifications.Molecule)};
+            default:
+               return Enumerable.Empty<ClassificationTemplate>();
+         }
       }
 
       public override bool CanDrag(ITreeNode node)
@@ -144,10 +210,24 @@ namespace PKSim.Presentation.Presenters.Main
          if (node.IsAnImplementationOf<ClassificationNode>())
             return true;
 
+         if (node.TagAsObject is IClassifiableWrapper wrapper && wrapper.WrappedObject is IPKSimBuildingBlock)
+            return true;
+
          return _observedDataInExplorerPresenter.CanDrag(node);
       }
 
       public override bool CopyAllowed() => false;
+
+      public override void NodeDoubleClicked(ITreeNode node)
+      {
+         if (node.TagAsObject is IClassifiableWrapper wrapper && wrapper.WrappedObject is IPKSimBuildingBlock buildingBlock)
+         {
+            EditBuildingBlock(buildingBlock);
+            return;
+         }
+
+         base.NodeDoubleClicked(node);
+      }
 
       public void Handle(SwapBuildingBlockEvent eventToHandle)
       {

--- a/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Main/BuildingBlockExplorerPresenter.cs
@@ -194,7 +194,7 @@ namespace PKSim.Presentation.Presenters.Main
             case ClassificationType.ObservedData:
                return _observedDataInExplorerPresenter.AvailableObservedDataCategoriesIn(parentClassificationNode);
             case ClassificationType.Individual:
-               return new[] {new ClassificationTemplate(PKSimConstants.Classifications.Species, ApplicationIcons.Individual)};
+               return new[] {new ClassificationTemplate(PKSimConstants.Classifications.Species)};
             case ClassificationType.ExpressionProfile:
                return new[] {new ClassificationTemplate(PKSimConstants.Classifications.Molecule)};
             default:

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.138" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.138" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Starter/UIApplicationStartup.cs
+++ b/src/PKSim.Starter/UIApplicationStartup.cs
@@ -18,7 +18,9 @@ using PKSim.CLI.Core.MinimalImplementations;
 using PKSim.Core;
 using PKSim.Core.Services;
 using PKSim.Infrastructure;
+using OSPSuite.Presentation.Mappers;
 using PKSim.Presentation;
+using PKSim.Presentation.Mappers;
 using System;
 using System.Threading;
 using PKSim.UI;
@@ -75,6 +77,7 @@ namespace PKSim.Starter
             pkSimContainer.Register<IApplicationController, ApplicationController>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreWorkspace, OSPSuite.Core.IWorkspace, IWorkspace, Workspace>(LifeStyle.Singleton);
             pkSimContainer.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, IPresentationUserSettings, IUserSettings, UserSettings>(LifeStyle.Singleton);
+            pkSimContainer.Register<IClassificationTypeToRootNodeTypeMapper, PKSimClassificationTypeToRootNodeTypeMapper>();
 
             // Full registration of OSPSuite Core UI and Presentation
             pkSimContainer.AddRegister(x => x.FromType<UIRegister>());

--- a/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
+++ b/src/PKSim.UI/BootStrapping/ApplicationStartup.cs
@@ -9,6 +9,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Services;
 using OSPSuite.Infrastructure.Services;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Mappers;
 using OSPSuite.Presentation.Presenters.Commands;
 using OSPSuite.Presentation.Presenters.Main;
 using OSPSuite.Presentation.Services;
@@ -26,6 +27,7 @@ using PKSim.Infrastructure;
 using PKSim.Presentation;
 using PKSim.Presentation.Core;
 using PKSim.Presentation.Infrastructure.Services;
+using PKSim.Presentation.Mappers;
 using PKSim.Presentation.Presenters.Main;
 using PKSim.Presentation.Views;
 using PKSim.UI.Views.Core;
@@ -67,6 +69,7 @@ namespace PKSim.UI.BootStrapping
          container.Register<IProgressUpdater, PKSimProgressUpdater>();
          container.RegisterImplementationOf(NumericFormatterOptions.Instance);
          container.Register<IExceptionManager, ExceptionManager>(LifeStyle.Singleton);
+         container.Register<IClassificationTypeToRootNodeTypeMapper, PKSimClassificationTypeToRootNodeTypeMapper>();
 
          container.AddRegister(x => x.FromType<UIRegister>());
          container.AddRegister(x => x.FromType<PresenterRegister>());

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.138" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -14,6 +15,7 @@ using OSPSuite.Presentation.Regions;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Events;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -64,7 +66,9 @@ namespace PKSim.Presentation
          A.CallTo(() => _regionResolver.RegionWithName(RegionNames.BuildingBlockExplorer)).Returns(_region);
          _project = new PKSimProject();
          var compound = new Compound().WithName("compound");
+         compound.Id = "compoundId";
          _individual = new Individual().WithName("individual");
+         _individual.Id = "individualId";
          _individual.OriginData = new OriginData { Species = new Species() };
          _project.AddBuildingBlock(_individual);
          _project.AddBuildingBlock(compound);
@@ -99,8 +103,9 @@ namespace PKSim.Presentation
          A.CallTo(() => _treeNodeFactory.CreateFor(PKSimRootNodeTypes.PopulationFolder)).Returns(_populationFolderNode);
          A.CallTo(() => _treeNodeFactory.CreateFor(RootNodeTypes.ObservedDataFolder)).Returns(_observationRootNode);
          A.CallTo(() => _treeNodeFactory.CreateFor(PKSimRootNodeTypes.EventFolder)).Returns(_eventRootNode);
-         A.CallTo(() => _treeNodeFactory.CreateFor(_individual)).Returns(_individualNode);
-         A.CallTo(() => _treeNodeFactory.CreateFor(compound)).Returns(_compoundNode);
+         A.CallTo(() => _treeNodeFactory.CreateForClassifiableBuildingBlock(A<ClassifiableIndividual>._)).Returns(_individualNode);
+         A.CallTo(() => _treeNodeFactory.CreateForClassifiableBuildingBlock(A<ClassifiableCompound>._)).Returns(_compoundNode);
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(_project);
 
          A.CallTo(() => _view.TreeView.NodeById(PKSimRootNodeTypes.CompoundFolder.Id)).Returns(_compoundFolderNode);
          A.CallTo(() => _view.TreeView.NodeById(PKSimRootNodeTypes.IndividualFolder.Id)).Returns(_individualFolderNode);
@@ -288,6 +293,37 @@ namespace PKSim.Presentation
       public void should_return_false_otherwise()
       {
          sut.AllowMultiSelectFor(new ITreeNode[] { A.Fake<ClassificationNode>(), A.Fake<ObservedDataNode>() }).ShouldBeFalse();
+      }
+   }
+
+   public class When_retrieving_the_available_classification_categories_for_a_building_block_folder : concern_for_BuildingBlockExplorerPresenter
+   {
+      [Observation]
+      public void should_offer_grouping_by_species_for_the_individual_folder()
+      {
+         sut.AvailableClassificationCategories(_individualFolderNode).Select(x => x.ClassificationName)
+            .ShouldContain(PKSimConstants.Classifications.Species);
+      }
+
+      [Observation]
+      public void should_not_offer_any_grouping_for_the_compound_folder()
+      {
+         sut.AvailableClassificationCategories(_compoundFolderNode).ShouldBeEmpty();
+      }
+   }
+
+   public class When_grouping_the_individuals_by_species : concern_for_BuildingBlockExplorerPresenter
+   {
+      protected override void Because()
+      {
+         sut.AddToClassificationTree(_individualFolderNode, PKSimConstants.Classifications.Species);
+      }
+
+      [Observation]
+      public void should_group_the_classifiable_individuals_by_the_species_category()
+      {
+         A.CallTo(() => _classificationPresenter.GroupClassificationsByCategory<ClassifiableIndividual>(_individualFolderNode, PKSimConstants.Classifications.Species, A<Func<ClassifiableIndividual, string>>._))
+            .MustHaveHappened();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/PKSimClassificationTypeToRootNodeTypeMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/PKSimClassificationTypeToRootNodeTypeMapperSpecs.cs
@@ -1,0 +1,39 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Presenters.Nodes;
+using PKSim.Presentation.Mappers;
+using PKSim.Presentation.Nodes;
+
+namespace PKSim.Presentation;
+
+public abstract class concern_for_PKSimClassificationTypeToRootNodeTypeMapper : ContextSpecification<PKSimClassificationTypeToRootNodeTypeMapper>
+{
+   protected override void Context()
+   {
+      sut = new PKSimClassificationTypeToRootNodeTypeMapper();
+   }
+}
+
+public class When_mapping_a_building_block_classification_type_to_a_root_node : concern_for_PKSimClassificationTypeToRootNodeTypeMapper
+{
+   [Observation]
+   public void should_map_each_building_block_classification_type_to_its_folder()
+   {
+      sut.MapFrom(ClassificationType.Compound).ShouldBeEqualTo(PKSimRootNodeTypes.CompoundFolder);
+      sut.MapFrom(ClassificationType.Formulation).ShouldBeEqualTo(PKSimRootNodeTypes.FormulationFolder);
+      sut.MapFrom(ClassificationType.Individual).ShouldBeEqualTo(PKSimRootNodeTypes.IndividualFolder);
+      sut.MapFrom(ClassificationType.Population).ShouldBeEqualTo(PKSimRootNodeTypes.PopulationFolder);
+      sut.MapFrom(ClassificationType.Protocol).ShouldBeEqualTo(PKSimRootNodeTypes.ProtocolFolder);
+      sut.MapFrom(ClassificationType.Event).ShouldBeEqualTo(PKSimRootNodeTypes.EventFolder);
+      sut.MapFrom(ClassificationType.ObserverSet).ShouldBeEqualTo(PKSimRootNodeTypes.ObserverSetFolder);
+      sut.MapFrom(ClassificationType.ExpressionProfile).ShouldBeEqualTo(PKSimRootNodeTypes.ExpressionProfileFolder);
+   }
+
+   [Observation]
+   public void should_delegate_non_building_block_types_to_the_default_core_mapper()
+   {
+      sut.MapFrom(ClassificationType.ObservedData).ShouldBeEqualTo(RootNodeTypes.ObservedDataFolder);
+      sut.MapFrom(ClassificationType.Simulation).ShouldBeEqualTo(RootNodeTypes.SimulationFolder);
+   }
+}

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.138" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.136" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.138" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #1435

## What

Adds **subfolders for building blocks** in the explorer tree, so users can organise each building-block type into their own folders — the same experience that already exists for observed data and simulations in PK-Sim (and modules in MoBi).

Applies to all 8 building-block types: Compound, Formulation, Individual, Population, Protocol, Event, Observer Set, Expression Profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added classification support for compounds, formulations, individuals, populations, protocols, events, observer sets, and expression profiles.
  * Classifiable building blocks can now be grouped and displayed in dedicated explorer folders.
  * Added context-menu actions for creating, removing, and grouping classifications.
  * Double-clicking a classifiable building block opens its editor.
  * Project snapshots now preserve these additional classifications.

* **Bug Fixes**
  * Improved loading and restoration of building-block classifications from saved projects.

* **Chores**
  * Updated supporting platform components to version 13.0.138.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->