### PR TITLE
Fixes #3679 New OPS not shown in the simulation <=> compound comparison

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -279,8 +279,8 @@ namespace PKSim.Assets
          public static string UpdateOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
             $"Update {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
-         public static string UpdateOverwriteParameterSetsInCompound(string compoundName) =>
-            $"Update {ObjectTypes.OverwriteParameterSet.ToLower()}s in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+         public static string ReplaceOverwriteParameterSetsInCompound(string compoundName) =>
+            $"Replace {ObjectTypes.OverwriteParameterSet.ToLower()}s in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
          public static string SetDefaultOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
             $"Set {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' as default in {ObjectTypes.Compound.ToLower()} '{compoundName}'";

--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -278,6 +278,9 @@ namespace PKSim.Assets
          public static string UpdateOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
             $"Update {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
+         public static string UpdateOverwriteParameterSetsInCompound(string compoundName) =>
+            $"Update {ObjectTypes.OverwriteParameterSet.ToLower()}s in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
          public static string SetDefaultOverwriteParameterSetInCompound(string overwriteParameterSetName, string compoundName) =>
             $"Set {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' as default in {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 

--- a/src/PKSim.Core/Commands/ReplaceOverwriteParameterSetsInCompoundCommand.cs
+++ b/src/PKSim.Core/Commands/ReplaceOverwriteParameterSetsInCompoundCommand.cs
@@ -13,17 +13,17 @@ namespace PKSim.Core.Commands
    ///    both compounds are matched by name and updated in place, so that a simulation having selected such a set keeps
    ///    its selection.
    /// </summary>
-   public class UpdateOverwriteParameterSetsCommand : BuildingBlockChangeCommand<Compound>
+   public class ReplaceOverwriteParameterSetsInCompoundCommand : BuildingBlockChangeCommand<Compound>
    {
       private readonly IReadOnlyList<OverwriteParameterSet> _sourceSets;
       private IReadOnlyList<OverwriteParameterSet> _previousSets;
 
-      public UpdateOverwriteParameterSetsCommand(Compound compound, IReadOnlyList<OverwriteParameterSet> sourceSets)
+      public ReplaceOverwriteParameterSetsInCompoundCommand(Compound compound, IReadOnlyList<OverwriteParameterSet> sourceSets)
          : base(compound)
       {
          _sourceSets = sourceSets.ToList();
          CommandType = PKSimConstants.Command.CommandTypeUpdate;
-         Description = PKSimConstants.Command.UpdateOverwriteParameterSetsInCompound(compound.Name);
+         Description = PKSimConstants.Command.ReplaceOverwriteParameterSetsInCompound(compound.Name);
          Visible = false;
       }
 
@@ -54,6 +54,6 @@ namespace PKSim.Core.Commands
       }
 
       protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
-         new UpdateOverwriteParameterSetsCommand(_buildingBlock, _previousSets).AsInverseFor(this);
+         new ReplaceOverwriteParameterSetsInCompoundCommand(_buildingBlock, _previousSets).AsInverseFor(this);
    }
 }

--- a/src/PKSim.Core/Commands/UpdateOverwriteParameterSetsCommand.cs
+++ b/src/PKSim.Core/Commands/UpdateOverwriteParameterSetsCommand.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands
+{
+   /// <summary>
+   ///    Replaces the <see cref="OverwriteParameterSet" />s of a compound with the sets given as source. Sets defined in
+   ///    both compounds are matched by name and updated in place, so that a simulation having selected such a set keeps
+   ///    its selection.
+   /// </summary>
+   public class UpdateOverwriteParameterSetsCommand : BuildingBlockChangeCommand<Compound>
+   {
+      private readonly IReadOnlyList<OverwriteParameterSet> _sourceSets;
+      private IReadOnlyList<OverwriteParameterSet> _previousSets;
+
+      public UpdateOverwriteParameterSetsCommand(Compound compound, IReadOnlyList<OverwriteParameterSet> sourceSets)
+         : base(compound)
+      {
+         _sourceSets = sourceSets.ToList();
+         CommandType = PKSimConstants.Command.CommandTypeUpdate;
+         Description = PKSimConstants.Command.UpdateOverwriteParameterSetsInCompound(compound.Name);
+         Visible = false;
+      }
+
+      protected override void PerformExecuteWith(IExecutionContext context)
+      {
+         base.PerformExecuteWith(context);
+         var cloneManager = context.CloneManager;
+         _previousSets = _buildingBlock.OverwriteParameterSets.Select(cloneManager.Clone).ToList();
+
+         _buildingBlock.OverwriteParameterSets
+            .Where(x => _sourceSets.FindByName(x.Name) == null)
+            .ToList()
+            .Each(_buildingBlock.RemoveOverwriteParameterSet);
+
+         _sourceSets.Each(sourceSet =>
+         {
+            var existingSet = _buildingBlock.OverwriteParameterSets.FindByName(sourceSet.Name);
+            if (existingSet != null)
+            {
+               existingSet.UpdatePropertiesFrom(sourceSet, cloneManager);
+               return;
+            }
+
+            var newSet = cloneManager.Clone(sourceSet);
+            _buildingBlock.AddOverwriteParameterSet(newSet);
+            context.Register(newSet);
+         });
+      }
+
+      protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+         new UpdateOverwriteParameterSetsCommand(_buildingBlock, _previousSets).AsInverseFor(this);
+   }
+}

