### PR TITLE
Fixes #3639 Rename the molecule in the population parameter paths

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands
+{
+   /// <summary>
+   ///    Updates the molecule referenced by the compound process and interaction selections of a simulation. This is
+   ///    required when the molecule of an expression profile used in the simulation was renamed. Without it, the simulation
+   ///    could not be created from its building blocks anymore since the referenced molecule would not exist
+   /// </summary>
+   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockIrreversibleStructureChangeCommand
+   {
+      private Simulation _simulation;
+      private readonly string _oldMoleculeName;
+      private readonly string _newMoleculeName;
+
+      public RenameMoleculeReferenceInSimulationCommand(Simulation simulation, string oldMoleculeName, string newMoleculeName, IExecutionContext context)
+      {
+         _simulation = simulation;
+         _oldMoleculeName = oldMoleculeName;
+         _newMoleculeName = newMoleculeName;
+         BuildingBlockId = simulation.Id;
+         ObjectType = context.TypeFor(simulation);
+         CommandType = PKSimConstants.Command.CommandTypeEdit;
+         Description = PKSimConstants.Command.RenameEntityCommandDescripiton(ObjectType, _oldMoleculeName, _newMoleculeName);
+
+         //Command is hidden as it only deals with internals
+         Visible = false;
+      }
+
+      protected override void PerformExecuteWith(IExecutionContext context)
+      {
+         allMoleculeReferences()
+            .Where(x => string.Equals(x.MoleculeName, _oldMoleculeName))
+            .Each(x => x.MoleculeName = _newMoleculeName);
+      }
+
+      private IEnumerable<IProcessMapping> allMoleculeReferences() =>
+         _simulation.CompoundPropertiesList.SelectMany(x => x.Processes.AllProcesses())
+            .Concat<IProcessMapping>(_simulation.InteractionProperties.Interactions);
+
+      protected override void ClearReferences()
+      {
+         _simulation = null;
+      }
+   }
+}

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationCommand.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Model;
@@ -11,7 +12,7 @@ namespace PKSim.Core.Commands
    ///    required when the molecule of an expression profile used in the simulation was renamed. Without it, the simulation
    ///    could not be created from its building blocks anymore since the referenced molecule would not exist
    /// </summary>
-   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockIrreversibleStructureChangeCommand
+   public class RenameMoleculeReferenceInSimulationCommand : BuildingBlockStructureChangeCommand
    {
       private Simulation _simulation;
       private readonly string _oldMoleculeName;
@@ -41,6 +42,17 @@ namespace PKSim.Core.Commands
       private IEnumerable<IProcessMapping> allMoleculeReferences() =>
          _simulation.CompoundPropertiesList.SelectMany(x => x.Processes.AllProcesses())
             .Concat<IProcessMapping>(_simulation.InteractionProperties.Interactions);
+
+      protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context)
+      {
+         return new RenameMoleculeReferenceInSimulationCommand(_simulation, _newMoleculeName, _oldMoleculeName, context).AsInverseFor(this);
+      }
+
+      public override void RestoreExecutionData(IExecutionContext context)
+      {
+         base.RestoreExecutionData(context);
+         _simulation = context.Get<Simulation>(BuildingBlockId);
+      }
 
       protected override void ClearReferences()
       {

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
@@ -18,6 +18,7 @@ namespace PKSim.Core.Commands
          _simulationSubject = simulationSubject;
          _oldMoleculeName = oldMoleculeName;
          _newMoleculeName = newMoleculeName;
+         BuildingBlockId = context.BuildingBlockIdContaining(simulationSubject);
          ObjectType = context.TypeFor(simulationSubject);
          CommandType = PKSimConstants.Command.CommandTypeEdit;
          Description = PKSimConstants.Command.RenameEntityCommandDescripiton(ObjectType, _oldMoleculeName, _newMoleculeName);

--- a/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
+++ b/src/PKSim.Core/Commands/RenameMoleculeReferenceInSimulationSubjectCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Extensions;
@@ -39,7 +40,30 @@ namespace PKSim.Core.Commands
 
          //We also need to update all object path
          allMoleculeContainers.SelectMany(x => x.GetAllChildren<IUsingFormula>()).Each(x => x.Formula.ReplaceKeywordInObjectPaths(_oldMoleculeName, _newMoleculeName));
+
+         renameMoleculeInParameterPathsOf(_simulationSubject as Population);
       }
