### PR TITLE
Fixes #3640 Reconfigure and run every converted simulation of the V12 test project

### DIFF
--- a/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
@@ -35,10 +35,7 @@ namespace PKSim.ProjectConverter.v13
       protected void LoadAll<TBuildingBlock>() where TBuildingBlock : class, IPKSimBuildingBlock =>
          All<TBuildingBlock>().Each(Load);
 
-      /// <summary>
-      ///    Every parameter the new absorption model added to the lumen of an individual. They are looked up by name
-      ///    rather than by path so the assertion does not depend on which segments a given species defines.
-      /// </summary>
+      //Looked up by name so the assertion does not depend on which segments a species defines
       protected void ShouldHaveTheNewLumenParameters(Individual individual)
       {
          var newLumenParameterNames = new[]
@@ -56,10 +53,7 @@ namespace PKSim.ProjectConverter.v13
          });
       }
 
-      /// <summary>
-      ///    The lumen pH of the lower intestine is a constant up to v12 and a distribution from v13 on. It is the clearest
-      ///    evidence that the definitions were taken over from the database rather than only the missing parameters.
-      /// </summary>
+      //The lumen pH turned from constant into distribution in v13, proving the definitions came from the database
       protected void ShouldHaveADistributedLumenPh(Individual individual)
       {
          var lumen = individual.Organism.GetSingleChildByName<IContainer>(CoreConstants.Organ.LUMEN);
@@ -69,8 +63,7 @@ namespace PKSim.ProjectConverter.v13
          (lowerJejunumPh != null).ShouldBeTrue($"individual '{individual.Name}' has no lumen pH in the lower jejunum");
          (lowerJejunumPh is IDistributedParameter).ShouldBeTrue($"the lumen pH of '{individual.Name}' is not distributed");
 
-         //The default individuals in the fixture never edited the pH, so it must follow its new distribution rather than
-         //stay pinned at the value it had as a constant before the conversion
+         //Unedited pH must follow the new distribution, not stay pinned at its old constant value
          lowerJejunumPh.IsFixedValue.ShouldBeFalse($"the unedited lumen pH of '{individual.Name}' was pinned to a value");
       }
 
