### PR TITLE
Fixes #3671 OriginData summary report renders gestational age with the wrong dimension

### DIFF
--- a/src/PKSim.Infrastructure/Reporting/Summary/OriginDataReportBuilder.cs
+++ b/src/PKSim.Infrastructure/Reporting/Summary/OriginDataReportBuilder.cs
@@ -87,13 +87,13 @@ namespace PKSim.Infrastructure.Reporting.Summary
          reportPart.AddPart(_reportGenerator.ReportFor(originData.AllCalculationMethods()));
       }
 
-      //Fallback for disease state parameters where the dimension is not statically known.
-      //DimensionForUnit can return an incorrect dimension when the unit name is defined in multiple dimensions.
-      private string displayValueFor(OriginDataParameter originDataParameter) =>
-         displayValueFor(originDataParameter, _dimensionRepository.DimensionForUnit(originDataParameter.Unit));
-
-      private string displayValueFor(OriginDataParameter originDataParameter, IDimension dimension)
+      //When the dimension is not known statically (disease state parameters), it is resolved from the unit
+      //name. DimensionForUnit can return an incorrect dimension when the unit name is defined in multiple
+      //dimensions, so callers pass the dimension explicitly whenever they know it.
+      private string displayValueFor(OriginDataParameter originDataParameter, IDimension dimension = null)
       {
+         dimension ??= _dimensionRepository.DimensionForUnit(originDataParameter.Unit);
+
          if (dimension != null)
          {
             var displayUnit = dimension.UnitOrDefault(originDataParameter.Unit);

--- a/src/PKSim.Infrastructure/Reporting/Summary/OriginDataReportBuilder.cs
+++ b/src/PKSim.Infrastructure/Reporting/Summary/OriginDataReportBuilder.cs
@@ -1,4 +1,5 @@
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Format;
 using PKSim.Assets;
@@ -50,21 +51,21 @@ namespace PKSim.Infrastructure.Reporting.Summary
          if (originData.Population.IsAgeDependent)
          {
             if (originData.Age != null)
-               individualProperties.AddIs(PKSimConstants.UI.Age, displayValueFor(originData.Age), originData.Age.Unit);
+               individualProperties.AddIs(PKSimConstants.UI.Age, displayValueFor(originData.Age, _dimensionRepository.AgeInYears), originData.Age.Unit);
 
             if (originData.Population.IsPreterm && originData.GestationalAge != null)
-               individualProperties.AddIs(PKSimConstants.UI.GestationalAge, displayValueFor(originData.GestationalAge), originData.GestationalAge.Unit);
+               individualProperties.AddIs(PKSimConstants.UI.GestationalAge, displayValueFor(originData.GestationalAge, _dimensionRepository.AgeInWeeks), originData.GestationalAge.Unit);
          }
 
-         individualProperties.AddIs(PKSimConstants.UI.Weight, displayValueFor(originData.Weight), originData.Weight.Unit);
+         individualProperties.AddIs(PKSimConstants.UI.Weight, displayValueFor(originData.Weight, _dimensionRepository.Mass), originData.Weight.Unit);
 
          if (originData.Population.IsHeightDependent)
          {
             if (originData.Height != null)
-               individualProperties.AddIs(PKSimConstants.UI.Height, displayValueFor(originData.Height), originData.Height.Unit);
+               individualProperties.AddIs(PKSimConstants.UI.Height, displayValueFor(originData.Height, _dimensionRepository.Length), originData.Height.Unit);
 
             if (originData.BMI != null)
-               individualProperties.AddIs(PKSimConstants.UI.BMI, displayValueFor(originData.BMI), originData.BMI.Unit);
+               individualProperties.AddIs(PKSimConstants.UI.BMI, displayValueFor(originData.BMI, _dimensionRepository.BMI), originData.BMI.Unit);
          }
 
          reportPart.AddPart(populationProperties);
@@ -86,9 +87,13 @@ namespace PKSim.Infrastructure.Reporting.Summary
          reportPart.AddPart(_reportGenerator.ReportFor(originData.AllCalculationMethods()));
       }
 
-      private string displayValueFor(OriginDataParameter originDataParameter)
+      //Fallback for disease state parameters where the dimension is not statically known.
+      //DimensionForUnit can return an incorrect dimension when the unit name is defined in multiple dimensions.
+      private string displayValueFor(OriginDataParameter originDataParameter) =>
+         displayValueFor(originDataParameter, _dimensionRepository.DimensionForUnit(originDataParameter.Unit));
+
+      private string displayValueFor(OriginDataParameter originDataParameter, IDimension dimension)
       {
-         var dimension = _dimensionRepository.DimensionForUnit(originDataParameter.Unit);
          if (dimension != null)
          {
             var displayUnit = dimension.UnitOrDefault(originDataParameter.Unit);

--- a/tests/PKSim.Tests/Infrastructure/OriginDataReportBuilderSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/OriginDataReportBuilderSpecs.cs
@@ -60,7 +60,8 @@ namespace PKSim.Infrastructure
             Age = new OriginDataParameter(0.1, "year(s)"),
             GestationalAge = new OriginDataParameter(30, "week(s)"),
             Weight = new OriginDataParameter(1.5, "kg"),
-            Height = new OriginDataParameter(4.454, "dm")
+            Height = new OriginDataParameter(4.454, "dm"),
+            BMI = new OriginDataParameter(0.0756, "kg/m²")
          };
       }
 
@@ -88,6 +89,7 @@ namespace PKSim.Infrastructure
          valuesFor(PKSimConstants.UI.Age).ShouldOnlyContainInOrder("0.10", "year(s)");
          valuesFor(PKSimConstants.UI.Weight).ShouldOnlyContainInOrder("1.50", "kg");
          valuesFor(PKSimConstants.UI.Height).ShouldOnlyContainInOrder("4.45", "dm");
+         valuesFor(PKSimConstants.UI.BMI).ShouldOnlyContainInOrder("7.56", "kg/m²");
       }
    }
 }

