### PR TITLE
Fixes #3606 Identify the application a project snapshot was created with

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using OSPSuite.Assets;
 using OSPSuite.Assets.Extensions;
+using OSPSuite.Core.Domain;
 using OSPSuite.Utility.Extensions;
 
 namespace PKSim.Assets
@@ -434,6 +435,7 @@ namespace PKSim.Assets
          public const string ImporterConfigurationNotFoundInProject = "Importer configuration for this dataset was not found in this project.\n\nThe data cannot be reloaded.";
          public const string SimulationCannotShareNamesWithCompounds = "Simulation cannot share names with compounds";
          public const string AProjectSnapshotShouldOnlyContainOneSimuilationWhenUsedToRebuildAModule = "A project snapshot should only contain one simulation when used to rebuild a module";
+         public static string ProjectSnapshotCannotBeLoaded(string snapshotApplicationName) => $"This file contains a {snapshotApplicationName} project snapshot and cannot be loaded in {Origins.PKSim.DisplayName}. Please load it in {snapshotApplicationName}.";
          public static string UnableToCreateIndividual(string constraints) => $"Could not create individuals with given constraint:\n{constraints}";
          public static string UnableToCreatePopulation(string constraints) => $"Could not create population with given constraint:\n{constraints}";
          public const string FactorShouldBeBiggerThanZero = "Factor should be bigger than 0.";

--- a/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -64,6 +64,7 @@ namespace PKSim.Core.Snapshots.Mappers
          var snapshot = await SnapshotFrom(project, x =>
          {
             x.Version = ProjectVersions.Current;
+            x.ApplicationName = Origins.PKSim.DisplayName;
             x.Name = SnapshotValueFor(project.Name);
             x.Description = SnapshotValueFor(project.Description);
          });

--- a/src/PKSim.Core/Snapshots/Project.cs
+++ b/src/PKSim.Core/Snapshots/Project.cs
@@ -14,6 +14,8 @@ namespace PKSim.Core.Snapshots
       [Required]
       public int Version { get; set; }
 
+      public string ApplicationName { get; set; }
+
       public ExpressionProfile[] ExpressionProfiles { get; set; }
       public Individual[] Individuals { get; set; }
       public Population[] Populations { get; set; }

--- a/src/PKSim.Core/Snapshots/Services/SnapshotTask.cs
+++ b/src/PKSim.Core/Snapshots/Services/SnapshotTask.cs
@@ -5,6 +5,7 @@ using OSPSuite.Core.Services;
 using OSPSuite.Core.Snapshots;
 using OSPSuite.Core.Snapshots.Mappers;
 using OSPSuite.Core.Snapshots.Services;
+using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Core.Snapshots.Mappers;
@@ -52,11 +53,25 @@ public class SnapshotTask : SnapshotTask<PKSimProject, Project>, ISnapshotTask
    public async Task<T> LoadModelFromProjectFileAsync<T>(string fileName, PKSimBuildingBlockType buildingBlockType, string buildingBlockName)
    {
       var projectSnapshot = await LoadSnapshotFromFileAsync<Project>(fileName);
+      validateApplication(projectSnapshot);
       var snapshot = projectSnapshot.BuildingBlockByTypeAndName(buildingBlockType, buildingBlockName);
       return await LoadModelFromSnapshot<T>(snapshot);
    }
 
-   protected override Task<PKSimProject> ProjectFrom(Project snapshot, bool runSimulations) => _projectMapper.MapToModel(snapshot, new ProjectContext(new PKSimProject(), runSimulations));
+   protected override Task<PKSimProject> ProjectFrom(Project snapshot, bool runSimulations)
+   {
+      validateApplication(snapshot);
+      return _projectMapper.MapToModel(snapshot, new ProjectContext(new PKSimProject(), runSimulations));
+   }
+
+   private static void validateApplication(Project snapshot)
+   {
+      var applicationName = snapshot?.ApplicationName;
+      if (string.IsNullOrEmpty(applicationName) || string.Equals(applicationName, Origins.PKSim.DisplayName))
+         return;
+
+      throw new PKSimException(PKSimConstants.Error.ProjectSnapshotCannotBeLoaded(applicationName));
+   }
 
    protected override SnapshotContext GetSnapshotContext() => new SnapshotContext(_projectRetriever.Current, SnapshotVersions.Current);
 

