### PR TITLE
Fixes #3397 Open exported files again

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,10 +47,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -25,11 +25,11 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.141" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,14 +36,14 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.140" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.140" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.140" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.140" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.140" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.141" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.140" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.141" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #3397

`OSPSuite.Core` family 13.0.140 -> 13.0.141 and `OSPSuite.Utility` 5.0.0.10 -> 5.0.0.11. No PK-Sim code change is needed.

Root cause was in `FileHelper.TryOpenFile` (Open-Systems-Pharmacology/OSPSuite.Utility#58): since .NET Core, `Process.Start(path)` no longer shell-executes, so it threw `Win32Exception` and the surrounding `catch` swallowed it. Both cases from the report go through that one method — *Export Simulation Structure to File* via `SimulationExportTask.CreateSimulationReport`, and *Export Results to Excel* via `ExportToExcelTask` — as do journal export, chart and observed data export to Excel, and the help links in `BaseShell`. Core 13.0.141 additionally fixes the message box hyperlinks (Open-Systems-Pharmacology/OSPSuite.Core#2915).

`OSPSuite.Utility` has to move too, otherwise PK-Sim's direct reference would downgrade what Core 13.0.141 pulls in.

MoBi had the same regression, fixed in Open-Systems-Pharmacology/MoBi#2462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