--- a/tests/PKSim.Tests/Infrastructure/OriginDataReportBuilderSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/OriginDataReportBuilderSpecs.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Serialization.Xml;
+using OSPSuite.Utility.Container;
+using PKSim.Assets;
+using PKSim.Core;
+using PKSim.Core.Mappers;
+using PKSim.Core.Model;
+using PKSim.Core.Reporting;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Infrastructure.ORM.Repositories;
+using PKSim.Infrastructure.Reporting.Summary;
+
+namespace PKSim.Infrastructure
+{
+   public abstract class concern_for_OriginDataReportBuilder : ContextSpecification<OriginDataReportBuilder>
+   {
+      protected OriginData _originData;
+
+      protected override void Context()
+      {
+         var serializerRepository = new UnitSystemXmlSerializerRepository();
+         serializerRepository.PerformMapping();
+         var realDimensions = new DimensionRepository(new PKSimDimensionFactory(), serializerRepository, new PKSimConfiguration(), A.Fake<IContainer>());
+
+         var dimensionRepository = A.Fake<IDimensionRepository>();
+         A.CallTo(() => dimensionRepository.AgeInWeeks).Returns(realDimensions.AgeInWeeks);
+         A.CallTo(() => dimensionRepository.AgeInYears).Returns(realDimensions.AgeInYears);
+         A.CallTo(() => dimensionRepository.Mass).Returns(realDimensions.Mass);
+         A.CallTo(() => dimensionRepository.Length).Returns(realDimensions.Length);
+         A.CallTo(() => dimensionRepository.BMI).Returns(realDimensions.BMI);
+
+         //"week(s)" is defined in "Age in weeks", "Age in years" and "Time", so a lookup by unit
+         //name alone is ambiguous and can return any of them. Pin it to the wrong one: the report
+         //must not depend on it for parameters whose dimension is known statically.
+         A.CallTo(() => dimensionRepository.DimensionForUnit(A<string>._)).Returns(realDimensions.AgeInYears);
+
+         sut = new OriginDataReportBuilder(
+            A.Fake<IReportGenerator>(),
+            dimensionRepository,
+            A.Fake<IRepresentationInfoRepository>(),
+            A.Fake<IParameterListOfValuesRetriever>());
+
+         _originData = new OriginData
+         {
+            Species = new Species {Name = "Human", DisplayName = "Human"},
+            Population = new SpeciesPopulation
+            {
+               Name = CoreConstants.Population.PRETERM,
+               DisplayName = "Preterm",
+               IsAgeDependent = true,
+               IsHeightDependent = true
+            },
+            Gender = new Gender {Name = "MALE", DisplayName = "Male"},
+            //values are stored in the base unit of their own dimension
+            Age = new OriginDataParameter(0.1, "year(s)"),
+            GestationalAge = new OriginDataParameter(30, "week(s)"),
+            Weight = new OriginDataParameter(1.5, "kg"),
+            Height = new OriginDataParameter(4.454, "dm")
+         };
+      }
+
+      protected IReadOnlyList<string> valuesFor(string key)
+      {
+         var individualProperties = sut.Report(_originData).SubParts.OfType<TablePart>()
+            .First(x => x.Title == PKSimConstants.UI.IndividualParameters);
+
+         return individualProperties.Rows.First(x => x.Key == key).Value;
+      }
+   }
+
+   public class When_reporting_the_origin_data_of_a_preterm_individual : concern_for_OriginDataReportBuilder
+   {
+      [Observation]
+      public void should_format_gestational_age_using_the_age_in_weeks_dimension()
+      {
+         //formatting 30 through "Age in years" would report 30 * 52.1786 = 1565.36 week(s)
+         valuesFor(PKSimConstants.UI.GestationalAge).ShouldOnlyContainInOrder("30.00", "week(s)");
+      }
+
+      [Observation]
+      public void should_format_the_remaining_origin_data_parameters_with_their_own_dimension()
+      {
+         valuesFor(PKSimConstants.UI.Age).ShouldOnlyContainInOrder("0.10", "year(s)");
+         valuesFor(PKSimConstants.UI.Weight).ShouldOnlyContainInOrder("1.50", "kg");
+         valuesFor(PKSimConstants.UI.Height).ShouldOnlyContainInOrder("4.45", "dm");
+      }
+   }
+}


### PR DESCRIPTION
Fixes #3671 

`OriginDataReportBuilder` resolved the dimension for every `OriginDataParameter` from the
unit name alone. `week(s)` is defined in three dimensions — `Age in weeks` (base `week(s)`),
`Age in years` (base `year(s)`) and `Time` (base `min`) — so `DimensionForUnit` returned
*Age in years* and gestational age was reported as `value * 52.1786`.

A correctly-built 30-week preterm individual was reported as `1565.36 week(s)`, most visibly
inside `CannotCreateIndividualWithConstraintsException`:


Reported from Open-Systems-Pharmacology/OSPSuite-R#2011.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting for age, gestational age, weight, height, and BMI values by applying the appropriate measurement dimensions.
  * Gestational age is now consistently displayed using the age-in-weeks unit system, including for preterm individuals.
  * Other origin data values continue to use their specific dimensions and formatted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->