--- a/tests/PKSim.Tests/Core/ProjectMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/ProjectMapperSpecs.cs
@@ -212,6 +212,12 @@ namespace PKSim.Core
       }
 
       [Observation]
+      public void should_identify_PKSim_as_the_application_that_created_the_snapshot()
+      {
+         _snapshot.ApplicationName.ShouldBeEqualTo("PK-Sim");
+      }
+
+      [Observation]
       public void should_retrieve_the_snapshot_for_all_underlying_models()
       {
          _snapshot.Compounds.ShouldContain(_compoundSnapshot);

--- a/tests/PKSim.Tests/Core/SnapshotTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/SnapshotTaskSpecs.cs
@@ -227,6 +227,50 @@ namespace PKSim.Core
       }
    }
 
+   public class When_loading_a_project_from_a_snapshot_file_created_with_another_application : concern_for_SnapshotTask
+   {
+      private readonly string _fileName = @"C:\test\SuperProject.json";
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         A.CallTo(() => _jsonSerializer.DeserializeAsArray(_fileName, typeof(Project))).Returns(new object[] {new Project {ApplicationName = Origins.MoBi.DisplayName},});
+      }
+
+      [Observation]
+      public void should_throw_an_exception()
+      {
+         The.Action(() => sut.LoadProjectFromSnapshotFileAsync(_fileName)).ShouldThrowAn<PKSimException>();
+      }
+   }
+
+   public class When_loading_a_project_from_a_snapshot_file_that_does_not_specify_the_application : concern_for_SnapshotTask
+   {
+      private PKSimProject _project;
+      private readonly string _fileName = @"C:\test\SuperProject.json";
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         var projectSnapshot = new Project();
+         var project = new PKSimProject();
+
+         A.CallTo(() => _jsonSerializer.DeserializeAsArray(_fileName, typeof(Project))).Returns(new object[] {projectSnapshot,});
+         A.CallTo(() => _projectMapper.MapToModel(projectSnapshot, A<ProjectContext>._)).Returns(project);
+      }
+
+      protected override async Task Because()
+      {
+         _project = await sut.LoadProjectFromSnapshotFileAsync(_fileName);
+      }
+
+      [Observation]
+      public void should_load_the_project()
+      {
+         _project.Name.ShouldBeEqualTo("SuperProject");
+      }
+   }
+
    public class When_checking_if_an_object_with_meta_data_is_fully_compatible_with_snapshot_creation : concern_for_SnapshotTask
    {
       private PKSimProject _oldProject;


### PR DESCRIPTION
Closes #3606. Companion PR: Open-Systems-Pharmacology/MoBi#2489

Snapshots don't record which application created them, so loading a MoBi snapshot in PK-Sim reported that the snapshot was outdated instead of naming the real problem.

Project snapshots now write an `ApplicationName`. PK-Sim rejects a snapshot that names a different application, but still loads snapshots that don't have the property at all — so every existing PK-Sim snapshot keeps working:

```
warn: This file contains a MoBi project snapshot and cannot be loaded in PK-Sim.
      Please load it in MoBi.
```

Found while testing, unrelated and pre-existing: `PKSim.CLI` reports failed snapshot loads as successful and exits 0, which hides this new error from automation. Filed as #3666, not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project snapshots now record the application that created them.
  * Snapshots from other applications display a clear message directing users to open them in the originating application.

* **Bug Fixes**
  * Snapshots without application information continue to load successfully.
  * Project names are correctly restored from snapshot file paths when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->