+
+      private void renameMoleculeInParameterPathsOf(Population population)
+      {
+         if (population == null)
+            return;
+
+         var individualValues = population.IndividualValuesCache;
+         foreach (var oldPath in individualValues.AllParameterPaths())
+         {
+            var newPath = renameMoleculeIn(oldPath);
+            if (!string.Equals(newPath, oldPath))
+               individualValues.RenamePath(oldPath, newPath);
+         }
+
+         population.AdvancedParameters.Each(x => x.ParameterPath = renameMoleculeIn(x.ParameterPath));
+      }
+
+      private string renameMoleculeIn(string parameterPath) =>
+         parameterPath.ToPathArray()
+            .Select(x => string.Equals(x, _oldMoleculeName) ? _newMoleculeName : x)
+            .ToPathString();
 
       protected override void ClearReferences()
       {

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.140" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/ExpressionProfileUpdater.cs
+++ b/src/PKSim.Core/Services/ExpressionProfileUpdater.cs
@@ -127,6 +127,18 @@ namespace PKSim.Core.Services
             command.Add(renameMoleculeReferences(x, oldMoleculeName, newMoleculeName));
          });
 
+         allSimulationsUsing(expressionProfile).Each(x =>
+         {
+            _lazyLoadTask.Load(x);
+
+            //A simulation holds its own copy of the simulation subject. It has to be renamed as well: it is the copy
+            //offered when reconfiguring the simulation, and the process selections below are resolved against it
+            command.Add(renameMoleculeReferences(x.BuildingBlock<ISimulationSubject>(), oldMoleculeName, newMoleculeName));
+
+            //The simulations also reference the molecule by name in their compound process and interaction selections.
+            //These references must follow the rename, otherwise the simulation cannot be created anymore from its building blocks
+            command.Add(new RenameMoleculeReferenceInSimulationCommand(x, oldMoleculeName, newMoleculeName, _executionContext).Run(_executionContext));
+         });
 
          return command;
       }
@@ -217,6 +229,13 @@ namespace PKSim.Core.Services
          return _projectRetriever.Current?.All<ISimulationSubject>()
             .Where(x => x.Uses(expressionProfile))
             .ToArray() ?? Array.Empty<ISimulationSubject>();
