### PR TITLE
Fixes #3662 Loading from snapshot fails

### DIFF
--- a/src/PKSim.Core/Mappers/ExpressionProfileToExpressionProfileBuildingBlockMapper.cs
+++ b/src/PKSim.Core/Mappers/ExpressionProfileToExpressionProfileBuildingBlockMapper.cs
@@ -58,7 +58,9 @@ namespace PKSim.Core.Mappers
 
       private void addInitialConditions(ExpressionProfile expressionProfile, ExpressionProfileBuildingBlock expressionProfileBuildingBlock)
       {
-         var builder = _moleculeBuilderFactory.Create(expressionProfile.Molecule.MoleculeType, expressionProfileBuildingBlock.FormulaCache)
+         //the builder is discarded once the initial conditions are created. Its formulas are created with template ids
+         //that would be identical in every expression profile, so they are kept out of the building block formula cache
+         var builder = _moleculeBuilderFactory.Create(expressionProfile.Molecule.MoleculeType, new BuildingBlockFormulaCache())
             .WithName(expressionProfile.Molecule.Name);
 
          _initialConditionsCreator.AddToExpressionProfile(expressionProfileBuildingBlock, expressionProfile.Individual.AllPhysicalContainersWithMoleculeFor(expressionProfile.Molecule), builder);

--- a/tests/PKSim.Tests/Core/ExpressionProfileToExpressionProfileBuildingBlockMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/ExpressionProfileToExpressionProfileBuildingBlockMapperSpecs.cs
@@ -153,6 +153,12 @@ namespace PKSim.Core
       }
 
       [Observation]
+      public void the_molecule_builder_should_not_be_created_in_the_formula_cache_of_the_building_block()
+      {
+         A.CallTo(() => _moleculeBuilderFactory.Create(A<QuantityType>._, A<IFormulaCache>.That.IsSameAs(_result.FormulaCache))).MustNotHaveHappened();
+      }
+
+      [Observation]
       public void resulting_expression_parameter_should_have_formula_or_value()
       {
          _result.ExpressionParameters.Count(x => x.Formula == null).ShouldBeEqualTo(1);


### PR DESCRIPTION
Fixes #3662

Expression profile building blocks carried ~59 formulas whose ids are PK-Sim RateKeys (`CompoundCommon.PARAM_Degradation_Coefficient`, `CompoundAcidBase_PKSim.*`, ...). Those ids are the same in every expression profile, so a MoBi project with more than one failed `WithIdRepository.Register` with `Id ... not unique`.

They came from `addInitialConditions`, which passed the building block's `FormulaCache` to `IMoleculeBuilderFactory.Create`. The factory dumps every rate formula of the drug/protein template into whatever cache it is given, and those formulas bypass the per-parameter `ResetIdFor` added in #3521. The builder is discarded right after the initial conditions are created, so it now gets its own cache; `AddToExpressionProfile` already clones the default start formula into the building block with a fresh id.

Each profile now holds 13 formulas, all with generated ids — the same shape produced by MoBi's interactive import, which clones the building block on the way in.

## Verification

- Mapped the five expression profile snapshots from the reporter's project through `SnapshotExchange.CreateExpressionProfileBuildingBlock`: 232 duplicate ids across profiles before, 0 after.
- `MoBi.CLI snap -p` on the reporter's snapshot: both PK-Sim modules and both simulations load, project written. `snap -s` on the result reloads it through `RegisterTask.Register(project)` — the call that throws in the GUI — cleanly.
- GUI load of the snapshot confirmed by the reporter.