### PR TITLE
Fixes #3677 Building blocks converted again and again on every project open

### DIFF
--- a/src/PKSim.Presentation/Services/ProjectTask.cs
+++ b/src/PKSim.Presentation/Services/ProjectTask.cs
@@ -346,7 +346,7 @@ namespace PKSim.Presentation.Services
             // which is not loaded but AFTER the deserialization.
             // Ideally this should go down in the callstack, but we are getting a circular dependency issue.
             _workspace.Project.All<Individual>().Each(_lazyLoadTask.Load);
-            _workspace.Project.HasChanged = false;
+            resetProjectChangedState();
          }
 
          try
@@ -376,6 +376,16 @@ namespace PKSim.Presentation.Services
          {
             _executionContext.PublishEvent(new EnableUIEvent(_workspace.Project, _workspace.ProjectLoaded));
          }
+      }
+
+      private void resetProjectChangedState()
+      {
+         var project = _workspace.Project;
+         //loaded building blocks still flagged as changed were converted during the load and must remain flagged so that the conversion is saved
+         var convertedBuildingBlocks = project.All<IPKSimBuildingBlock>().Where(x => x.IsLoaded && x.HasChanged).ToList();
+         project.HasChanged = false;
+         convertedBuildingBlocks.Each(x => x.HasChanged = true);
+         project.HasChanged = convertedBuildingBlocks.Any();
       }
 
       private void checkFileExtension(string projectFile)

--- a/src/PKSim.Presentation/Services/ProjectTask.cs
+++ b/src/PKSim.Presentation/Services/ProjectTask.cs
@@ -383,6 +383,7 @@ namespace PKSim.Presentation.Services
          var project = _workspace.Project;
          //loaded building blocks still flagged as changed were converted during the load and must remain flagged so that the conversion is saved
          var convertedBuildingBlocks = project.All<IPKSimBuildingBlock>().Where(x => x.IsLoaded && x.HasChanged).ToList();
+         //this resets the HasChanged flag of ALL building blocks, hence the converted ones captured above need to be restored below
          project.HasChanged = false;
          convertedBuildingBlocks.Each(x => x.HasChanged = true);
          project.HasChanged = convertedBuildingBlocks.Any();

--- a/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ProjectTaskSpecs.cs
@@ -713,6 +713,82 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_opening_a_project_in_which_building_blocks_were_converted_from_an_older_version : concern_for_ProjectTask
+   {
+      private string _fileToOpen;
+      private Compound _convertedCompound;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _fileToOpen = "toto.pksim5";
+         FileHelper.FileExists = x => string.Equals(x, _fileToOpen);
+         _project = new PKSimProject();
+         _workspace.Project = _project;
+         _convertedCompound = new Compound {Name = "Converted compound", IsLoaded = true};
+         //simulates the conversion of the project to the current version taking place during the project load
+         A.CallTo(() => _workspace.OpenProject(_fileToOpen)).Invokes(x =>
+         {
+            _project.AddBuildingBlock(_convertedCompound);
+            _convertedCompound.HasChanged = true;
+            _project.HasChanged = true;
+         });
+      }
+
+      protected override Task Because()
+      {
+         sut.OpenProjectFrom(_fileToOpen);
+         return _completed;
+      }
+
+      [Observation]
+      public void should_keep_the_converted_building_block_flagged_as_changed_so_that_the_converted_content_is_persisted_with_the_next_save()
+      {
+         _convertedCompound.HasChanged.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_keep_the_project_flagged_as_changed_so_that_the_user_is_prompted_to_save_the_conversion()
+      {
+         _project.HasChanged.ShouldBeTrue();
+      }
+   }
+
+   public class When_opening_a_project_that_is_already_at_the_current_version : concern_for_ProjectTask
+   {
+      private string _fileToOpen;
+      private Compound _compound;
+
+      protected override async Task Context()
+      {
+         await base.Context();
+         _fileToOpen = "toto.pksim5";
+         FileHelper.FileExists = x => string.Equals(x, _fileToOpen);
+         _project = new PKSimProject();
+         _workspace.Project = _project;
+         _compound = new Compound {Name = "Compound", IsLoaded = true, HasChanged = false};
+         //simulates the loading process itself flagging the project as changed even though no conversion took place
+         A.CallTo(() => _workspace.OpenProject(_fileToOpen)).Invokes(x =>
+         {
+            _project.AddBuildingBlock(_compound);
+            _compound.HasChanged = false;
+            _project.HasChanged = true;
+         });
+      }
+
+      protected override Task Because()
+      {
+         sut.OpenProjectFrom(_fileToOpen);
+         return _completed;
+      }
+
+      [Observation]
+      public void should_not_flag_the_project_as_changed_so_that_the_user_is_not_prompted_to_save()
+      {
+         _project.HasChanged.ShouldBeFalse();
+      }
+   }
+
    public class When_opening_a_project_file_that_does_not_exist : concern_for_ProjectTask
    {
       private string _fileToOpen;


### PR DESCRIPTION
Fixes #3677

## Problem
Opening a pre-v13 project converts all building blocks correctly, but the conversion is never persisted: after save and reopen, the same building blocks are converted again, accumulating history entries on every open/save cycle.

## Cause
`ProjectTask.openProjectFromFile` unconditionally sets `Project.HasChanged = false` after the project is opened (introduced with #3293 to suppress a spurious save prompt). The `PKSimProject.HasChanged` setter cascades `false` into every building block, wiping the `HasChanged` flags that the converters set during deserialization. On save, a building block's content is only re-serialized when `IsLoaded && HasChanged`, so the stored old-version XML was never rewritten while the project row was stamped with the current version. Simulations were unaffected because they are lazy-loaded after the reset.

## Fix
Before resetting the project changed state, capture all loaded building blocks still flagged as changed (i.e. converted during the load), restore their flags after the reset, and keep the project flagged as changed when any conversion happened so the user is prompted to save. Opening a project already at the current version still resets the flag, preserving the fix for #3272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)