### PR TITLE
Fixes #3514 Propagate the molecule rename of an expression profile

### DIFF
--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands
+{
+   /// <summary>
+   ///    Updates the molecule referenced by the compound process and interaction selections of a simulation. This is
+   ///    required when the molecule of an expression profile used in the simulation was renamed. Without it, the simulation
+   ///    could not be created from its building blocks anymore since the referenced molecule would not exist
+   /// </summary>
+   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockIrreversibleStructureChangeCommand
+   {
+      private Simulation _simulation;
+      private readonly string _oldMoleculeName;
+      private readonly string _newMoleculeName;
+
+      public RenameMoleculeReferenceInSimulationCommand(Simulation simulation, string oldMoleculeName, string newMoleculeName, IExecutionContext context)
+      {
+         _simulation = simulation;
+         _oldMoleculeName = oldMoleculeName;
+         _newMoleculeName = newMoleculeName;
+         BuildingBlockId = simulation.Id;
+         ObjectType = context.TypeFor(simulation);
+         CommandType = PKSimConstants.Command.CommandTypeEdit;
+         Description = PKSimConstants.Command.RenameEntityCommandDescripiton(ObjectType, _oldMoleculeName, _newMoleculeName);
+
+         //Command is hidden as it only deals with internals
+         Visible = false;
+      }
+
+      protected override void PerformExecuteWith(IExecutionContext context)
+      {
+         allMoleculeReferences()
+            .Where(x => string.Equals(x.MoleculeName, _oldMoleculeName))
+            .Each(x => x.MoleculeName = _newMoleculeName);
+      }
+
+      private IEnumerable<IProcessMapping> allMoleculeReferences() =>
+         _simulation.CompoundPropertiesList.SelectMany(x => x.Processes.AllProcesses())
+            .Concat<IProcessMapping>(_simulation.InteractionProperties.Interactions);
+
+      protected override void ClearReferences()
+      {
+         _simulation = null;
+      }
+   }
+}

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Model;
@@ -11,7 +12,7 @@ namespace PKSim.Core.Commands
    ///    required when the molecule of an expression profile used in the simulation was renamed. Without it, the simulation
    ///    could not be created from its building blocks anymore since the referenced molecule would not exist
    /// </summary>
-   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockIrreversibleStructureChangeCommand
+   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockStructureChangeCommand
    {
       private Simulation _simulation;
       private readonly string _oldMoleculeName;
@@ -41,6 +42,17 @@ namespace PKSim.Core.Commands
       private IEnumerable<IProcessMapping> allMoleculeReferences() =>
          _simulation.CompoundPropertiesList.SelectMany(x => x.Processes.AllProcesses())
             .Concat<IProcessMapping>(_simulation.InteractionProperties.Interactions);
+
+      protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+      {
+         return new RenameMoleculeReferenceInSimulationCommand(_simulation, _newMoleculeName, _oldMoleculeName, context).AsInverseFor(this);
+      }
+
+      public override void RestoreExecutionData(IExecutionContext context)
+      {
+         base.RestoreExecutionData(context);
+         _simulation = context.Get<Simulation>(BuildingBlockId);
+      }
 
       protected override void ClearReferences()
       {

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
@@ -18,6 +18,7 @@ namespace PKSim.Core.Commands
          _simulationSubject = simulationSubject;
          _oldMoleculeName = oldMoleculeName;
          _newMoleculeName = newMoleculeName;
+         BuildingBlockId = context.BuildingBlockIdContaining(simulationSubject);
          ObjectType = context.TypeFor(simulationSubject);
          CommandType = PKSimConstants.Command.CommandTypeEdit;
          Description = PKSimConstants.Command.RenameEntityCommandDescripiton(ObjectType, _oldMoleculeName, _newMoleculeName);

--- a/src/PKSim.Core/Services/ExpressionProfileUpdater.cs
+++ b/src/PKSim.Core/Services/ExpressionProfileUpdater.cs
@@ -127,6 +127,18 @@ namespace PKSim.Core.Services
             command.Add(renameMoleculeReferences(x, oldMoleculeName, newMoleculeName));
          });
 
+         allSimulationsUsing(expressionProfile).Each(x =>
+         {
+            _lazyLoadTask.Load(x);
+
+            //A simulation holds its own copy of the simulation subject. It has to be renamed as well: it is the copy
+            //offered when reconfiguring the simulation, and the process selections below are resolved against it
+            command.Add(renameMoleculeReferences(x.BuildingBlock<ISimulationSubject>(), oldMoleculeName, newMoleculeName));
+
+            //The simulations also reference the molecule by name in their compound process and interaction selections.
+            //These references must follow the rename, otherwise the simulation cannot be created anymore from its building blocks
+            command.Add(new RenameMoleculeReferenceInSimulationCommand(x, oldMoleculeName, newMoleculeName, _executionContext).Run(_executionContext));
+         });
 
          return command;
       }
