### PR TITLE
Fixes #3622 Add the model calculation methods a saved simulation needs to reconfigure

### DIFF
--- a/src/PKSim.Infrastructure/ProjectConverter/IndividualCalculationMethodsUpdater.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/IndividualCalculationMethodsUpdater.cs
@@ -1,6 +1,9 @@
-﻿using PKSim.Core;
+﻿using System.Linq;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
+using PKSim.Core.Services;
 
 namespace PKSim.Infrastructure.ProjectConverter
 {
@@ -9,24 +12,37 @@ namespace PKSim.Infrastructure.ProjectConverter
       void AddMissingCalculationMethodsTo(Individual individual);
       void AddMissingCalculationMethodsTo(Simulation simulation);
 
-      /// <summary>
-      ///    Adds a single calculation method by name if the individual does not reference it yet. Unlike
-      ///    <see cref="AddMissingCalculationMethodsTo(Individual)" /> this does not touch the legacy body-surface-area,
-      ///    renal-aging and dynamic-formula methods, so it will not add a second method into a category the individual
-      ///    already fills with a different option.
-      /// </summary>
+      //Adds one calculation method by name, without touching the legacy methods, so it cannot fill a category twice.
       void AddCalculationMethodTo(Individual individual, string calculationMethodName);
 
-      void AddCalculationMethodTo(Simulation simulation, string calculationMethodName);
+      //Adds the model calculation methods the current default defines but the saved simulation is missing.
+      void AddMissingModelCalculationMethodsTo(Simulation simulation);
    }
 
    public class IndividualCalculationMethodsUpdater : IIndividualCalculationMethodsUpdater
    {
       private readonly ICalculationMethodRepository _calculationMethodRepository;
+      private readonly IModelPropertiesTask _modelPropertiesTask;
 
-      public IndividualCalculationMethodsUpdater(ICalculationMethodRepository calculationMethodRepository)
+      public IndividualCalculationMethodsUpdater(ICalculationMethodRepository calculationMethodRepository, IModelPropertiesTask modelPropertiesTask)
       {
          _calculationMethodRepository = calculationMethodRepository;
+         _modelPropertiesTask = modelPropertiesTask;
+      }
+
+      public void AddMissingModelCalculationMethodsTo(Simulation simulation)
+      {
+         var individual = simulation?.Individual;
+         var modelConfiguration = simulation?.ModelProperties?.ModelConfiguration;
+         if (individual?.OriginData == null || modelConfiguration == null)
+            return;
+
+         var defaultModelProperties = _modelPropertiesTask.DefaultFor(individual.OriginData, modelConfiguration.ModelName);
+         var calculationMethodCache = simulation.ModelProperties.CalculationMethodCache;
+
+         defaultModelProperties.AllCalculationMethods()
+            .Where(x => calculationMethodCache.CalculationMethodFor(x.Category) == null)
+            .Each(calculationMethodCache.AddCalculationMethod);
       }
 
       public void AddMissingCalculationMethodsTo(Individual individual)
@@ -52,14 +68,6 @@ namespace PKSim.Infrastructure.ProjectConverter
             return;
 
          addMissingCalculationMethodTo(individual.OriginData, calculationMethodName);
-      }
-
-      public void AddCalculationMethodTo(Simulation simulation, string calculationMethodName)
-      {
-         if (simulation?.BuildingBlock<Individual>() == null)
-            return;
-
-         addMissingCalculationMethodTo(simulation.ModelProperties, calculationMethodName);
       }
 
       private void addMissingCalculationMethods(IWithCalculationMethods withCalculationMethods, bool isHuman)

--- a/src/PKSim.Infrastructure/ProjectConverter/v13/Converter12To13.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v13/Converter12To13.cs
@@ -90,14 +90,15 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
          if (simulation == null)
             return;
 
-         //A simulation keeps its own copy of the building blocks it was created from, so they are converted as well
-         addLumenSegmentVolumeCalculationMethodTo(simulation);
-
+         //A simulation carries its own copies of the building blocks, so they are converted too
          convertIndividual(simulation.BuildingBlock<Individual>());
          convertPopulation(simulation.BuildingBlock<Population>());
          simulation.Compounds.Each(convertCompound);
          simulation.AllBuildingBlocks<Formulation>().Each(convertFormulation);
          simulation.AllBuildingBlocks<PKSimEvent>().Each(convertEvent);
+
+         //Last, once the converted individual's calculation methods have flowed into the model properties
+         _individualCalculationMethodsUpdater.AddMissingModelCalculationMethodsTo(simulation);
       }
 
       private void convertPopulation(Population population)