+      }
+
+      private IReadOnlyList<Simulation> allSimulationsUsing(ExpressionProfile expressionProfile)
+      {
+         return _projectRetriever.Current?.All<Simulation>()
+            .Where(x => x.UsedBuildingBlockByTemplateId(expressionProfile.Id) != null)
+            .ToArray() ?? Array.Empty<Simulation>();
       }
 
       public void SynchronizeAllSimulationSubjectsWithExpressionProfile(ISimulationSubject internalSimulationSubject)

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.140" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.140" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.140" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.138" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileInPopulationSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileInPopulationSpecs.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core;
+using PKSim.Core.Model;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+
+namespace PKSim.IntegrationTests
+{
+   public class When_renaming_the_molecule_of_an_expression_profile_used_by_a_population : ContextForIntegration<IRenameBuildingBlockTask>
+   {
+      private Population _population;
+      private ExpressionProfile _expressionProfile;
+      private PKSimProject _project;
+      private IEntityPathResolver _entityPathResolver;
+      private string _referenceConcentrationPath;
+      private double[] _valuesBeforeRename;
+      private double _meanBeforeRename;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IRenameBuildingBlockTask>();
+         _entityPathResolver = IoC.Resolve<IEntityPathResolver>();
+
+         var individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(individual, "CYP3A4");
+         _population = DomainFactoryForSpecs.CreateDefaultPopulation(individual);
+         IoC.Resolve<IMoleculeParameterVariabilityCreator>().AddVariabilityTo(_population);
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_population);
+         _project.AddBuildingBlock(_expressionProfile);
+         IoC.Resolve<ICoreWorkspace>().Project = _project;
+         _project.All<IPKSimBuildingBlock>().Each(IoC.Resolve<IRegistrationTask>().Register);
+
+         var referenceConcentration = _population.MoleculeByName("CYP3A4").ReferenceConcentration;
+         _referenceConcentrationPath = _entityPathResolver.PathFor(referenceConcentration);
+         _valuesBeforeRename = _population.IndividualValuesCache.GetValues(_referenceConcentrationPath);
+         _meanBeforeRename = _population.AdvancedParameterFor(_entityPathResolver, referenceConcentration)
+            .DistributedParameter.MeanParameter.Value;
+      }
+
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_expressionProfile, "CYP2D6|Human|Standard");
+      }
+
+      [Observation]
+      public void should_have_renamed_the_molecule_in_the_advanced_parameter_paths()
+      {
+         pathsContaining(_population.AdvancedParameters.Select(x => x.ParameterPath), "CYP3A4").ShouldBeEmpty();
+         pathsContaining(_population.AdvancedParameters.Select(x => x.ParameterPath), "CYP2D6").ShouldNotBeEmpty();
+      }
+
+      [Observation]
+      public void should_have_renamed_the_molecule_in_the_generated_individual_values()
+      {
+         pathsContaining(_population.IndividualValuesCache.AllParameterPaths(), "CYP3A4").ShouldBeEmpty();
+         pathsContaining(_population.IndividualValuesCache.AllParameterPaths(), "CYP2D6").ShouldNotBeEmpty();
+      }
+
+      [Observation]
+      public void should_still_resolve_the_variability_of_the_renamed_molecule()
+      {
+         var molecule = _population.MoleculeByName("CYP2D6");
+         _population.AdvancedParameterFor(_entityPathResolver, molecule.ReferenceConcentration).ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_still_export_the_varied_parameters_of_the_renamed_molecule()
+      {
+         var exported = _population.AllVectorialParameters(_entityPathResolver).Select(_entityPathResolver.PathFor);
+         pathsContaining(exported, "CYP2D6").ShouldNotBeEmpty();
+      }
+
+      [Observation]
+      public void should_move_the_existing_variability_instead_of_regenerating_it()
+      {
+         var referenceConcentration = _population.MoleculeByName("CYP2D6").ReferenceConcentration;
+         var newPath = _entityPathResolver.PathFor(referenceConcentration);
+
+         _population.IndividualValuesCache.GetValues(newPath).ShouldBeEqualTo(_valuesBeforeRename);
+
+         _population.AdvancedParameterFor(_entityPathResolver, referenceConcentration)
+            .DistributedParameter.MeanParameter.Value.ShouldBeEqualTo(_meanBeforeRename);
+      }
+
+      [Observation]
+      public void should_keep_the_renamed_paths_when_the_population_values_are_cloned()
+      {
+         var clone = _population.IndividualValuesCache.Clone();
+         pathsContaining(clone.AllParameterPaths(), "CYP3A4").ShouldBeEmpty();
+      }
+
+      private static string[] pathsContaining(System.Collections.Generic.IEnumerable<string> paths, string moleculeName) =>
+         paths.Where(x => x.Contains(moleculeName)).ToArray();
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         _project.All<IPKSimBuildingBlock>().Each(Unregister);
+      }
+   }
+}

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -1,0 +1,228 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Core.Domain.IContainer;
+using PKSim.Core;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Infrastructure;
+
+namespace PKSim.IntegrationTests
+{
+   public abstract class concern_for_renaming_an_expression_profile : ContextForSimulationIntegration<IRenameBuildingBlockTask>
+   {
+      protected Individual _individual;
+      protected ExpressionProfile _expressionProfile;
+      protected PKSimProject _project;
+      protected IBuildingBlockInProjectManager _buildingBlockInProjectManager;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IRenameBuildingBlockTask>();
+         _buildingBlockInProjectManager = IoC.Resolve<IBuildingBlockInProjectManager>();
+
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualEnzyme>(_individual, "CYP3A4");
+
+         var compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _simulation = DomainFactoryForSpecs.CreateSimulationWith(_individual, compound, protocol) as IndividualSimulation;
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_individual);
+         _project.AddBuildingBlock(_expressionProfile);
+         _project.AddBuildingBlock(compound);
+         _project.AddBuildingBlock(protocol);
+         _project.AddBuildingBlock(_simulation);
+
+         IoC.Resolve<ICoreWorkspace>().Project = _project;
+         var registrationTask = IoC.Resolve<IRegistrationTask>();
+         _project.All<IPKSimBuildingBlock>().Each(registrationTask.Register);
+
+         //simulate a saved project: nothing has changed yet
+         _project.HasChanged = false;
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         _project.All<IPKSimBuildingBlock>().Each(Unregister);
+      }
+   }
+
+   public class When_renaming_the_molecule_of_an_expression_profile_used_by_an_individual_used_in_a_simulation : concern_for_renaming_an_expression_profile
+   {
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_expressionProfile, "CYP2D6|Human|Standard");
+      }
+
+      [Observation]
+      public void should_have_renamed_the_molecule_in_the_individual()
+      {
+         _individual.MoleculeByName("CYP2D6").ShouldNotBeNull();
+         _individual.MoleculeByName("CYP3A4").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_have_renamed_all_molecule_containers_in_the_individual()
+      {
+         _individual.AllMoleculeContainersFor(_individual.MoleculeByName("CYP2D6")).Count.ShouldBeGreaterThan(0);
+         _individual.GetAllChildren<IContainer>(x => x.IsNamed("CYP3A4")).Count.ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_have_marked_the_individual_as_changed_so_that_the_rename_is_persisted()
+      {
+         _individual.HasChanged.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_have_marked_the_expression_profile_as_changed()
+      {
+         _expressionProfile.HasChanged.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_have_marked_the_simulation_as_out_of_sync_with_its_building_blocks()
+      {
+         _buildingBlockInProjectManager.StatusFor(_simulation).ShouldBeEqualTo(BuildingBlockStatus.Red);
+      }
+   }
+
+   public abstract class concern_for_renaming_an_expression_profile_mapped_to_a_process : ContextForSimulationIntegration<IRenameBuildingBlockTask>
+   {
+      protected Individual _individual;
+      protected ExpressionProfile _expressionProfile;
+      protected Compound _compound;
+      protected Protocol _protocol;
+      protected PKSimProject _project;
+      protected const string _transportProcessName = "ActProc1";
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IRenameBuildingBlockTask>();
+         var context = IoC.Resolve<IExecutionContext>();
+
+         _individual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _expressionProfile = DomainFactoryForSpecs.CreateExpressionProfileAndAddToIndividual<IndividualTransporter>(_individual, "Tr1");
+         new SetTransportTypeCommand(_expressionProfile.Molecule.DowncastTo<IndividualTransporter>(), TransportType.Efflux, context).Run(context);
+
+         _compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var transportProcess = IoC.Resolve<ICloneManager>()
+            .Clone(IoC.Resolve<ICompoundProcessRepository>().ProcessByName(CoreConstantsForSpecs.Process.ACTIVE_TRANSPORT_SPECIFIC_MM))
+            .WithName(_transportProcessName);
+         _compound.AddProcess(transportProcess);
+
+         _protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol).DowncastTo<IndividualSimulation>();
+         addTransportSelectionTo(_simulation, _expressionProfile.MoleculeName);
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+
+         _project = new PKSimProject();
+         _project.AddBuildingBlock(_individual);
+         _project.AddBuildingBlock(_expressionProfile);
+         _project.AddBuildingBlock(_compound);
+         _project.AddBuildingBlock(_protocol);
+         _project.AddBuildingBlock(_simulation);
+
+         IoC.Resolve<ICoreWorkspace>().Project = _project;
+         var registrationTask = IoC.Resolve<IRegistrationTask>();
+         _project.All<IPKSimBuildingBlock>().Each(registrationTask.Register);
+      }
+
+      protected static void addTransportSelectionTo(Simulation simulation, string moleculeName)
+      {
+         simulation.CompoundPropertiesList.First()
+            .Processes
+            .TransportAndExcretionSelection
+            .AddPartialProcessSelection(new ProcessSelection { ProcessName = _transportProcessName, MoleculeName = moleculeName });
+      }
+
+      protected ProcessSelection TransportSelectionOf(Simulation simulation) =>
+         simulation.CompoundPropertiesList.First().Processes.TransportAndExcretionSelection.AllPartialProcesses().First();
+
+      protected override void Because()
+      {
+         sut.RenameBuildingBlock(_expressionProfile, "Tr2|Human|Standard");
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         _project.All<IPKSimBuildingBlock>().Each(Unregister);
+      }
+   }
+
+   public class When_renaming_the_molecule_of_an_expression_profile_mapped_to_a_process_in_a_simulation : concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_have_renamed_the_molecule_referenced_by_the_process_selection_of_the_simulation()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr2");
+      }
+   }
+
+   public class When_undoing_the_rename_of_the_molecule_of_an_expression_profile_mapped_to_a_process_in_a_simulation :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      protected override void Because()
+      {
+         //Go through the command that is actually put in the history, so that the undo uses the production inverse
+         var context = IoC.Resolve<IExecutionContext>();
+         new RenameEntityCommand(_expressionProfile, "Tr2|Human|Standard", context)
+            .ExecuteAndInvokeInverse(context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_name_in_the_individual()
+      {
+         _individual.MoleculeByName("Tr1").ShouldNotBeNull();
+         _individual.MoleculeByName("Tr2").ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_referenced_by_the_process_selection_of_the_simulation()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr1");
+      }
+   }
+
+   public class When_reconfiguring_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_offer_a_simulation_subject_whose_molecule_matches_the_process_selection()
+      {
+         //This is what the Configure Simulation wizard pre-selects for the simulation subject step
+         var offeredSubject = IoC.Resolve<IBuildingBlockInProjectManager>()
+            .TemplateBuildingBlocksUsedBy<ISimulationSubject>(_simulation).Single();
+
+         var mappedMoleculeName = TransportSelectionOf(_simulation).MoleculeName;
+         offeredSubject.MoleculeByName(mappedMoleculeName).ShouldNotBeNull();
+      }
+   }
+
+   public class When_recreating_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed : concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      [Observation]
+      public void should_be_able_to_create_the_simulation_model_from_the_renamed_building_blocks()
+      {
+         var recreatedSimulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(_individual, _compound, _protocol);
+         addTransportSelectionTo(recreatedSimulation, TransportSelectionOf(_simulation).MoleculeName);
+
+         DomainFactoryForSpecs.AddModelToSimulation(recreatedSimulation);
+
+         recreatedSimulation.Model.ShouldNotBeNull();
+      }
+   }
+}

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -202,7 +202,6 @@ namespace PKSim.IntegrationTests
    {
       protected override void Because()
       {
-         //the command is reversible on its own, independently of the macro command it is normally part of
          var context = IoC.Resolve<IExecutionContext>();
          new RenameMoleculeReferenceInSimulationCommand(_simulation, "Tr1", "Tr2", context)
             .ExecuteAndInvokeInverse(context);

--- a/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/RenameExpressionProfileSpecs.cs
@@ -197,6 +197,24 @@ namespace PKSim.IntegrationTests
       }
    }
 