@@ -194,11 +187,7 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   /// <summary>
-   ///    An individual that uses the Du Bois body-surface-area option rather than the default Mosteller must not end up
-   ///    with a second method in the same category, which would crash when the individual is mapped to a building block
-   ///    (as happens when a simulation is created or configured).
-   /// </summary>
+   //A second BSA method in the same category crashes the mapping to a building block
    public class When_converting_a_human_individual_that_uses_the_du_bois_body_surface_area_method : ContextForIntegration<Converter12To13>
    {
       private Individual _individual;
@@ -237,11 +226,7 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   /// <summary>
-   ///    No saved project fixture in the repository carries a meal event, so the event branch of the converter is
-   ///    exercised here against the real database template instead. A <see cref="PKSimEvent" /> is rebuilt from a clone of
-   ///    that template and then degraded to look like a project saved before v13, so the conversion has real work to do.
-   /// </summary>
+   //No project fixture carries a meal event, so one is rebuilt from the database template and degraded to pre-v13 state
    public abstract class concern_for_Converter12To13_events : ContextForIntegration<Converter12To13>
    {
       protected PKSimEvent _oldEvent;
@@ -254,8 +239,7 @@ namespace PKSim.ProjectConverter.v13
          _cloner = OSPSuite.Utility.Container.IoC.Resolve<ICloner>();
          var eventGroupRepository = OSPSuite.Utility.Container.IoC.Resolve<IEventGroupRepository>();
 
-         //Any meal that gained the new reset events works. Picking it from the repository keeps the test independent of a
-         //specific meal name
+         //Any meal that gained the new reset events works
          var mealTemplate = eventGroupRepository.All()
             .First(x => x.GetAllChildren<IContainer>(isResetEvent).Any());
 
@@ -268,10 +252,7 @@ namespace PKSim.ProjectConverter.v13
          sut.Convert(_oldEvent, ProjectVersions.V12);
       }
 
-      /// <summary>
-      ///    Rebuilds a <see cref="PKSimEvent" /> from a clone of the template, then strips one reset event and adds back the
-      ///    obsolete stop event so that the state matches a meal saved before the new oral absorption model.
-      /// </summary>
+      //Strips one reset event and adds back the obsolete stop event, like a meal saved before v13
       private PKSimEvent oldEventFrom(EventGroupBuilder template)
       {
          var oldEvent = new PKSimEvent {TemplateName = template.Name}.WithName(template.Name);
@@ -305,12 +286,7 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   /// <summary>
-   ///    End to end check of the v12 → v13 conversion against a real project provided for the new oral absorption model.
-   ///    The project carries several individuals and populations (healthy, diseased and animal) and a set of oral
-   ///    particle-dissolution simulations with all meals plus the gallbladder and urinary bladder emptying events, and one
-   ///    large-molecule IV simulation. The acceptance criteria come from the model owner.
-   /// </summary>
+   //End to end check against the real v12 project provided by the model owner
    public abstract class concern_for_Converter12To13_with_the_test_project : ContextWithLoadedProject<Converter12To13>
    {
       protected IEntityPathResolver _entityPathResolver;
@@ -322,8 +298,7 @@ namespace PKSim.ProjectConverter.v13
          LoadProject("V12_TestProject");
       }
 
-      //The lumen pH parameters are the only user facing parameters redefined by the new model, so they are the ones the
-      //conversion has to carry over unchanged. Every segment uses "pH" except the stomach, which uses "pH in fasted state".
+      //Every segment uses "pH" except the stomach, which uses "pH in fasted state"
       protected IParameter LumenPhParameterIn(ISimulationSubject simulationSubject, string segment)
       {
          var parameterName = segment == CoreConstants.Organ.STOMACH
@@ -333,10 +308,7 @@ namespace PKSim.ProjectConverter.v13
          return simulationSubject.Individual.EntityAt<IParameter>(Constants.ORGANISM, CoreConstants.Organ.LUMEN, segment, parameterName);
       }
 
-      //Returns the error a run reported, or null when it succeeded. An individual simulation is run through the SimModel
-      //manager so the returned SimulationRunResults can be inspected directly: a solver failure sets Success to false and
-      //carries the error, which the higher level engine swallows. A population run raises an exception on failure, so it
-      //is run through the runner and the exception is captured.
+      //An individual run goes through the SimModel manager because the higher level engine swallows solver errors
       protected string RunErrorFor(Simulation simulation)
       {
          switch (simulation)
@@ -492,8 +464,7 @@ namespace PKSim.ProjectConverter.v13
       [Observation]
       public void should_have_added_the_new_compound_parameters()
       {
-         //These particle-dissolution parameters are new in v13 and were absent from the saved compounds. They are needed
-         //so that a value edited in a simulation can be committed back to the compound building block.
+         //New in v13, needed so a value edited in a simulation can be committed back to the compound
          var newCompoundParameterNames = new[] {"Surface integration factor", "Diffusion layer thickness exponent"};
 
          _allCompounds.Any().ShouldBeTrue();
@@ -503,9 +474,7 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   //Reconfigure: rebuild every model from the building blocks - a partial conversion fails here on an unresolved
-   //reference - then run it, so a defect that only surfaces when the model is solved is caught as well (issue 3640).
-   //Populations are trimmed to two individuals to keep the runs fast.
+   //An incomplete conversion fails the model rebuild, a wrong value the run (issue 3640)
    public class When_reconfiguring_and_running_the_converted_simulations_of_the_test_project : concern_for_Converter12To13_with_the_test_project
    {
       private ISimulationModelCreator _simulationModelCreator;
@@ -553,9 +522,7 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   //Builds a new simulation from the converted standalone building blocks (fresh model properties), not the copies
-   //stored inside a simulation, for the configuration of every simulation of the project, and runs it. A building
-   //block missing a new parameter fails the model construction, a wrong value surfaces when the model is solved.
+   //Uses the converted standalone building blocks, not the copies stored inside the simulations
    public class When_creating_and_running_new_simulations_from_the_converted_building_blocks_of_the_test_project : concern_for_Converter12To13_with_the_test_project
    {
       private IEventMappingFactory _eventMappingFactory;
@@ -599,9 +566,6 @@ namespace PKSim.ProjectConverter.v13
          Assert.IsTrue(errors.Count == 0, errors.ToString("\n"));
       }
 
-      //Rebuilds the configuration of the stored simulation from the standalone building blocks of the project: the same
-      //subject, compounds, protocols, formulation and events, on the same model with fresh default model properties -
-      //as a user would when creating a new simulation and picking the same building blocks.
       private Simulation createSimulationWithTheConfigurationOf(Simulation storedSimulation)
       {
          var subject = templateSubjectOf(storedSimulation);
@@ -650,8 +614,7 @@ namespace PKSim.ProjectConverter.v13
          return formulation;
       }
 
-      //The events are wired up as the simulation event configuration does it: the template as used building block and a
-      //mapping carrying the start time of the stored simulation
+      //The event resolves through a used building block keyed by the template id
       private void addTemplateEventsOf(Simulation storedSimulation, Simulation newSimulation)
       {
          foreach (var eventMapping in storedSimulation.EventProperties.EventMappings)

--- a/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
@@ -7,6 +7,7 @@ using System;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core;
@@ -331,6 +332,47 @@ namespace PKSim.ProjectConverter.v13
 
          return simulationSubject.Individual.EntityAt<IParameter>(Constants.ORGANISM, CoreConstants.Organ.LUMEN, segment, parameterName);
       }
+
+      //Returns the error a run reported, or null when it succeeded. An individual simulation is run through the SimModel
+      //manager so the returned SimulationRunResults can be inspected directly: a solver failure sets Success to false and
+      //carries the error, which the higher level engine swallows. A population run raises an exception on failure, so it
+      //is run through the runner and the exception is captured.
+      protected string RunErrorFor(Simulation simulation)
+      {
+         switch (simulation)
+         {
+            case IndividualSimulation individualSimulation:
+               var modelCoreSimulation = OSPSuite.Utility.Container.IoC.Resolve<ISimulationToModelCoreSimulationMapper>().MapFrom(individualSimulation, shouldCloneModel: false);
+               var runResults = OSPSuite.Utility.Container.IoC.Resolve<ISimModelManager>().RunSimulation(modelCoreSimulation);
+               return runResults.Success ? null : errorFrom(runResults);
+
+            case PopulationSimulation populationSimulation:
+               try
+               {
+                  OSPSuite.Utility.Container.IoC.Resolve<ISimulationRunner>().RunSimulation(populationSimulation).Wait();
+                  return populationSimulation.HasResults ? null : "produced no results";
+               }
+               catch (Exception e)
+               {
+                  return (e.InnerException ?? e).Message;
+               }
+
+            default:
+               return null;
+         }
+      }
+
+      private static string errorFrom(SimulationRunResults runResults) =>
+         string.IsNullOrEmpty(runResults.Error)
+            ? $"solver failed with {runResults.Warnings.Count()} warning(s)"
+            : runResults.Error;
+
+      //The run uses as many individuals as there are ids, so trimming the ids is enough to keep it fast
+      protected static void ReduceToTwoIndividuals(PopulationSimulation simulation)
+      {
+         var individualIds = simulation.Population.IndividualValuesCache.IndividualIds;
+         individualIds.Skip(2).ToList().Each(x => individualIds.Remove(x));
+      }
    }
 
    public class When_converting_the_modified_individual_of_the_test_project : concern_for_Converter12To13_with_the_test_project
@@ -461,9 +503,10 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   //Reconfigure: rebuild every model from the building blocks. A partial conversion fails here on an unresolved
-   //reference, so there is no need to run - which for all twelve would be far too slow.
-   public class When_reconfiguring_the_converted_simulations_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   //Reconfigure: rebuild every model from the building blocks - a partial conversion fails here on an unresolved
+   //reference - then run it, so a defect that only surfaces when the model is solved is caught as well (issue 3640).
+   //Populations are trimmed to two individuals to keep the runs fast.
+   public class When_reconfiguring_and_running_the_converted_simulations_of_the_test_project : concern_for_Converter12To13_with_the_test_project
    {
       private ISimulationModelCreator _simulationModelCreator;
       private List<Simulation> _allSimulations;
@@ -477,7 +520,7 @@ namespace PKSim.ProjectConverter.v13
       }
 
       [Observation]
-      public void should_rebuild_the_model_of_every_converted_simulation()
+      public void should_rebuild_the_model_of_every_converted_simulation_and_run_it()
       {
          _allSimulations.Any().ShouldBeTrue();
 
@@ -486,11 +529,21 @@ namespace PKSim.ProjectConverter.v13
          {
             try
             {
+               if (simulation is PopulationSimulation populationSimulation)
+                  ReduceToTwoIndividuals(populationSimulation);
+
                _simulationModelCreator.CreateModelFor(simulation);
                if (simulation.Model?.Root == null)
+               {
                   errors.Add($"{simulation.Name}: no model was built");
+                  continue;
+               }
+
+               var error = RunErrorFor(simulation);
+               if (error != null)
+                  errors.Add($"{simulation.Name}: {error}");
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                errors.Add($"{simulation.Name}: {(e.InnerException ?? e).Message}");
             }
@@ -500,58 +553,118 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
-   //One population is run to prove a rebuilt model still solves; the reconfigure test already covers every model.
-   public class When_running_a_converted_population_simulation_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   //Builds a new simulation from the converted standalone building blocks (fresh model properties), not the copies
+   //stored inside a simulation, for the configuration of every simulation of the project, and runs it. A building
+   //block missing a new parameter fails the model construction, a wrong value surfaces when the model is solved.
+   public class When_creating_and_running_new_simulations_from_the_converted_building_blocks_of_the_test_project : concern_for_Converter12To13_with_the_test_project
    {
-      private PopulationSimulation _simulation;
+      private IEventMappingFactory _eventMappingFactory;
+      private List<Simulation> _allSimulations;
 
       public override void GlobalContext()
       {
          base.GlobalContext();
-         _simulation = FindByName<PopulationSimulation>("11_Pop_01_Human_Default_Healthy");
-         reduceToTwoIndividuals(_simulation);
-         OSPSuite.Utility.Container.IoC.Resolve<ISimulationModelCreator>().CreateModelFor(_simulation);
-      }
-
-      protected override void Because()
-      {
-         OSPSuite.Utility.Container.IoC.Resolve<ISimulationRunner>().RunSimulation(_simulation).Wait();
+         _eventMappingFactory = OSPSuite.Utility.Container.IoC.Resolve<IEventMappingFactory>();
+         _allSimulations = All<Simulation>();
+         _allSimulations.Each(Load);
       }
 
       [Observation]
-      public void should_have_produced_results_for_the_two_individuals()
+      public void should_create_and_run_a_new_simulation_for_the_configuration_of_every_simulation_of_the_project()
       {
-         _simulation.HasResults.ShouldBeTrue();
-         _simulation.Results.Count.ShouldBeEqualTo(2);
+         _allSimulations.Any().ShouldBeTrue();
+
+         var errors = new List<string>();
+         foreach (var storedSimulation in _allSimulations)
+         {
+            try
+            {
+               var newSimulation = createSimulationWithTheConfigurationOf(storedSimulation);
+               if (newSimulation.Model?.Root == null)
+               {
+                  errors.Add($"{storedSimulation.Name}: no model was built");
+                  continue;
+               }
+
+               var error = RunErrorFor(newSimulation);
+               if (error != null)
+                  errors.Add($"{storedSimulation.Name}: {error}");
+            }
+            catch (Exception e)
+            {
+               errors.Add($"{storedSimulation.Name}: {(e.InnerException ?? e).Message}");
+            }
+         }
+
+         Assert.IsTrue(errors.Count == 0, errors.ToString("\n"));
       }
 
-      //The run uses as many individuals as there are ids, so trimming the ids is enough to keep it fast
-      private static void reduceToTwoIndividuals(PopulationSimulation simulation)
+      //Rebuilds the configuration of the stored simulation from the standalone building blocks of the project: the same
+      //subject, compounds, protocols, formulation and events, on the same model with fresh default model properties -
+      //as a user would when creating a new simulation and picking the same building blocks.
+      private Simulation createSimulationWithTheConfigurationOf(Simulation storedSimulation)
       {
-         var individualIds = simulation.Population.IndividualValuesCache.IndividualIds;
-         individualIds.Skip(2).ToList().Each(x => individualIds.Remove(x));
-      }
-   }
+         var subject = templateSubjectOf(storedSimulation);
+         var compounds = storedSimulation.CompoundPropertiesList.Select(x => FindByName<Compound>(x.Compound.Name)).ToList();
+         var protocols = storedSimulation.CompoundPropertiesList.Select(templateProtocolOf).ToList();
+         var formulation = templateFormulationOf(storedSimulation);
+         var modelProperties = DomainFactoryForSpecs.CreateModelPropertiesFor(subject, storedSimulation.ModelConfiguration.ModelName);
 
-   //Builds a new oral simulation from the converted standalone building blocks (fresh model properties), not the copies
-   //stored inside a simulation. A building block missing a new parameter fails the model construction.
-   public class When_creating_a_new_oral_simulation_from_the_converted_building_blocks_of_the_test_project : concern_for_Converter12To13_with_the_test_project
-   {
-      private Simulation _simulation;
+         var newSimulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(subject, compounds, protocols, modelProperties, storedSimulation.AllowAging, formulation);
+         addTemplateEventsOf(storedSimulation, newSimulation);
 
-      protected override void Because()
-      {
-         var individual = FindByName<Individual>("01_Human_Default_Healthy");
-         var compound = FindByName<Compound>("C1");
-         var protocol = FindByName<Protocol>("Oral_BD");
-         var formulation = FindByName<Formulation>("Particles_2Bin");
-         _simulation = DomainFactoryForSpecs.CreateSimulationWith(individual, compound, protocol, formulation);
+         if (newSimulation is PopulationSimulation populationSimulation)
+            ReduceToTwoIndividuals(populationSimulation);
+
+         DomainFactoryForSpecs.AddModelToSimulation(newSimulation);
+         return newSimulation;
       }
 
-      [Observation]
-      public void should_have_built_a_model_from_the_converted_building_blocks()
+      private ISimulationSubject templateSubjectOf(Simulation storedSimulation)
       {
-         (_simulation.Model?.Root != null).ShouldBeTrue();
+         var usedSubject = storedSimulation.UsedBuildingBlocksInSimulation<Population>().FirstOrDefault()
+                           ?? storedSimulation.UsedBuildingBlocksInSimulation<Individual>().First();
+
+         var subject = _project.BuildingBlockById<ISimulationSubject>(usedSubject.TemplateId);
+         Load(subject);
+         return subject;
+      }
+
+      private Protocol templateProtocolOf(CompoundProperties compoundProperties)
+      {
+         var protocol = compoundProperties.ProtocolProperties.Protocol;
+         return protocol == null ? null : FindByName<Protocol>(protocol.Name);
+      }
+
+      private Formulation templateFormulationOf(Simulation storedSimulation)
+      {
+         var formulationMapping = storedSimulation.CompoundPropertiesList
+            .SelectMany(x => x.ProtocolProperties.FormulationMappings)
+            .FirstOrDefault();
+
+         if (formulationMapping == null)
+            return null;
+
+         var formulation = _project.BuildingBlockById<Formulation>(formulationMapping.TemplateFormulationId);
+         Load(formulation);
+         return formulation;
+      }
+
+      //The events are wired up as the simulation event configuration does it: the template as used building block and a
+      //mapping carrying the start time of the stored simulation
+      private void addTemplateEventsOf(Simulation storedSimulation, Simulation newSimulation)
+      {
+         foreach (var eventMapping in storedSimulation.EventProperties.EventMappings)
+         {
+            var templateEvent = _project.BuildingBlockById<PKSimEvent>(eventMapping.TemplateEventId);
+            Load(templateEvent);
+
+            var newEventMapping = _eventMappingFactory.Create(templateEvent);
+            newEventMapping.StartTime.Value = eventMapping.StartTime.Value;
+
+            newSimulation.AddUsedBuildingBlock(new UsedBuildingBlock(templateEvent.Id, PKSimBuildingBlockType.Event) {BuildingBlock = templateEvent});
+            newSimulation.EventProperties.AddEventMapping(newEventMapping);
+         }
       }
    }
 


### PR DESCRIPTION
## What

Extends the v13 conversion integration tests to the full matrix requested in #3640:

- **Reconfigure and run** every simulation of `V12_TestProject.pksim5` — the model is rebuilt from the simulation's converted building blocks (where an incomplete conversion surfaces as an unresolved reference) and then solved, so a defect that only shows at solve time is caught as well.
- **Create and run a new simulation** from the converted standalone building blocks for the configuration of every simulation of the project: same subject, compounds, protocols, formulation and events, on the same model with fresh default model properties — as a user would when creating a new simulation and picking the same building blocks.

These two classes replace the previous reconfigure-only test, the single population run and the single new-simulation creation, which they subsume.

## Why

The reconfigure errors reported in #3640 were fixed by #3644 (missing model calculation methods), but the test coverage the issue asked for was only partially in place: nothing ran the reconfigured models, and only one of the twelve configurations was recreated from the standalone building blocks. See the [triage notes](https://github.com/Open-Systems-Pharmacology/PK-Sim/issues/3640#issuecomment-5336552289) for the full picture.

## How

- The run/trim helpers moved to the shared test-project context: individual simulations run through `ISimModelManager` so the returned `SimulationRunResults` can be inspected (the higher-level engine swallows solver errors), population runs surface failures as exceptions and are trimmed to two individuals to keep CI time reasonable.
- The new-simulation test wires events exactly as `EventBuildingBlockCreator` resolves them: the template event as used building block keyed by its template id, plus an `EventMapping` carrying the stored simulation's start time.

## Tests

The test project builds cleanly; the two new classes are running locally as this PR is opened (all twelve simulations are rebuilt and solved twice, which takes a while) — the local result will be reported in a comment, and CI verifies independently.

Fixes #3640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
