### PR TITLE
Fixes #3678 Error when undoing a commit of simulation parameters to an overwrite parameter set

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -296,6 +296,12 @@ namespace PKSim.Assets
          public static string SetExtendedPropertyOnOverwriteParameterSet(string propertyName, string overwriteParameterSetName, string compoundName) =>
             $"Set '{propertyName}' on {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
+         public static string CommitSimulationParametersToCompound(string overwriteParameterSetName, string compoundName) =>
+            $"Commit simulation parameters to {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
+         public static string SetSimulationParameterTracking(int parameterCount, bool tracked, string simulationName) =>
+            $"Mark {parameterCount} parameter(s) as {(tracked ? "uncommitted" : "committed")} in {ObjectTypes.Simulation.ToLower()} '{simulationName}'";
+
          public static string AddEntityToContainer(string entityType, string entityName, string containerType, string containerName)
          {
             var lowerEntityType = string.IsNullOrEmpty(entityType) ? entityType : entityType.ToLower();

--- a/src/PKSim.Core/Commands/SetSimulationParameterTrackingCommand.cs
+++ b/src/PKSim.Core/Commands/SetSimulationParameterTrackingCommand.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Events;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands
+{
+   /// <summary>
+   ///    Tracks or untracks compound parameter paths in the <see cref="SimulationParameterChangeTracker" /> of a
+   ///    simulation. Only paths whose tracking state actually changes are reversed by the inverse command.
+   /// </summary>
+   public class SetSimulationParameterTrackingCommand : PKSimReversibleCommand
+   {
+      private readonly bool _tracked;
+      private readonly string _simulationId;
+      private readonly IReadOnlyList<string> _parameterPaths;
+      private IReadOnlyList<string> _changedPaths;
+      private Simulation _simulation;
+
+      public SetSimulationParameterTrackingCommand(Simulation simulation, IReadOnlyList<string> parameterPaths, bool tracked)
+      {
+         _simulation = simulation;
+         _simulationId = simulation.Id;
+         _parameterPaths = parameterPaths;
+         _tracked = tracked;
+         Visible = false;
+         ObjectType = PKSimConstants.ObjectTypes.Simulation;
+         CommandType = PKSimConstants.Command.CommandTypeEdit;
+         Description = PKSimConstants.Command.SetSimulationParameterTracking(parameterPaths.Count, tracked, simulation.Name);
+      }
+
+      protected override void ExecuteWith(IExecutionContext context)
+      {
+         var tracker = _simulation.ParameterChangeTracker;
+         _changedPaths = _parameterPaths.Where(path => tracker.IsTracked(path) != _tracked).ToList();
+         _changedPaths.Each(path =>
+         {
+            if (_tracked)
+               tracker.Track(path);
+            else
+               tracker.Untrack(path);
+         });
+
+         context.PublishEvent(new SimulationStatusChangedEvent(_simulation));
+      }
+
+      protected override void ClearReferences()
+      {
+         _simulation = null;
+      }
+
+      protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+         new SetSimulationParameterTrackingCommand(_simulation, _changedPaths, !_tracked).AsInverseFor(this);
+
+      public override void RestoreExecutionData(IExecutionContext context)
+      {
+         _simulation = context.Get<Simulation>(_simulationId);
+      }
+   }
+}

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -4,8 +4,8 @@ using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Core.Events;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using IBuildingBlockRepository = PKSim.Core.Repositories.IBuildingBlockRepository;
@@ -53,12 +53,14 @@ namespace PKSim.Core.Services
       private readonly IExecutionContext _executionContext;
       private readonly IContainerTask _containerTask;
       private readonly IBuildingBlockRepository _buildingBlockRepository;
+      private readonly IObjectBaseFactory _objectBaseFactory;
 
-      public CommitSimulationParametersTask(IExecutionContext executionContext, IContainerTask containerTask, IBuildingBlockRepository buildingBlockRepository)
+      public CommitSimulationParametersTask(IExecutionContext executionContext, IContainerTask containerTask, IBuildingBlockRepository buildingBlockRepository, IObjectBaseFactory objectBaseFactory)
       {
          _executionContext = executionContext;
          _containerTask = containerTask;
          _buildingBlockRepository = buildingBlockRepository;
+         _objectBaseFactory = objectBaseFactory;
       }
 
       public ICommand CommitParametersToCompound(Simulation simulation, CompoundCommitInfo commitInfo)
@@ -73,24 +75,29 @@ namespace PKSim.Core.Services
             ? createNewSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues)
             : updateExistingSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues, simulation, commitInfo.ParameterPaths, parameterCache);
 