@@ -130,14 +131,9 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
             _converted = true;
       }
 
-      //The individual already carries the legacy calculation methods from its earlier conversions, so only the one new to
-      //v13 is added. Re-running the whole set would add a second body-surface-area method to an individual that uses the
-      //Du Bois option, which then breaks when the individual is mapped to a building block.
+      //Only the v13 method: re-running the whole set can add a second BSA method (Du Bois vs Mosteller) and later crash the mapping
       private void addLumenSegmentVolumeCalculationMethodTo(Individual individual) =>
          _individualCalculationMethodsUpdater.AddCalculationMethodTo(individual, ConverterConstants.CalculationMethod.LumenSegmentVolume);
-
-      private void addLumenSegmentVolumeCalculationMethodTo(Simulation simulation) =>
-         _individualCalculationMethodsUpdater.AddCalculationMethodTo(simulation, ConverterConstants.CalculationMethod.LumenSegmentVolume);
 
       /// <summary>
       ///    The lumen is where the new absorption model redefined existing parameters, turning constants into formulas and

--- a/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
@@ -7,7 +7,6 @@ using System;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
-using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core;
@@ -462,70 +461,98 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   public class When_running_the_converted_simulations_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   //Reconfigure: rebuild every model from the building blocks. A partial conversion fails here on an unresolved
+   //reference, so there is no need to run - which for all twelve would be far too slow.
+   public class When_reconfiguring_the_converted_simulations_of_the_test_project : concern_for_Converter12To13_with_the_test_project
    {
-      private ISimulationRunner _simulationRunner;
-      private ISimulationToModelCoreSimulationMapper _modelCoreSimulationMapper;
+      private ISimulationModelCreator _simulationModelCreator;
       private List<Simulation> _allSimulations;
 
       public override void GlobalContext()
       {
          base.GlobalContext();
-         _simulationRunner = OSPSuite.Utility.Container.IoC.Resolve<ISimulationRunner>();
-         _modelCoreSimulationMapper = OSPSuite.Utility.Container.IoC.Resolve<ISimulationToModelCoreSimulationMapper>();
+         _simulationModelCreator = OSPSuite.Utility.Container.IoC.Resolve<ISimulationModelCreator>();
          _allSimulations = All<Simulation>();
          _allSimulations.Each(Load);
       }
 
       [Observation]
-      public void should_run_every_converted_simulation_without_error()
+      public void should_rebuild_the_model_of_every_converted_simulation()
       {
          _allSimulations.Any().ShouldBeTrue();
 
          var errors = new List<string>();
          foreach (var simulation in _allSimulations)
          {
-            var error = runErrorFor(simulation);
-            if (error != null)
-               errors.Add($"{simulation.Name}: {error}");
+            try
+            {
+               _simulationModelCreator.CreateModelFor(simulation);
+               if (simulation.Model?.Root == null)
+                  errors.Add($"{simulation.Name}: no model was built");
+            }
+            catch (System.Exception e)
+            {
+               errors.Add($"{simulation.Name}: {(e.InnerException ?? e).Message}");
+            }
          }
 
          Assert.IsTrue(errors.Count == 0, errors.ToString("\n"));
       }
+   }
 