--- a/src/PKSim.Core/Comparison/CompoundDiffBuilder.cs
+++ b/src/PKSim.Core/Comparison/CompoundDiffBuilder.cs
@@ -8,11 +8,13 @@ namespace PKSim.Core.Comparison
    {
       private readonly ContainerDiffBuilder _containerDiffBuilder;
       private readonly IObjectComparer _comparer;
+      private readonly EnumerableComparer _enumerableComparer;
 
-      public CompoundDiffBuilder(ContainerDiffBuilder containerDiffBuilder, IObjectComparer comparer)
+      public CompoundDiffBuilder(ContainerDiffBuilder containerDiffBuilder, IObjectComparer comparer, EnumerableComparer enumerableComparer)
       {
          _containerDiffBuilder = containerDiffBuilder;
          _comparer = comparer;
+         _enumerableComparer = enumerableComparer;
       }
 
       public override void Compare(IComparison<Compound> comparison)
@@ -20,6 +22,7 @@ namespace PKSim.Core.Comparison
          _containerDiffBuilder.Compare(comparison);
          _comparer.Compare(comparison.ChildComparison(x => x.CalculationMethodCache));
          CompareStringValues(x => x.IsSmallMolecule.ToString(), PKSimConstants.UI.IsSmallMolecule, comparison);
+         _enumerableComparer.CompareEnumerables(comparison, x => x.OverwriteParameterSets, x => x.Name, missingItemType: PKSimConstants.ObjectTypes.OverwriteParameterSet);
       }
    }
 }

--- a/src/PKSim.Core/Comparison/OverwriteParameterSetDiffBuilder.cs
+++ b/src/PKSim.Core/Comparison/OverwriteParameterSetDiffBuilder.cs
@@ -1,0 +1,28 @@
+using OSPSuite.Core.Comparison;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Comparison
+{
+   public class OverwriteParameterSetDiffBuilder : DiffBuilder<OverwriteParameterSet>
+   {
+      private readonly ObjectBaseDiffBuilder _objectBaseDiffBuilder;
+      private readonly IObjectComparer _comparer;
+      private readonly EnumerableComparer _enumerableComparer;
+
+      public OverwriteParameterSetDiffBuilder(ObjectBaseDiffBuilder objectBaseDiffBuilder, IObjectComparer comparer, EnumerableComparer enumerableComparer)
+      {
+         _objectBaseDiffBuilder = objectBaseDiffBuilder;
+         _comparer = comparer;
+         _enumerableComparer = enumerableComparer;
+      }
+
+      public override void Compare(IComparison<OverwriteParameterSet> comparison)
+      {
+         _objectBaseDiffBuilder.Compare(comparison);
+         CompareValues(x => x.IsDefault, PKSimConstants.UI.IsDefault, comparison);
+         _comparer.Compare(comparison.ChildComparison(x => x.ExtendedProperties));
+         _enumerableComparer.CompareEnumerables(comparison, x => x.ParameterValues, x => x.Path);
+      }
+   }
+}

--- a/src/PKSim.Core/Services/BuildingBlockParametersToSimulationUpdater.cs
+++ b/src/PKSim.Core/Services/BuildingBlockParametersToSimulationUpdater.cs
@@ -5,6 +5,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Events;
 using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 using PKSim.Assets;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
@@ -65,6 +66,9 @@ namespace PKSim.Core.Services
             updateCommands.Add(command);
          }
 
+         //then bring over the overwrite parameter sets defined in the template so that they can be selected in the simulation
+         updateCommands.Add(updateOverwriteParameterSets(templateBuildingBlock, usedBuildingBlock));
+
          //now make sure that the used building block is updated with the template building block info
          updateCommands.Add(new UpdateUsedBuildingBlockInfoCommand(simulation, usedBuildingBlock, templateBuildingBlock, _executionContext).Run(_executionContext));
 