+         //Only untrack paths that were actually resolved to parameter values
+         command.Add(new SetSimulationParameterTrackingCommand(simulation, parameterValues.Select(pv => pv.Path.PathAsString).ToList(), tracked: false));
+
          command.Run(_executionContext);
 
-         command.All().Each(subCommand => _executionContext.UpdateBuildingBlockPropertiesInCommand(subCommand, simulationCompound));
          _executionContext.UpdateBuildingBlockPropertiesInCommand(command, simulationCompound);
 
-         //Only untrack paths that were actually resolved to parameter values
-         parameterValues.Each(pv => simulation.ParameterChangeTracker.Untrack(pv.Path));
-
-         _executionContext.PublishEvent(new SimulationStatusChangedEvent(simulation));
-         
          return command;
       }
 
       private PKSimMacroCommand createNewSetsCommand(Compound simulationCompound, Compound templateCompound, string setName, List<ParameterValue> parameterValues)
       {
-         var command = new PKSimMacroCommand();
+         var command = new PKSimMacroCommand
+         {
+            ObjectType = PKSimConstants.ObjectTypes.OverwriteParameterSet,
+            CommandType = PKSimConstants.Command.CommandTypeAdd,
+            Description = PKSimConstants.Command.CommitSimulationParametersToCompound(setName, templateCompound.Name)
+         };
 
-         command.Add(addOverwriteParameterSetCommand(simulationCompound, setName, parameterValues));
+         var simulationCompoundCommand = addOverwriteParameterSetCommand(simulationCompound, setName, parameterValues);
+         simulationCompoundCommand.Visible = false;
+
+         command.Add(simulationCompoundCommand);
          command.Add(addOverwriteParameterSetCommand(templateCompound, setName, parameterValues));
 
          return command;
@@ -98,7 +105,7 @@ namespace PKSim.Core.Services
 
       private ICommand addOverwriteParameterSetCommand(Compound compound, string setName, List<ParameterValue> parameterValues)
       {
-         var newSet = new OverwriteParameterSet { Name = setName };
+         var newSet = _objectBaseFactory.Create<OverwriteParameterSet>().WithName(setName);
          parameterValues.Each(newSet.Add);
          return new AddOverwriteParameterSetToCompoundCommand(newSet, compound);
       }
@@ -120,13 +127,18 @@ namespace PKSim.Core.Services
       private PKSimMacroCommand updateExistingSetsCommand(Compound simulationCompound, Compound templateCompound, string setName,
          List<ParameterValue> parameterValues, Simulation simulation, IReadOnlyList<string> parameterPaths, PathCache<IParameter> parameterCache)
       {
-         var command = new PKSimMacroCommand();
+         var command = new PKSimMacroCommand
+         {
+            ObjectType = PKSimConstants.ObjectTypes.OverwriteParameterSet,
+            CommandType = PKSimConstants.Command.CommandTypeUpdate,
+            Description = PKSimConstants.Command.CommitSimulationParametersToCompound(setName, templateCompound.Name)
+         };
 
          var existingSimulationSet = simulationCompound.OverwriteParameterSets.FindByName(setName);
          var existingTemplateSet = templateCompound.OverwriteParameterSets.FindByName(setName);
          var pathsToRemove = pathsResetByUser(existingSimulationSet, parameterPaths, simulation, parameterCache);
 
-         command.Add(new UpdateOverwriteParameterSetCommand(existingSimulationSet, simulationCompound, parameterValues, pathsToRemove));
+         command.Add(new UpdateOverwriteParameterSetCommand(existingSimulationSet, simulationCompound, parameterValues, pathsToRemove) { Visible = false });
          command.Add(new UpdateOverwriteParameterSetCommand(existingTemplateSet, templateCompound, parameterValues, pathsToRemove));
 
          return command;

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetMapper.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Snapshots.Mappers;
 using OSPSuite.Utility.Extensions;
 using static OSPSuite.Core.Extensions.SnapshotMapperBaseExtensions;
@@ -11,11 +12,13 @@ public class OverwriteParameterSetMapper : SnapshotMapperBase<ModelOverwritePara
 {
    private readonly ParameterValueMapper _parameterValueMapper;
    private readonly ExtendedPropertyMapper _extendedPropertyMapper;
+   private readonly IObjectBaseFactory _objectBaseFactory;
 
-   public OverwriteParameterSetMapper(ParameterValueMapper parameterValueMapper, ExtendedPropertyMapper extendedPropertyMapper)
+   public OverwriteParameterSetMapper(ParameterValueMapper parameterValueMapper, ExtendedPropertyMapper extendedPropertyMapper, IObjectBaseFactory objectBaseFactory)
    {
       _parameterValueMapper = parameterValueMapper;
       _extendedPropertyMapper = extendedPropertyMapper;
+      _objectBaseFactory = objectBaseFactory;
    }
 
    public override async Task<SnapshotOverwriteParameterSet> MapToSnapshot(ModelOverwriteParameterSet model)
@@ -34,11 +37,8 @@ public class OverwriteParameterSetMapper : SnapshotMapperBase<ModelOverwritePara
 
    public override async Task<ModelOverwriteParameterSet> MapToModel(SnapshotOverwriteParameterSet snapshot, SnapshotContext snapshotContext)
    {
-      var overwriteParameterSet = new ModelOverwriteParameterSet
-      {
-         Name = snapshot.Name,
-         IsDefault = ModelValueFor(snapshot.IsDefault, false)
-      };
+      var overwriteParameterSet = _objectBaseFactory.Create<ModelOverwriteParameterSet>().WithName(snapshot.Name);
+      overwriteParameterSet.IsDefault = ModelValueFor(snapshot.IsDefault, false);
 
       var extendedProperties = await _extendedPropertyMapper.MapToModels(snapshot.ExtendedProperties, snapshotContext);
       extendedProperties?.Each(overwriteParameterSet.ExtendedProperties.Add);

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -8,6 +8,9 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Commands;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 
@@ -24,12 +27,16 @@ namespace PKSim.Core
       protected IParameter _lipophilicityParam;
       protected IParameter _permeabilityParam;
       protected PathCache<IParameter> _parameterCache;
+      protected IObjectBaseFactory _objectBaseFactory;
+      private int _createdSetCount;
 
       protected override void Context()
       {
          _executionContext = A.Fake<IExecutionContext>();
          _containerTask = A.Fake<IContainerTask>();
          _buildingBlockRepository = A.Fake<PKSim.Core.Repositories.IBuildingBlockRepository>();
+         _objectBaseFactory = A.Fake<IObjectBaseFactory>();
+         A.CallTo(() => _objectBaseFactory.Create<OverwriteParameterSet>()).ReturnsLazily(() => new OverwriteParameterSet { Id = $"NewSetId{_createdSetCount++}" });
 
          _simulationCompound = new Compound { Name = "Aspirin", Id = "SimCompId" };
          _templateCompound = new Compound { Name = "Aspirin", Id = "TemplateCompId" };
@@ -57,7 +64,7 @@ namespace PKSim.Core
          A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(_parameterCache);
          A.CallTo(() => _executionContext.TypeFor(_simulationCompound)).Returns("Compound");
 
-         sut = new CommitSimulationParametersTask(_executionContext, _containerTask, _buildingBlockRepository);
+         sut = new CommitSimulationParametersTask(_executionContext, _containerTask, _buildingBlockRepository, _objectBaseFactory);
       }
    }
 
@@ -104,6 +111,16 @@ namespace PKSim.Core
       }
 
       [Observation]
+      public void should_create_the_overwrite_parameter_sets_with_their_own_id()
+      {
+         var simulationSetId = _simulationCompound.OverwriteParameterSets[0].Id;
+         var templateSetId = _templateCompound.OverwriteParameterSets[0].Id;
+         string.IsNullOrEmpty(simulationSetId).ShouldBeFalse();
+         string.IsNullOrEmpty(templateSetId).ShouldBeFalse();
+         simulationSetId.ShouldNotBeEqualTo(templateSetId);
+      }
+
+      [Observation]
       public void should_set_building_block_properties_on_the_command()
       {
          A.CallTo(() => _executionContext.UpdateBuildingBlockPropertiesInCommand(A<IOSPSuiteCommand>._, _simulationCompound)).MustHaveHappened();
@@ -113,6 +130,21 @@ namespace PKSim.Core
       public void should_publish_a_simulation_status_changed_event_for_the_simulation()
       {
          A.CallTo(() => _executionContext.PublishEvent(A<SimulationStatusChangedEvent>.That.Matches(e => e.Simulation == _simulation))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_only_show_the_change_to_the_template_compound_in_the_history()
+      {
+         var visibleSubCommands = _result.DowncastTo<IPKSimMacroCommand>().All().Where(x => x.Visible).ToList();
+         visibleSubCommands.Count.ShouldBeEqualTo(1);
+         visibleSubCommands[0].DowncastTo<IBuildingBlockChangeCommand>().BuildingBlockId.ShouldBeEqualTo(_templateCompound.Id);
+      }
+
+      [Observation]
+      public void should_describe_the_commit_on_the_macro_command()
+      {
+         _result.Description.ShouldBeEqualTo(PKSimConstants.Command.CommitSimulationParametersToCompound("MyNewSet", _templateCompound.Name));
+         _result.CommandType.ShouldBeEqualTo(PKSimConstants.Command.CommandTypeAdd);
       }
    }
 
@@ -170,6 +202,14 @@ namespace PKSim.Core
       {
          _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
          _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_only_show_the_change_to_the_template_compound_in_the_history()
+      {
+         var visibleSubCommands = _result.DowncastTo<IPKSimMacroCommand>().All().Where(x => x.Visible).ToList();
+         visibleSubCommands.Count.ShouldBeEqualTo(1);
+         visibleSubCommands[0].DowncastTo<IBuildingBlockChangeCommand>().BuildingBlockId.ShouldBeEqualTo(_templateCompound.Id);
       }
    }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -20,12 +21,15 @@ namespace PKSim.Core
       protected SnapshotOverwriteParameterSet _snapshot;
       protected ParameterValueMapper _parameterValueMapper;
       protected ExtendedPropertyMapper _extendedPropertyMapper;
+      protected IObjectBaseFactory _objectBaseFactory;
 
       protected override Task Context()
       {
          _parameterValueMapper = new ParameterValueMapper();
          _extendedPropertyMapper = new ExtendedPropertyMapper();
-         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper);
+         _objectBaseFactory = A.Fake<IObjectBaseFactory>();
+         A.CallTo(() => _objectBaseFactory.Create<ModelOverwriteParameterSet>()).ReturnsLazily(() => new ModelOverwriteParameterSet { Id = "NewSetId" });
+         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper, _objectBaseFactory);
 
          _modelOverwriteParameterSet = new ModelOverwriteParameterSet
          {
@@ -88,7 +92,8 @@ namespace PKSim.Core
       {
          _parameterValueMapper = new ParameterValueMapper();
          _extendedPropertyMapper = new ExtendedPropertyMapper();
-         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper);
+         _objectBaseFactory = A.Fake<IObjectBaseFactory>();
+         sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper, _objectBaseFactory);
 
          _modelOverwriteParameterSet = new ModelOverwriteParameterSet
          {
@@ -164,6 +169,12 @@ namespace PKSim.Core
          _result.ParameterValues.Count.ShouldBeEqualTo(2);
          _result.ParameterValueByPath("Compound|Lipophilicity").Value.ShouldBeEqualTo(1.5);
          _result.ParameterValueByPath("Compound|Solubility").Value.ShouldBeEqualTo(0.5);
+      }
+
+      [Observation]
+      public void should_create_the_set_with_an_id()
+      {
+         _result.Id.ShouldBeEqualTo("NewSetId");
       }
    }
 

--- a/tests/PKSim.Tests/Core/SetSimulationParameterTrackingCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/SetSimulationParameterTrackingCommandSpecs.cs
@@ -1,0 +1,97 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Events;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_SetSimulationParameterTrackingCommand : ContextSpecification<SetSimulationParameterTrackingCommand>
+   {
+      protected IExecutionContext _executionContext;
+      protected IndividualSimulation _simulation;
+      protected const string _lipophilicityPath = "Organism|Aspirin|Lipophilicity";
+      protected const string _permeabilityPath = "Organism|Aspirin|Permeability";
+
+      protected override void Context()
+      {
+         _executionContext = A.Fake<IExecutionContext>();
+         _simulation = new IndividualSimulation { Id = "SimId", Name = "Sim" };
+         A.CallTo(() => _executionContext.Get<Simulation>(_simulation.Id)).Returns(_simulation);
+
+         _simulation.ParameterChangeTracker.Track(_lipophilicityPath);
+         _simulation.ParameterChangeTracker.Track(_permeabilityPath);
+
+         sut = new SetSimulationParameterTrackingCommand(_simulation, new[] { _lipophilicityPath, _permeabilityPath }, tracked: false);
+      }
+   }
+
+   public class When_untracking_committed_simulation_parameters : concern_for_SetSimulationParameterTrackingCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(_executionContext);
+      }
+
+      [Observation]
+      public void should_untrack_the_committed_paths()
+      {
+         _simulation.ParameterChangeTracker.HasUncommittedChanges.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_publish_a_simulation_status_changed_event()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationStatusChangedEvent>.That.Matches(x => x.Simulation == _simulation))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_be_shown_in_the_history()
+      {
+         sut.Visible.ShouldBeFalse();
+      }
+   }
+
+   public class When_undoing_the_untracking_of_committed_simulation_parameters : concern_for_SetSimulationParameterTrackingCommand
+   {
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_track_the_committed_paths_again()
+      {
+         _simulation.ParameterChangeTracker.IsTracked(_lipophilicityPath).ShouldBeTrue();
+         _simulation.ParameterChangeTracker.IsTracked(_permeabilityPath).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_publish_a_simulation_status_changed_event_for_the_undo_as_well()
+      {
+         A.CallTo(() => _executionContext.PublishEvent(A<SimulationStatusChangedEvent>.That.Matches(x => x.Simulation == _simulation))).MustHaveHappenedTwiceExactly();
+      }
+   }
+
+   public class When_undoing_the_untracking_of_a_path_that_was_not_tracked : concern_for_SetSimulationParameterTrackingCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _simulation.ParameterChangeTracker.Untrack(_permeabilityPath);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_only_restore_the_path_whose_tracking_state_was_changed_by_the_command()
+      {
+         _simulation.ParameterChangeTracker.IsTracked(_lipophilicityPath).ShouldBeTrue();
+         _simulation.ParameterChangeTracker.IsTracked(_permeabilityPath).ShouldBeFalse();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #3678

The committed `OverwriteParameterSet` was built with `new` instead of `IObjectBaseFactory`, so its `Id` stayed empty and the set was never registered. Undo then resolved it to `null` and the inverse command threw. Fixed in the commit task and on the snapshot load path.

Two related problems fixed while reproducing:

- The commit showed a blank parent over two sub-commands in the history. The sub-command writing into the simulation's own copy of the compound is now hidden and both macro commands carry a description, so commit and undo each show a single row.
- The orange overlay did not return on undo, because the `ParameterChangeTracker` update ran outside command scope. It now lives in a reversible command that also republishes `SimulationStatusChangedEvent`.

`dotnet test tests/PKSim.Tests/PKSim.Tests.csproj` — 5647 passed, 0 failed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)