@@ -217,6 +229,13 @@ namespace PKSim.Core.Services
          return _projectRetriever.Current?.All<ISimulationSubject>()
             .Where(x => x.Uses(expressionProfile))
             .ToArray() ?? Array.Empty<ISimulationSubject>();
+      }
+
+      private IReadOnlyList<Simulation> allSimulationsUsing(ExpressionProfile expressionProfile)
+      {
+         return _projectRetriever.Current?.All<Simulation>()
+            .Where(x => x.UsedBuildingBlockByTemplateId(expressionProfile.Id) != null)
+            .ToArray() ?? Array.Empty<Simulation>();
       }
 
       public void SynchronizeAllSimulationSubjectsWithExpressionProfile(ISimulationSubject internalSimulationSubject)

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -1,0 +1,228 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Core.Domain.IContainer;
+using PKSim.Core;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+
+namespace PKSim.IntegrationTests
+{
+   public abstract class concern_for_renaming_an_expression_profile : ContextForSimulationIntegration<IRenameBuildingBlockTask>
+   {
+      protected Individual _individual;
+      protected ExpressionProfile _expressionProfile;
+      protected PKSimProject _project;
+      protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IRenameBuildingBlockTask>();
+         _buildingBlockInProjectManager = IoC.Resolve<IBuildingBlockInProjectManager>();
+
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(_individual, "CYP3A4");
+
+         var compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _simulation = DomainFactoryForSpecs.CreateSimulationWith(_individual, compound, protocol) as IndividualSimulation;
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_individual);
+         _project.AddBuildingBlock(_expressionProfile);
+         _project.AddBuildingBlock(compound);
+         _project.AddBuildingBlock(protocol);
+         _project.AddBuildingBlock(_simulation);
+
+         IoC.Resolve<ICoreWorkspace>().Project = _project;
+         var registrationTask = IoC.Resolve<IRegistrationTask>();
+         _project.All<IPKSimBuildingBlock>().Each(registrationTask.Register);
+
+         //simulate a saved project: nothing has changed yet
+         _project.HasChanged = false;
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         _project.All<IPKSimBuildingBlock>().Each(Unregister);
+      }
+   }
+
+   public class When_renaming_the_molecule_of_an_expression_profile_used_by_an_individual_used_in_a_simulation : concern_for_renaming_an_expression_profile
+   {
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_expressionProfile, "CYP2D6|Human|Standard");
+      }
+
+      [Observation]
+      public void should_have_renamed_the_molecule_in_the_individual()
+      {
+         _individual.MoleculeByName("CYP2D6").ShouldNotBeNull();
+         _individual.MoleculeByName("CYP3A4").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_have_renamed_all_molecule_containers_in_the_individual()
+      {
+         _individual.AllMoleculeContainersFor(_individual.MoleculeByName("CYP2D6")).Count.ShouldBeGreaterThan(0);
+         _individual.GetAllChildren<IContainer>(x => x.IsNamed("CYP3A4")).Count.ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_have_marked_the_individual_as_changed_so_that_the_rename_is_persisted()
+      {
+         _individual.HasChanged.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_have_marked_the_expression_profile_as_changed()
+      {
+         _expressionProfile.HasChanged.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_have_marked_the_simulation_as_out_of_sync_with_its_building_blocks()
+      {
+         _buildingBlockInProjectManager.StatusFor(_simulation).ShouldBeEqualTo(BuildingBlockStatus.Red);
+      }
+   }
+
+   public abstract class concern_for_renaming_an_expression_profile_mapped_to_a_process : ContextForSimulationIntegration<IRenameBuildingBlockTask>
+   {
+      protected Individual _individual;
+      protected ExpressionProfile _expressionProfile;
+      protected Compound _compound;
+      protected Protocol _protocol;
+      protected PKSimProject _project;
+      protected const string _transportProcessName = "ActProc1";
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IRenameBuildingBlockTask>();
+         var context = IoC.Resolve<IExecutionContext>();
+
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualTransporter>(_individual, "Tr1");
+         new SetTransportTypeCommand(_expressionProfile.Molecule.DowncastTo<IndividualTransporter>(), TransportType.Efflux, context).Run(context);
+
+         _compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var transportProcess = IoC.Resolve<ICloneManager>()
+            .Clone(IoC.Resolve<ICompoundProcessRepository>().ProcessByName(CoreConstantsForSpecs.Process.ACTIVE_TRANSPORT_SPECIFIC_MM))
+            .WithName(_transportProcessName);
+         _compound.AddProcess(transportProcess);
+
+         _protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol).DowncastTo<IndividualSimulation>();
+         addTransportSelectionTo(_simulation, _expressionProfile.MoleculeName);
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_individual);
+         _project.AddBuildingBlock(_expressionProfile);
+         _project.AddBuildingBlock(_compound);
+         _project.AddBuildingBlock(_protocol);
+         _project.AddBuildingBlock(_simulation);
+
+         IoC.Resolve<ICoreWorkspace>().Project = _project;
+         var registrationTask = IoC.Resolve<IRegistrationTask>();
+         _project.All<IPKSimBuildingBlock>().Each(registrationTask.Register);
+      }
+
+      protected static void addTransportSelectionTo(Simulation simulation, string moleculeName)
+      {
+         simulation.CompoundPropertiesList.First()
+            .Processes
+            .TransportAndExcretionSelection
+            .AddPartialProcessSelection(new ProcessSelection { ProcessName = _transportProcessName, MoleculeName = moleculeName });
+      }
+
+      protected ProcessSelection TransportSelectionOf(Simulation simulation) =>
+         simulation.CompoundPropertiesList.First().Processes.TransportAndExcretionSelection.AllPartialProcesses().First();
+
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_expressionProfile, "Tr2|Human|Standard");
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         _project.All<IPKSimBuildingBlock>().Each(Unregister);
+      }
+   }
+
+   public class When_renaming_the_molecule_of_an_expression_profile_mapped_to_a_process_in_a_simulation : concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_have_renamed_the_molecule_referenced_by_the_process_selection_of_the_simulation()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr2");
+      }
+   }
+
+   public class When_undoing_the_rename_of_the_molecule_of_an_expression_profile_mapped_to_a_process_in_a_simulation :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      protected override void Because()
+      {
+         //Go through the command that is actually put in the history, so that the undo uses the production inverse
+         var context = IoC.Resolve<IExecutionContext>();
+         new RenameEntityCommand(_expressionProfile, "Tr2|Human|Standard", context)
+            .ExecuteAndInvokeInverse(context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_name_in_the_individual()
+      {
+         _individual.MoleculeByName("Tr1").ShouldNotBeNull();
+         _individual.MoleculeByName("Tr2").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_referenced_by_the_process_selection_of_the_simulation()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr1");
+      }
+   }
+
+   public class When_reconfiguring_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_offer_a_simulation_subject_whose_molecule_matches_the_process_selection()
+      {
+         //This is what the Configure Simulation wizard pre-selects for the simulation subject step
+         var offeredSubject = IoC.Resolve<IBuildingBlockInProjectManager>()
+            .TemplateBuildingBlocksUsedBy<ISimulationSubject>(_simulation).Single();
+
+         var mappedMoleculeName = TransportSelectionOf(_simulation).MoleculeName;
+         offeredSubject.MoleculeByName(mappedMoleculeName).ShouldNotBeNull();
+      }
+   }
+
+   public class When_recreating_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed : concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_be_able_to_create_the_simulation_model_from_the_renamed_building_blocks()
+      {
+         var recreatedSimulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol);
+         addTransportSelectionTo(recreatedSimulation, TransportSelectionOf(_simulation).MoleculeName);
+
+         DomainFactoryForSpecs.AddModelToSimulation(recreatedSimulation);
+
+         recreatedSimulation.Model.ShouldNotBeNull();
+      }
+   }
+}

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -202,7 +202,6 @@ namespace PKSim.IntegrationTests
    {
       protected override void Because()
       {
-         //the command is reversible on its own, independently of the macro command it is normally part of
          var context = IoC.Resolve<IExecutionContext>();
          new RenameMoleculeReferenceInSimulationCommand(_simulation, "Tr1", "Tr2", context)
             .ExecuteAndInvokeInverse(context);

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -197,6 +197,24 @@ namespace PKSim.IntegrationTests
       }
    }
 