-      //Returns the error a run reported, or null when it succeeded. An individual simulation is run through the SimModel
-      //manager so the returned SimulationRunResults can be inspected directly: a solver failure sets Success to false and
-      //carries the error, which the higher level engine swallows. A population run raises an exception on failure, so it
-      //is run through the runner and the exception is captured.
-      private string runErrorFor(Simulation simulation)
+   //One population is run to prove a rebuilt model still solves; the reconfigure test already covers every model.
+   public class When_running_a_converted_population_simulation_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   {
+      private PopulationSimulation _simulation;
+
+      public override void GlobalContext()
       {
-         switch (simulation)
-         {
-            case IndividualSimulation individualSimulation:
-               var modelCoreSimulation = _modelCoreSimulationMapper.MapFrom(individualSimulation, shouldCloneModel: false);
-               var runResults = OSPSuite.Utility.Container.IoC.Resolve<ISimModelManager>().RunSimulation(modelCoreSimulation);
-               return runResults.Success ? null : errorFrom(runResults);
-
-            case PopulationSimulation populationSimulation:
-               try
-               {
-                  _simulationRunner.RunSimulation(populationSimulation).Wait();
-                  return populationSimulation.HasResults ? null : "produced no results";
-               }
-               catch (System.Exception e)
-               {
-                  return (e.InnerException ?? e).Message;
-               }
-
-            default:
-               return null;
-         }
+         base.GlobalContext();
+         _simulation = FindByName<PopulationSimulation>("11_Pop_01_Human_Default_Healthy");
+         reduceToTwoIndividuals(_simulation);
+         OSPSuite.Utility.Container.IoC.Resolve<ISimulationModelCreator>().CreateModelFor(_simulation);
       }
 
-      private static string errorFrom(SimulationRunResults runResults) =>
-         string.IsNullOrEmpty(runResults.Error)
-            ? $"solver failed with {runResults.Warnings.Count()} warning(s)"
-            : runResults.Error;
+      protected override void Because()
+      {
+         OSPSuite.Utility.Container.IoC.Resolve<ISimulationRunner>().RunSimulation(_simulation).Wait();
+      }
+
+      [Observation]
+      public void should_have_produced_results_for_the_two_individuals()
+      {
+         _simulation.HasResults.ShouldBeTrue();
+         _simulation.Results.Count.ShouldBeEqualTo(2);
+      }
+
+      //The run uses as many individuals as there are ids, so trimming the ids is enough to keep it fast
+      private static void reduceToTwoIndividuals(PopulationSimulation simulation)
+      {
+         var individualIds = simulation.Population.IndividualValuesCache.IndividualIds;
+         individualIds.Skip(2).ToList().Each(x => individualIds.Remove(x));
+      }
+   }
+
+   //Builds a new oral simulation from the converted standalone building blocks (fresh model properties), not the copies
+   //stored inside a simulation. A building block missing a new parameter fails the model construction.
+   public class When_creating_a_new_oral_simulation_from_the_converted_building_blocks_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   {
+      private Simulation _simulation;
+
+      protected override void Because()
+      {
+         var individual = FindByName<Individual>("01_Human_Default_Healthy");
+         var compound = FindByName<Compound>("C1");
+         var protocol = FindByName<Protocol>("Oral_BD");
+         var formulation = FindByName<Formulation>("Particles_2Bin");
+         _simulation = DomainFactoryForSpecs.CreateSimulationWith(individual, compound, protocol, formulation);
+      }
+
+      [Observation]
+      public void should_have_built_a_model_from_the_converted_building_blocks()
+      {
+         (_simulation.Model?.Root != null).ShouldBeTrue();
+      }
    }
 
    public class When_creating_a_simulation_using_the_building_blocks_of_the_simple_project_730_project : ContextWithLoadedProject<Converter12To13>


### PR DESCRIPTION
## What

Follow-up to #3630 (v13 project conversion). Fixes a gap found by reconfiguring/recreating a converted simulation: the model rebuild failed because parameters the new oral-absorption model introduces (for instance the pure water concentration on the organism) were never created, so the formulas referencing them could not resolve.

## Why

Those parameters belong to **model** calculation methods (e.g. the fundamental physical constants). A simulation saved before v13 keeps the calculation methods it was saved with, and the conversion was only adding the one calculation method new to v13 (`LumenSegmentVolume`) — the other model calculation methods the new model relies on were missing, so their parameters were never generated.

Running the *stored* model hid this: the parameters were baked into the saved model. It only surfaces when the model is rebuilt from the building blocks — i.e. **Reconfigure** or **create a new simulation** — which is exactly the workflow Yuri raised on #3630.

## How

`IndividualCalculationMethodsUpdater.AddMissingModelCalculationMethodsTo(simulation)` aligns a simulation's model calculation methods with the current default for its model (`ModelPropertiesTask.DefaultFor`), adding **only** the categories the simulation does not already fill, so a user-selected option (e.g. the Du Bois body-surface-area method) is never replaced. `Converter12To13` calls it after the individual has been converted, so the individual's own calculation methods have already flowed into the model properties.

## Tests

Extends the v13 conversion tests against the provided `V12_TestProject`:

- **reconfigure** every simulation — the model is rebuilt from the building blocks, which is where an incomplete conversion surfaces (verified: the test fails fast without the fix). Not run, since a broken conversion already throws at construction and running all twelve would be prohibitively slow;
- **run** one population simulation, trimmed to two individuals, to prove a rebuilt model still solves end to end;
- **create a new** oral particle-dissolution simulation from the converted standalone building blocks.

The earlier smoke test that ran all twelve stored models is removed — it ran the pre-built models (so it never exercised the rebuild) and running them all was slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