@@ -75,6 +79,15 @@ namespace PKSim.Core.Services
 
          synchronizeBuildingBlocks(templateBuildingBlock, simulation);
          return updateCommands;
+      }
+
+      private ICommand updateOverwriteParameterSets(IPKSimBuildingBlock templateBuildingBlock, UsedBuildingBlock usedBuildingBlock)
+      {
+         if (templateBuildingBlock is not Compound templateCompound)
+            return new PKSimEmptyCommand();
+
+         var simulationCompound = usedBuildingBlock.BuildingBlock.DowncastTo<Compound>();
+         return new UpdateOverwriteParameterSetsCommand(simulationCompound, templateCompound.OverwriteParameterSets).Run(_executionContext);
       }
 
       /// <summary>

--- a/src/PKSim.Core/Services/BuildingBlockParametersToSimulationUpdater.cs
+++ b/src/PKSim.Core/Services/BuildingBlockParametersToSimulationUpdater.cs
@@ -87,7 +87,7 @@ namespace PKSim.Core.Services
             return new PKSimEmptyCommand();
 
          var simulationCompound = usedBuildingBlock.BuildingBlock.DowncastTo<Compound>();
-         return new UpdateOverwriteParameterSetsCommand(simulationCompound, templateCompound.OverwriteParameterSets).Run(_executionContext);
+         return new ReplaceOverwriteParameterSetsInCompoundCommand(simulationCompound, templateCompound.OverwriteParameterSets).Run(_executionContext);
       }
 
       /// <summary>

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -63,20 +63,19 @@ namespace PKSim.Core.Services
 
       public ICommand CommitParametersToCompound(Simulation simulation, CompoundCommitInfo commitInfo)
       {
-         var simulationCompound = simulation.BuildingBlockByTemplateId<Compound>(commitInfo.TemplateCompoundId);
          var templateCompound = _buildingBlockRepository.ById<Compound>(commitInfo.TemplateCompoundId);
 
          var parameterCache = _containerTask.CacheAllChildren<IParameter>(simulation.Model.Root);
          var parameterValues = createParameterValuesFor(commitInfo, parameterCache);
 
          var command = commitInfo.ShouldCreateNew
-            ? createNewSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues)
-            : updateExistingSetsCommand(simulationCompound, templateCompound, commitInfo.OverwriteParameterSetName, parameterValues, simulation, commitInfo.ParameterPaths, parameterCache);
+            ? createNewSetCommand(templateCompound, commitInfo.OverwriteParameterSetName, parameterValues)
+            : updateExistingSetCommand(templateCompound, commitInfo.OverwriteParameterSetName, parameterValues, simulation, commitInfo.ParameterPaths, parameterCache);
 
          command.Run(_executionContext);
 
-         command.All().Each(subCommand => _executionContext.UpdateBuildingBlockPropertiesInCommand(subCommand, simulationCompound));
-         _executionContext.UpdateBuildingBlockPropertiesInCommand(command, simulationCompound);
+         command.All().Each(subCommand => _executionContext.UpdateBuildingBlockPropertiesInCommand(subCommand, templateCompound));
+         _executionContext.UpdateBuildingBlockPropertiesInCommand(command, templateCompound);
 
          //Only untrack paths that were actually resolved to parameter values
          parameterValues.Each(pv => simulation.ParameterChangeTracker.Untrack(pv.Path));
@@ -86,47 +85,38 @@ namespace PKSim.Core.Services
          return command;
       }
 
-      private PKSimMacroCommand createNewSetsCommand(Compound simulationCompound, Compound templateCompound, string setName, List<ParameterValue> parameterValues)
+      private PKSimMacroCommand createNewSetCommand(Compound templateCompound, string setName, List<ParameterValue> parameterValues)
       {
          var command = new PKSimMacroCommand();
 
-         command.Add(addOverwriteParameterSetCommand(simulationCompound, setName, parameterValues));
-         command.Add(addOverwriteParameterSetCommand(templateCompound, setName, parameterValues));
+         var newSet = new OverwriteParameterSet { Name = setName };
+         parameterValues.Each(newSet.Add);
+         command.Add(new AddOverwriteParameterSetToCompoundCommand(newSet, templateCompound));
 
          return command;
       }
 
-      private ICommand addOverwriteParameterSetCommand(Compound compound, string setName, List<ParameterValue> parameterValues)
-      {
-         var newSet = new OverwriteParameterSet { Name = setName };
-         parameterValues.Each(newSet.Add);
-         return new AddOverwriteParameterSetToCompoundCommand(newSet, compound);
-      }
-
       /// <summary>
