### PR TITLE
Fixes #3661 Make the commit simulation parameters caption singular

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -304,7 +304,7 @@ namespace PKSim.Assets
             return $"Add {lowerEntityType} '{entityName}' to {lowerContainerType} '{containerName}'";
          }
 
-         public static readonly string CommitSimulationParametersDescription = "Commit simulation parameters to compounds";
+         public static readonly string CommitSimulationParametersDescription = "Commit simulation parameters to compound";
          public static readonly string CreateNewParameterSet = "Create New Parameter Set";
          public static readonly string UpdateExistingParameterSet = "Update Existing Parameter Set";
          public static readonly string CommitOptions = "Commit Options";
@@ -1079,7 +1079,7 @@ namespace PKSim.Assets
          public static readonly string Diff = "Show Differences...";
          public static readonly string Update = "Update from Building Block...";
          public static readonly string Commit = "Commit to Building Block...";
-         public static readonly string CommitSimulationParametersToCompounds = "Commit Simulation Parameters to Compounds...";
+         public static readonly string CommitSimulationParametersToCompound = "Commit Simulation Parameters to Compound...";
          public static readonly string File = "&File";
          public static readonly string RecentProjects = "&Recent Projects";
          public static readonly string EditQuery = "&Edit Database Query...";

--- a/src/PKSim.Presentation/Core/MenuBarItemExtensions.cs
+++ b/src/PKSim.Presentation/Core/MenuBarItemExtensions.cs
@@ -39,7 +39,7 @@ namespace PKSim.Presentation.Core
 
       public static IMenuBarButton WithCommitSimulationParametersCommandFor(this IMenuBarButton menuBarItem, Simulation simulation, Compound compound)
       {
-         var command = IoC.Resolve<CommitSimulationParametersToCompoundsUICommand>();
+         var command = IoC.Resolve<CommitSimulationParametersToCompoundUICommand>();
          command.Subject = simulation;
          command.CompoundFilter = compound;
          return menuBarItem.WithCommand(command);

--- a/src/PKSim.Presentation/Presenters/ContextMenus/UsedCompoundInSimulationContextMenu.cs
+++ b/src/PKSim.Presentation/Presenters/ContextMenus/UsedCompoundInSimulationContextMenu.cs
@@ -24,7 +24,7 @@ namespace PKSim.Presentation.Presenters.ContextMenus
          }
 
          if (_simulation is IndividualSimulation && _simulation.HasUncommittedChangesForCompound(templateBuildingBlock.Name))
-            yield return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.CommitSimulationParametersToCompounds)
+            yield return CreateMenuButton.WithCaption(PKSimConstants.MenuNames.CommitSimulationParametersToCompound)
                .WithCommitSimulationParametersCommandFor(_simulation, templateBuildingBlock)
                .WithIcon(ApplicationIcons.Commit);
       }

--- a/src/PKSim.Presentation/UICommands/CommitSimulationParametersToCompoundUICommand.cs
+++ b/src/PKSim.Presentation/UICommands/CommitSimulationParametersToCompoundUICommand.cs
@@ -8,7 +8,7 @@ using ILazyLoadTask = PKSim.Core.Services.ILazyLoadTask;
 
 namespace PKSim.Presentation.UICommands
 {
-   public class CommitSimulationParametersToCompoundsUICommand : ObjectUICommand<Simulation>
+   public class CommitSimulationParametersToCompoundUICommand : ObjectUICommand<Simulation>
    {
       private readonly IApplicationController _applicationController;
       private readonly ICommitSimulationParametersTask _commitTask;
@@ -20,7 +20,7 @@ namespace PKSim.Presentation.UICommands
       /// </summary>
       public Compound CompoundFilter { get; set; }
 
-      public CommitSimulationParametersToCompoundsUICommand(
+      public CommitSimulationParametersToCompoundUICommand(
          IApplicationController applicationController,
          ICommitSimulationParametersTask commitTask,
          IBuildingBlockTask buildingBlockTask,


### PR DESCRIPTION
Fixes #3661

The *Commit Simulation Parameters to Compounds...* context menu entry and the dialog caption were phrased in the plural, but the action always targets exactly one compound: `UsedCompoundInSimulationContextMenu` creates the command with a single `templateBuildingBlock`, the UI command carries a single `CompoundFilter`, and the task method is `CommitParametersToCompound`.

Changes:
- `PKSimConstants.MenuNames.CommitSimulationParametersToCompounds` → `CommitSimulationParametersToCompound`, value `"Commit Simulation Parameters to Compound..."`
- `PKSimConstants.Command.CommitSimulationParametersDescription` → `"Commit simulation parameters to compound"` (used as the caption of `CommitSimulationParametersView`)
- Renamed `CommitSimulationParametersToCompoundsUICommand` → `CommitSimulationParametersToCompoundUICommand` and its file, so the identifiers match the corrected wording

Neither string is shared with any other feature — the menu name had a single call site and the description is only used for that one dialog's caption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)