+   public class When_undoing_the_rename_of_the_molecule_reference_in_a_simulation_on_its_own :
+      concern_for_renaming_an_expression_profile_mapped_to_a_process
+   {
+      protected override void Because()
+      {
+         //the command is reversible on its own, independently of the macro command it is normally part of
+         var context = IoC.Resolve<IExecutionContext>();
+         new RenameMoleculeReferenceInSimulationCommand(_simulation, "Tr1", "Tr2", context)
+            .ExecuteAndInvokeInverse(context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_molecule_referenced_by_the_process_selection()
+      {
+         TransportSelectionOf(_simulation).MoleculeName.ShouldBeEqualTo("Tr1");
+      }
+   }
+
    public class When_reconfiguring_a_simulation_after_the_molecule_of_an_expression_profile_was_renamed :
       concern_for_renaming_an_expression_profile_mapped_to_a_process
    {

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.138" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.138" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.140" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.138" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.138" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.140" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.138" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.140" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #3639

Stacked on #3637 — review that first. Also includes `update core` to 13.0.140, which is required by the change below.

A population keeps its user defined variability (`AdvancedParameter.ParameterPath`) and the values generated per individual (`IndividualValuesCache`) in collections keyed by parameter path, and those paths contain the molecule name. They did not follow the rename of an expression profile molecule.

`Population.AllVectorialParameters` resolves those paths and drops what it cannot find, so the variability silently disappeared — the entries vanish from the distribution tab and the molecule's columns vanish from the population CSV export. No error. Confirmed in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renaming a molecule in an expression profile now updates related population parameter paths and generated values.
  - Existing variability remains associated with the renamed molecule and continues to support export and population cloning.

- **Tests**
  - Added integration coverage for molecule renaming across population simulations.

- **Chores**
  - Updated OSPSuite components to version 13.0.140.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->