### PR TITLE
update core

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.149" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -63,14 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Infrastructure/NeighborhoodFinalizerSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/NeighborhoodFinalizerSpecs.cs
@@ -45,6 +45,8 @@ namespace PKSim.Infrastructure
          A.CallTo(() => _flatNeighborhoodRepository.NeighborhoodFrom(_neighborhood.Name)).Returns(flatNeighborhood);
          var containerPath1 = A.Fake<ObjectPath>();
          var containerPath2 = A.Fake<ObjectPath>();
+         A.CallTo(() => containerPath1.PathAsString).Returns("Organism|FirstNeighbor");
+         A.CallTo(() => containerPath2.PathAsString).Returns("Organism|SecondNeighbor");
          A.CallTo(() => _flatContainerRepository.ContainerPathFrom(flatNeighborhood.FirstNeighborId)).Returns(containerPath1);
          A.CallTo(() => _flatContainerRepository.ContainerPathFrom(flatNeighborhood.SecondNeighborId)).Returns(containerPath2);
          A.CallTo(() => containerPath1.Resolve<IContainer>(_organism)).Returns(_firstNeighbor);

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.149" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.145" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.149" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Bumps the OSPSuite.Core package family from 13.0.145 to 13.0.149.

Also adjusts `NeighborhoodFinalizerSpecs` because of the `NeighborhoodBuilder` change in Open-Systems-Pharmacology/OSPSuite.Core#2919: `resolveReferenceIfRequired` now skips resolution when a neighbor path is undefined (empty `PathAsString`). The spec used a bare `A.Fake<ObjectPath>()`, whose `PathAsString` is empty, so the neighbors were never resolved. The fakes now return a non-empty path, matching the real DB-derived container paths that `NeighborhoodFinalizer` assigns in production.