+   public class When_undoing_the_rename_of_the_molecule_reference_in_a_simulation_on_its_own :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      protected override void Because()
+      {
+         //the command is reversible on its own, independently of the macro command it is normally part of
+         var context = IoC.Resolve<IExecutionContext>();
+         new RenameMoleculeReferenceInSimulationCommand(_simulation, "Tr1", "Tr2", context)
+            .ExecuteAndInvokeInverse(context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_referenced_by_the_process_selection()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr1");
+      }
+   }
+
    public class When_reconfiguring_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed :
       concern_for_renaming_an_expression_profile_mapped_to_a_process
    {


### PR DESCRIPTION
## Problem

Fixes #3514 Two defects:

1. **The rename was never saved.** `RenameMoleculeReferenceInSimulationSubjectCommand` never set `BuildingBlockId`, so the individual was neither flagged `HasChanged` nor version incremented. Since `serializeContentFor` skips unchanged building blocks, the old individual stayed in the project file — reopening it gave molecules that no longer match their expression profiles. The missing version increment also kept simulations green.

2. **Simulations kept the old molecule name** in their compound process/interaction selections and in their own copy of the simulation subject. Snapshots rebuild simulations from templates, so a stale mapping is a dangling reference — the `NullReferenceException` in `ProcessToProcessBuilderMapper` from the report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renaming a molecule in an expression profile now updates related molecule references throughout simulations, including process and interaction selections.
  - Simulations are correctly marked out of sync when referenced molecule names change.
  - Renamed molecules remain available when reconfiguring or recreating simulations.

- **Bug Fixes**
  - Undoing a molecule rename now restores both individual data and simulation process selections.
  - Improved tracking of the building block associated with simulation subject rename operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->