-      ///    Creates a macro command that updates existing OverwriteParameterSets (identified by <paramref name="setName" />)
-      ///    in both the simulation and template compounds. Parameters that were previously in the set but have been
-      ///    reset by the user (no longer differ from their original/default value) are removed from the set. Entries
+      ///    Creates a macro command that updates the existing OverwriteParameterSet (identified by
+      ///    <paramref name="setName" />) in the template compound. Parameters that were previously in the set but have
+      ///    been reset by the user (no longer differ from their original/default value) are removed from the set. Entries
       ///    the user has not touched since the previous commit are preserved.
       /// </summary>
-      /// <param name="simulationCompound">The compound used in the simulation whose OverwriteParameterSet will be updated.</param>
-      /// <param name="templateCompound">The project template compound whose corresponding OverwriteParameterSet will be updated.</param>
-      /// <param name="setName">Name of the existing OverwriteParameterSet to update in both compounds.</param>
+      /// <param name="templateCompound">The project template compound whose OverwriteParameterSet will be updated.</param>
+      /// <param name="setName">Name of the existing OverwriteParameterSet to update.</param>
       /// <param name="parameterValues">The new parameter values to apply to the set.</param>
       /// <param name="simulation">The simulation, used to check which paths are still tracked.</param>
       /// <param name="parameterPaths">The parameter paths being committed, used to determine which paths the user has reset.</param>
       /// <param name="parameterCache">Cache of simulation parameters, used to compare current values against the set's stored values when detecting resets.</param>
-      /// <returns>A macro command containing the update commands for both compounds.</returns>
-      private PKSimMacroCommand updateExistingSetsCommand(Compound simulationCompound, Compound templateCompound, string setName,
+      /// <returns>A macro command containing the update command for the template compound.</returns>
+      private PKSimMacroCommand updateExistingSetCommand(Compound templateCompound, string setName,
          List<ParameterValue> parameterValues, Simulation simulation, IReadOnlyList<string> parameterPaths, PathCache<IParameter> parameterCache)
       {
          var command = new PKSimMacroCommand();
 
-         var existingSimulationSet = simulationCompound.OverwriteParameterSets.FindByName(setName);
          var existingTemplateSet = templateCompound.OverwriteParameterSets.FindByName(setName);
-         var pathsToRemove = pathsResetByUser(existingSimulationSet, parameterPaths, simulation, parameterCache);
+         var pathsToRemove = pathsResetByUser(existingTemplateSet, parameterPaths, simulation, parameterCache);
 
-         command.Add(new UpdateOverwriteParameterSetCommand(existingSimulationSet, simulationCompound, parameterValues, pathsToRemove));
          command.Add(new UpdateOverwriteParameterSetCommand(existingTemplateSet, templateCompound, parameterValues, pathsToRemove));
 
          return command;

--- a/src/PKSim.Presentation/DTO/Mappers/SimulationToCompoundCommitDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/SimulationToCompoundCommitDTOMapper.cs
@@ -44,19 +44,30 @@ namespace PKSim.Presentation.DTO.Mappers
          if (!changedPaths.Any())
             return null;
 
-         var existingSelection = simulation.OverwriteParameterSetSelections.SelectedSetFor(compound.Name);
-         var hasExistingSelection = existingSelection != null && templateCompound.OverwriteParameterSets.Contains(existingSelection);
+         var selectedSetInTemplate = selectedSetInTemplateFor(simulation, compound.Name, templateCompound);
 
          return new CompoundCommitDTO
          {
             CompoundName = compound.Name,
             Compound = templateCompound,
             AvailableExistingSets = templateCompound.OverwriteParameterSets,
-            CreateNew = !hasExistingSelection,
-            SelectedExistingSet = hasExistingSelection ? existingSelection : null,
+            CreateNew = selectedSetInTemplate == null,
+            SelectedExistingSet = selectedSetInTemplate,
             NewSetName = compound.Name,
             Parameters = changedPaths.Select(path => _parameterCommitDTOMapper.MapFrom(path, parameterCache[path])).ToList()
          };
+      }
+
+      /// <summary>
+      ///    Returns the set of <paramref name="templateCompound" /> selected for the compound in the simulation, matched by
+      ///    name. The selection holds the set of the compound in the simulation when it was made in the simulation
+      ///    configuration, and the set of the template compound when it was restored from a snapshot, so the two cannot be
+      ///    compared by reference.
+      /// </summary>
+      private OverwriteParameterSet selectedSetInTemplateFor(Simulation simulation, string compoundName, Compound templateCompound)
+      {
+         var selection = simulation.OverwriteParameterSetSelections.SelectedSetFor(compoundName);
+         return selection == null ? null : templateCompound.OverwriteParameterSets.FindByName(selection.Name);
       }
 
       private Compound templateCompoundFor(Simulation simulation, string compoundName)

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -55,7 +55,7 @@ namespace PKSim.Core
          _parameterCache.Add("Organism|Aspirin|Permeability", _permeabilityParam);
 
          A.CallTo(() => _containerTask.CacheAllChildren<IParameter>(root)).Returns(_parameterCache);
-         A.CallTo(() => _executionContext.TypeFor(_simulationCompound)).Returns("Compound");
+         A.CallTo(() => _executionContext.TypeFor(_templateCompound)).Returns("Compound");
 
          sut = new CommitSimulationParametersTask(_executionContext, _containerTask, _buildingBlockRepository);
       }
