### PR TITLE
Clarify base individual caption when creating a population (Fixes #3384)

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -1772,7 +1772,7 @@ namespace PKSim.Assets
          public static readonly string ImportPopulation = "Import Population";
          public static readonly string PopulationSettings = "Settings";
          public static readonly string PopulationParameterRanges = "Population Parameters Ranges";
-         public static readonly string IndividualIsMeanOfPopulation = "<I>This individual will represent the mean individual of the created population</I>";
+         public static readonly string IndividualIsMeanOfPopulation = "<I>Individuals are sampled from a population with this individual as its mean, then filtered by the ranges below</I>";
          public static readonly string GenderRatio = "Gender Ratio";
          public static readonly string AddButtonText = "Add";
          public static readonly string RemoveButtonText = "Remove";


### PR DESCRIPTION
The caption under the base individual selection in the *Create Population* dialog read *"This individual will represent the mean individual of the created population"*, which is not accurate: the selected individual is used as the mean of the distributions from which individuals are sampled, and the sampled individuals are then filtered by the parameter ranges. The resulting population is therefore not centered on the base individual whenever the ranges are asymmetric around it.

The caption now describes both steps:

> *Individuals are sampled from a population with this individual as its mean, then filtered by the ranges below*

The label sits directly above the *Population Parameters Ranges* grid, so "the ranges below" refers to it unambiguously.

Fixes #3384

🤖 Generated with [Claude Code](https://claude.com/claude-code)