### PR TITLE
Fixes #3684 Commit of a compound from a simulation reports it as in sync although the overwrite parameter sets differ

### DIFF
--- a/src/PKSim.Core/Services/SimulationParametersToBuildingBlockUpdater.cs
+++ b/src/PKSim.Core/Services/SimulationParametersToBuildingBlockUpdater.cs
@@ -72,11 +72,23 @@ namespace PKSim.Core.Services
          var synchronizeCommand = synchronizeBuildingBlocks(templateBuildingBlock, updateTemplateParametersCommand, simulation);
          updateCommands.Add(synchronizeCommand);
 
+         //then bring over the overwrite parameter sets defined in the template so that both compounds are in sync
+         updateCommands.Add(updateOverwriteParameterSets(templateBuildingBlock, usedBuildingBlock));
+
          //now make sure that the used building block is updated with the template building block info
          updateCommands.Add(new UpdateUsedBuildingBlockInfoCommand(simulation, usedBuildingBlock, templateBuildingBlock, _executionContext).Run(_executionContext));
 
          _executionContext.PublishEvent(new BuildingBlockUpdatedEvent(templateBuildingBlock));
          return updateCommands;
+      }
+
+      private ICommand updateOverwriteParameterSets(IPKSimBuildingBlock templateBuildingBlock, UsedBuildingBlock usedBuildingBlock)
+      {
+         if (templateBuildingBlock is not Compound templateCompound)
+            return new PKSimEmptyCommand();
+
+         var simulationCompound = usedBuildingBlock.BuildingBlock.DowncastTo<Compound>();
+         return new ReplaceOverwriteParameterSetsInCompoundCommand(simulationCompound, templateCompound.OverwriteParameterSets).Run(_executionContext);
       }
 
       private ICommand synchronizeBuildingBlocks(IPKSimBuildingBlock templateBuildingBlock, IPKSimMacroCommand updateTemplateParametersCommand, Simulation simulation)

--- a/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
@@ -206,6 +206,7 @@ namespace PKSim.IntegrationTests
          var setInSimulation = _simulationCompound.OverwriteParameterSets.FindByName("OPS 1");
          setInSimulation.ShouldNotBeNull();
          setInSimulation.ParameterValues.Single().Value.ShouldBeEqualTo(2);
+         _templateCompound.OverwriteParameterSets.FindByName("OPS 1").ShouldNotBeNull();
       }
    }
 }

--- a/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/SimulationParametersToBuildingBlockUpdaterSpecs.cs
@@ -1,7 +1,9 @@
-﻿using OSPSuite.BDDHelper;
+﻿using System.Linq;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility.Container;
 using PKSim.Core;
 using PKSim.Core.Model;
@@ -21,6 +23,7 @@ namespace PKSim.IntegrationTests
       protected Individual _templateIndividualUsingSameProfile;
       protected Individual _templateIndividualUsingAnotherProfile;
       protected ExpressionProfile _templateExpressionProfileCYP2D6;
+      protected Compound _templateCompound;
 
       public override void GlobalContext()
       {
@@ -38,7 +41,7 @@ namespace PKSim.IntegrationTests
          _templateExpressionProfileCYP2D6 = DomainFactoryForSpecs.CreateExpressionProfile<IndividualEnzyme>("CYP2D6");
          moleculeExpressionTask.AddExpressionProfile(_templateIndividualUsingAnotherProfile, _templateExpressionProfileCYP2D6);
 
-         var compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var compound = _templateCompound = DomainFactoryForSpecs.CreateStandardCompound();
          var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
          
          _simulation = DomainFactoryForSpecs.CreateSimulationWith(_templateIndividual, compound, protocol) as IndividualSimulation;
@@ -175,6 +178,34 @@ namespace PKSim.IntegrationTests
       public void should_make_the_template_parameter_eligible_for_snapshot_export()
       {
          _templateFatVolume.ShouldExportToSnapshot().ShouldBeTrue();
+      }
+   }
+
+   public class When_updating_the_template_compound_from_a_simulation_while_the_template_defines_an_overwrite_parameter_set_missing_in_the_simulation : concern_for_SimulationParametersToBuildingBlockUpdater
+   {
+      private Compound _simulationCompound;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _simulationCompound = _simulation.BuildingBlockByTemplateId<Compound>(_templateCompound.Id);
+
+         var setInTemplate = new OverwriteParameterSet {Name = "OPS 1"};
+         setInTemplate.Add(new ParameterValue {Path = $"{_templateCompound.Name}|Lipophilicity".ToObjectPath(), Value = 2});
+         _templateCompound.AddOverwriteParameterSet(setInTemplate);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateParametersFromSimulationInBuildingBlock(_simulation, _templateCompound);
+      }
+
+      [Observation]
+      public void should_have_added_the_set_only_defined_in_the_template_to_the_compound_of_the_simulation()
+      {
+         var setInSimulation = _simulationCompound.OverwriteParameterSets.FindByName("OPS 1");
+         setInSimulation.ShouldNotBeNull();
+         setInSimulation.ParameterValues.Single().Value.ShouldBeEqualTo(2);
       }
    }
 }


### PR DESCRIPTION
Fixes #3684
Follow-up from #3679, which introduced the comparison of overwrite parameter sets and the `ReplaceOverwriteParameterSetsInCompoundCommand` used here.

Committing simulation parameters writes the overwrite parameter set to the project compound only. Committing that compound then cleared the altered flag on the used building block - asserting that the two compounds are identical - while the set was still missing from the simulation's copy, so the compound turned green and the comparison kept reporting the set as missing.

`SimulationParametersToBuildingBlockUpdater` now brings the project compound's sets into the simulation's copy, the way `BuildingBlockParametersToSimulationUpdater` already does on the update path, just before the used building block info is synchronized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Overwrite parameter sets defined in template compounds are now synchronized with their corresponding simulation compounds.
  * Updating building blocks now correctly preserves template-defined parameter overrides.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->