@@ -90,13 +90,6 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_add_the_overwrite_parameter_set_to_the_simulation_compound()
-      {
-         _simulationCompound.OverwriteParameterSets.Count.ShouldBeEqualTo(1);
-         _simulationCompound.OverwriteParameterSets[0].Name.ShouldBeEqualTo("MyNewSet");
-      }
-
-      [Observation]
       public void should_add_the_overwrite_parameter_set_to_the_template_compound()
       {
          _templateCompound.OverwriteParameterSets.Count.ShouldBeEqualTo(1);
@@ -104,9 +97,15 @@ namespace PKSim.Core
       }
 
       [Observation]
+      public void should_not_add_the_overwrite_parameter_set_to_the_compound_used_in_the_simulation()
+      {
+         _simulationCompound.OverwriteParameterSets.ShouldBeEmpty();
+      }
+
+      [Observation]
       public void should_set_building_block_properties_on_the_command()
       {
-         A.CallTo(() => _executionContext.UpdateBuildingBlockPropertiesInCommand(A<IOSPSuiteCommand>._, _simulationCompound)).MustHaveHappened();
+         A.CallTo(() => _executionContext.UpdateBuildingBlockPropertiesInCommand(A<IOSPSuiteCommand>._, _templateCompound)).MustHaveHappened();
       }
 
       [Observation]
@@ -125,6 +124,8 @@ namespace PKSim.Core
       protected override void Context()
       {
          base.Context();
+         //the compound in the simulation still holds the set as it was brought over from the template. It should not
+         //be touched by the commit
          _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
          _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|OldParam".ToObjectPath(), Value = 1.0 });
          _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
@@ -154,28 +155,26 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_update_the_simulation_existing_set_with_new_parameter_value()
-      {
-         _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
-      }
-
-      [Observation]
       public void should_update_the_template_existing_set_with_new_parameter_value()
       {
          _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeTrue();
       }
 
       [Observation]
+      public void should_not_update_the_set_in_the_compound_used_in_the_simulation()
+      {
+         _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|Lipophilicity").ShouldBeFalse();
+      }
+
+      [Observation]
       public void should_preserve_existing_entries_for_parameters_no_longer_present_in_the_simulation()
       {
-         _simulationExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
          _templateExistingSet.ParameterValues.Any(pv => pv.Path.PathAsString == "Organism|Aspirin|OldParam").ShouldBeTrue();
       }
    }
 
    public class When_committing_a_tracked_parameter_to_an_existing_set_with_other_untouched_entries : concern_for_CommitSimulationParametersTask
    {
-      private OverwriteParameterSet _simulationExistingSet;
       private OverwriteParameterSet _templateExistingSet;
 
       protected override void Context()
@@ -183,10 +182,6 @@ namespace PKSim.Core
          base.Context();
          //Permeability is in the existing set with the same value the simulation parameter currently holds (7.2),
          //modelling a parameter that was previously committed and has not been touched since.
-         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
-         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
-         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
-
          _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
          _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
          _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
@@ -206,27 +201,20 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_preserve_the_existing_untouched_entry_in_the_simulation_set()
-      {
-         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
-      }
-
-      [Observation]
       public void should_preserve_the_existing_untouched_entry_in_the_template_set()
       {
          _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
       }
 
       [Observation]
-      public void should_add_the_newly_committed_entry_to_the_simulation_set()
+      public void should_add_the_newly_committed_entry_to_the_template_set()
       {
-         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
+         _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
       }
    }
 
    public class When_committing_to_an_existing_set_after_user_has_reset_a_parameter_in_that_set : concern_for_CommitSimulationParametersTask
    {
-      private OverwriteParameterSet _simulationExistingSet;
       private OverwriteParameterSet _templateExistingSet;
 
       protected override void Context()
@@ -235,10 +223,6 @@ namespace PKSim.Core
          //Permeability is in the existing set with stored value 99.0. The simulation's Permeability parameter is
          //at 7.2 — different from the stored value and not tracked — which models a parameter the user has reset
          //since the previous commit.
-         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
-         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 99.0 });
-         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
-
          _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
          _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 99.0 });
          _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
@@ -258,40 +242,30 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_remove_the_reset_entry_from_the_simulation_set()
-      {
-         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldBeNull();
-      }
-
-      [Observation]
       public void should_remove_the_reset_entry_from_the_template_set()
       {
          _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldBeNull();
       }
 
       [Observation]
-      public void should_add_the_newly_committed_entry_to_the_simulation_set()
+      public void should_add_the_newly_committed_entry_to_the_template_set()
       {
-         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
+         _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Lipophilicity").ShouldNotBeNull();
       }
    }
 
    public class When_committing_to_an_existing_set_with_an_unchecked_tracked_parameter : concern_for_CommitSimulationParametersTask
    {
-      private OverwriteParameterSet _simulationExistingSet;
+      private OverwriteParameterSet _templateExistingSet;
 
       protected override void Context()
       {
          base.Context();
          //Permeability is tracked AND in the existing set with the same stored value, but the user unchecks it in
          //the commit dialog (it is not in ParameterPaths). The entry should be preserved as-is rather than removed.
-         _simulationExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId1" };
-         _simulationExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
-         _simulationCompound.AddOverwriteParameterSet(_simulationExistingSet);
-
-         var templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
-         templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
-         _templateCompound.AddOverwriteParameterSet(templateExistingSet);
+         _templateExistingSet = new OverwriteParameterSet { Name = "ExistingSet", Id = "SetId2" };
+         _templateExistingSet.Add(new ParameterValue { Path = "Organism|Aspirin|Permeability".ToObjectPath(), Value = 7.2 });
+         _templateCompound.AddOverwriteParameterSet(_templateExistingSet);
 
          _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
          _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Permeability");
@@ -311,7 +285,7 @@ namespace PKSim.Core
       [Observation]
       public void should_preserve_the_unchecked_tracked_entry()
       {
-         _simulationExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
+         _templateExistingSet.ParameterValueByPath("Organism|Aspirin|Permeability").ShouldNotBeNull();
       }
 
       [Observation]

--- a/tests/PKSim.Tests/IntegrationTests/BuildingBlockParametersToSimulationUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/BuildingBlockParametersToSimulationUpdaterSpecs.cs
@@ -3,6 +3,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility.Container;
 using PKSim.Core;
 using PKSim.Core.Model;
@@ -16,6 +17,7 @@ namespace PKSim.IntegrationTests
       protected Individual _templateIndividual;
       private ICoreWorkspace _workspace;
       protected ExpressionProfile _templateExpressionProfile;
+      protected Compound _templateCompound;
       private IMoleculeExpressionTask<Individual> _moleculeExpressionTask;
 
       public override void GlobalContext()
@@ -28,7 +30,7 @@ namespace PKSim.IntegrationTests
          _moleculeExpressionTask.AddExpressionProfile(_templateIndividual, _templateExpressionProfile);
 
 
-         var compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var compound = _templateCompound = DomainFactoryForSpecs.CreateStandardCompound();
          var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
          _simulation = DomainFactoryForSpecs.CreateSimulationWith(_templateIndividual, compound, protocol) as IndividualSimulation;
          _workspace = IoC.Resolve<ICoreWorkspace>();
@@ -86,6 +88,62 @@ namespace PKSim.IntegrationTests
       public void should_return_a_command_containing_all_the_sub_commands_describing_the_update()
       {
          _result.IsEmpty().ShouldBeFalse();
+      }
+   }
+
+   public class When_updating_the_compound_of_a_simulation_from_the_template_compound_defining_overwrite_parameter_sets : concern_for_BuildingBlockParametersToSimulationUpdater
+   {
+      private Compound _simulationCompound;
+      private string _existingSetId;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _simulationCompound = _simulation.BuildingBlockByTemplateId<Compound>(_templateCompound.Id);
+
+         var existingSetInSimulation = new OverwriteParameterSet { Name = "OPS 1", Id = "ExistingSetId" };
+         existingSetInSimulation.Add(parameterValueFor(1));
+         _simulationCompound.AddOverwriteParameterSet(existingSetInSimulation);
+         _existingSetId = existingSetInSimulation.Id;
+
+         var staleSetInSimulation = new OverwriteParameterSet { Name = "OPS stale", Id = "StaleSetId" };
+         _simulationCompound.AddOverwriteParameterSet(staleSetInSimulation);
+
+         var updatedSetInTemplate = new OverwriteParameterSet { Name = "OPS 1" };
+         updatedSetInTemplate.Add(parameterValueFor(2));
+         _templateCompound.AddOverwriteParameterSet(updatedSetInTemplate);
+
+         var newSetInTemplate = new OverwriteParameterSet { Name = "OPS 2" };
+         newSetInTemplate.Add(parameterValueFor(3));
+         _templateCompound.AddOverwriteParameterSet(newSetInTemplate);
+      }
+
+      private ParameterValue parameterValueFor(double value) =>
+         new() { Path = $"{_templateCompound.Name}|Lipophilicity".ToObjectPath(), Value = value };
+
+      protected override void Because()
+      {
+         sut.UpdateParametersFromBuildingBlockInSimulation(_templateCompound, _simulation);
+      }
+
+      [Observation]
+      public void should_have_added_the_set_only_defined_in_the_template_to_the_compound_of_the_simulation()
+      {
+         _simulationCompound.OverwriteParameterSets.FindByName("OPS 2").ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_have_updated_the_set_defined_in_both_compounds_without_replacing_it()
+      {
+         var updatedSet = _simulationCompound.OverwriteParameterSets.FindByName("OPS 1");
+         updatedSet.Id.ShouldBeEqualTo(_existingSetId);
+         updatedSet.ParameterValues.Single().Value.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void should_have_removed_the_set_no_longer_defined_in_the_template()
+      {
+         _simulationCompound.OverwriteParameterSets.FindByName("OPS stale").ShouldBeNull();
       }
    }
 }

--- a/tests/PKSim.Tests/IntegrationTests/CompoundComparisonSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/CompoundComparisonSpecs.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Comparison;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
+using PKSim.Core.Model;
+
+namespace PKSim.IntegrationTests
+{
+   public abstract class concern_for_CompoundComparison : ContextForIntegration<IObjectComparer>
+   {
+      protected Compound _templateCompound;
+      protected Compound _simulationCompound;
+      protected DiffReport _report;
+
+      protected override void Context()
+      {
+         base.Context();
+         var compoundFactory = IoC.Resolve<ICompoundFactory>();
+         _templateCompound = compoundFactory.Create().WithName("C1");
+         _simulationCompound = compoundFactory.Create().WithName("C1");
+      }
+
+      protected override void Because()
+      {
+         _report = sut.Compare(_templateCompound, _simulationCompound);
+      }
+
+      protected OverwriteParameterSet OverwriteParameterSetFor(string name, double value)
+      {
+         var overwriteParameterSet = new OverwriteParameterSet { Name = name };
+         overwriteParameterSet.Add(new ParameterValue { Path = "C1|Lipophilicity".ToObjectPath(), Value = value });
+         return overwriteParameterSet;
+      }
+   }
+
+   public class When_comparing_a_compound_defining_an_overwrite_parameter_set_with_a_compound_that_does_not_define_it : concern_for_CompoundComparison
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _templateCompound.AddOverwriteParameterSet(OverwriteParameterSetFor("OPS xyz", 2));
+      }
+
+      [Observation]
+      public void should_report_the_overwrite_parameter_set_as_missing()
+      {
+         var missingItem = _report.OfType<MissingDiffItem>().SingleOrDefault(x => x.MissingObjectType == PKSimConstants.ObjectTypes.OverwriteParameterSet);
+         missingItem.ShouldNotBeNull();
+         missingItem.MissingObjectName.ShouldBeEqualTo("OPS xyz");
+      }
+   }
+
+   public class When_comparing_two_compounds_defining_the_same_overwrite_parameter_set_with_different_values : concern_for_CompoundComparison
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _templateCompound.AddOverwriteParameterSet(OverwriteParameterSetFor("OPS xyz", 2));
+         _simulationCompound.AddOverwriteParameterSet(OverwriteParameterSetFor("OPS xyz", 5));
+      }
+
+      [Observation]
+      public void should_report_the_value_defined_in_the_set_as_different()
+      {
+         _report.OfType<PropertyValueDiffItem>().Any(x => x.Object1.IsAnImplementationOf<ParameterValue>()).ShouldBeTrue();
+      }
+   }
+
+   public class When_comparing_two_compounds_defining_the_same_overwrite_parameter_set : concern_for_CompoundComparison
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _templateCompound.AddOverwriteParameterSet(OverwriteParameterSetFor("OPS xyz", 2));
+         _simulationCompound.AddOverwriteParameterSet(OverwriteParameterSetFor("OPS xyz", 2));
+      }
+
+      [Observation]
+      public void should_not_report_any_difference()
+      {
+         _report.IsEmpty.ShouldBeTrue();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Presentation/SimulationToCompoundCommitDTOMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationToCompoundCommitDTOMapperSpecs.cs
@@ -138,6 +138,74 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_mapping_a_simulation_whose_selection_holds_the_set_of_the_compound_in_the_simulation : concern_for_SimulationToCompoundCommitDTOMapper
+   {
+      private CompoundCommitDTO _result;
+      private OverwriteParameterSet _setInTemplateCompound;
+
+      protected override void Context()
+      {
+         base.Context();
+         //a selection made in the simulation configuration holds the set of the compound in the simulation, which is never
+         //the same instance as the set of the template compound
+         _setInTemplateCompound = new OverwriteParameterSet { Name = "ExistingSet", Id = "TemplateSetId" };
+         _templateCompound.AddOverwriteParameterSet(_setInTemplateCompound);
+
+         var setInSimulationCompound = new OverwriteParameterSet { Name = "ExistingSet", Id = "SimulationSetId" };
+         _simulationCompound.AddOverwriteParameterSet(setInSimulationCompound);
+         _simulation.OverwriteParameterSetSelections.SetSelectionForCompound("Aspirin", setInSimulationCompound);
+
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_simulation, _simulationCompound);
+      }
+
+      [Observation]
+      public void should_default_to_update_existing()
+      {
+         _result.CreateNew.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_select_the_set_of_the_template_compound()
+      {
+         _result.SelectedExistingSet.ShouldBeEqualTo(_setInTemplateCompound);
+      }
+   }
+
+   public class When_mapping_a_simulation_whose_selected_set_is_not_defined_in_the_template_compound : concern_for_SimulationToCompoundCommitDTOMapper
+   {
+      private CompoundCommitDTO _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation.OverwriteParameterSetSelections.SetSelectionForCompound("Aspirin", new OverwriteParameterSet { Name = "RemovedSet" });
+
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_simulation, _simulationCompound);
+      }
+
+      [Observation]
+      public void should_default_to_create_new()
+      {
+         _result.CreateNew.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_select_an_existing_set()
+      {
+         _result.SelectedExistingSet.ShouldBeNull();
+      }
+   }
+
    public class When_mapping_a_simulation_with_existing_overwrite_set_selection : concern_for_SimulationToCompoundCommitDTOMapper
    {
       private CompoundCommitDTO _result;
@@ -146,6 +214,7 @@ namespace PKSim.Presentation
       protected override void Context()
       {
          base.Context();
+         //a selection restored from a snapshot holds the set of the template compound
          _existingSet = new OverwriteParameterSet { Name = "ExistingSet" };
          _templateCompound.AddOverwriteParameterSet(_existingSet);
          _simulation.OverwriteParameterSetSelections.SetSelectionForCompound("Aspirin", _existingSet);


### PR DESCRIPTION
Fixes #3679

`CompoundDiffBuilder` did not compare `OverwriteParameterSets`, so a set defined in one compound and not in the other was not reported. It is now compared by name, and a new `OverwriteParameterSetDiffBuilder` compares the content of sets defined in both.

Committing simulation parameters to a set now writes it to the project compound only. The compound in the simulation is therefore correctly shown as changed, and the comparison names the missing set. The sets are brought into the compound of the simulation when the building block is updated in the simulation, by a new reversible `ReplaceOverwriteParameterSetsInCompoundCommand` that reconciles them by name in place so that a simulation having selected a set keeps its selection.

A second commit fixes the commit dialog, which compared the selected set with the sets of the template compound by reference. A selection made in the simulation configuration holds the set of the compound in the simulation, so the comparison never matched and the dialog always defaulted to creating a new set instead of offering to update the set in use.

Follow-up filed as #3684.

`dotnet test tests/PKSim.Tests/PKSim.Tests.csproj` - 5658 passed, 0 failed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replacing overwrite parameter sets in compounds, including undo.
  * Compound comparisons now identify missing and changed overwrite parameter sets.
  * Template overwrite parameter sets now synchronize with simulation compounds.
* **Bug Fixes**
  * Parameter commits now update the template compound consistently.
  * Improved mapping when selections originate from simulations or restored snapshots.
* **Tests**
  * Added coverage for synchronization, comparison, commits, and parameter-set mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->