### PR TITLE
Fixes #3489 Add the event offset parameter to simple protocols saved before v13

### DIFF
--- a/src/PKSim.Core/Model/ProtocolFactory.cs
+++ b/src/PKSim.Core/Model/ProtocolFactory.cs
@@ -16,6 +16,7 @@ namespace PKSim.Core.Model
    {
       Protocol Create(ProtocolMode protocolMode);
       Protocol Create(ProtocolMode protocolMode, ApplicationType applicationType);
+      void AddEventOffsetParameterTo(SimpleProtocol protocol);
    }
 
    public class ProtocolFactory : IProtocolFactory
@@ -76,13 +77,19 @@ namespace PKSim.Core.Model
          }
 
          protocol.AddParameter(_parameterFactory.CreateFor(Constants.Parameters.END_TIME, CoreConstants.DEFAULT_PROTOCOL_END_TIME_IN_MIN, Constants.Dimension.TIME, PKSimBuildingBlockType.Protocol));
+         AddEventOffsetParameterTo(protocol);
+
+         return protocol;
+      }
+
+      //Also used by the project converter to add the parameter to protocols saved before v13
+      public void AddEventOffsetParameterTo(SimpleProtocol protocol)
+      {
          var eventOffsetParameter = _parameterFactory.CreateFor(CoreConstants.Parameters.EVENT_OFFSET, 0, Constants.Dimension.TIME, PKSimBuildingBlockType.Protocol);
          eventOffsetParameter.Info.MinValue = null;
          eventOffsetParameter.Info.MinIsAllowed = true;
          eventOffsetParameter.Visible = false;
          protocol.AddParameter(eventOffsetParameter);
-
-         return protocol;
       }
 
       private AdvancedProtocol createAdvancedProtocol(ApplicationType applicationType)

--- a/src/PKSim.Infrastructure/ProjectConverter/v13/Converter12To13.cs
+++ b/src/PKSim.Infrastructure/ProjectConverter/v13/Converter12To13.cs
@@ -25,6 +25,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
       IVisitor<Compound>,
       IVisitor<Formulation>,
       IVisitor<PKSimEvent>,
+      IVisitor<SimpleProtocol>,
       IVisitor<Simulation>
    {
       private readonly CoreConverter121To130 _coreConverter;
@@ -34,6 +35,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
       private readonly ITemplateStructureUpdater _templateStructureUpdater;
       private readonly IIndividualCalculationMethodsUpdater _individualCalculationMethodsUpdater;
       private readonly IPopulationParameterValuesUpdater _populationParameterValuesUpdater;
+      private readonly IProtocolFactory _protocolFactory;
       private readonly ICloner _cloner;
       private readonly Lazy<Compound> _templateCompound;
       private bool _converted;
@@ -47,6 +49,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
          ITemplateStructureUpdater templateStructureUpdater,
          IIndividualCalculationMethodsUpdater individualCalculationMethodsUpdater,
          IPopulationParameterValuesUpdater populationParameterValuesUpdater,
+         IProtocolFactory protocolFactory,
          ICloner cloner)
       {
          _coreConverter = coreConverter;
@@ -56,6 +59,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
          _templateStructureUpdater = templateStructureUpdater;
          _individualCalculationMethodsUpdater = individualCalculationMethodsUpdater;
          _populationParameterValuesUpdater = populationParameterValuesUpdater;
+         _protocolFactory = protocolFactory;
          _cloner = cloner;
          //The compound template is the same for every compound, so it is built once and reused
          _templateCompound = new Lazy<Compound>(compoundFactory.Create);
@@ -86,6 +90,8 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
 
       public void Visit(PKSimEvent pkSimEvent) => convertEvent(pkSimEvent);
 
+      public void Visit(SimpleProtocol protocol) => convertProtocol(protocol);
+
       public void Visit(Simulation simulation) => convertSimulation(simulation);
 
       private void convertSimulation(Simulation simulation)
@@ -99,6 +105,7 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
          simulation.Compounds.Each(convertCompound);
          simulation.AllBuildingBlocks<Formulation>().Each(convertFormulation);
          simulation.AllBuildingBlocks<PKSimEvent>().Each(convertEvent);
+         simulation.AllBuildingBlocks<Protocol>().OfType<SimpleProtocol>().Each(convertProtocol);
 
          //Last, once the converted individual's calculation methods have flowed into the model properties
          _individualCalculationMethodsUpdater.AddMissingModelCalculationMethodsTo(simulation);
@@ -198,6 +205,16 @@ namespace PKSim.Infrastructure.ProjectConverter.v13
                   _converted = true;
             }
          }
+      }
+
+      //The event offset was introduced in v13, where only the factory adds it to newly created protocols
+      private void convertProtocol(SimpleProtocol protocol)
+      {
+         if (protocol == null || protocol.EventOffsetParameter != null)
+            return;
+
+         _protocolFactory.AddEventOffsetParameterTo(protocol);
+         _converted = true;
       }
 
       private void convertFormulation(Formulation formulation)

--- a/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
+++ b/tests/PKSim.Tests/ProjectConverter/v13/Converter12To13Specs.cs
@@ -286,6 +286,69 @@ namespace PKSim.ProjectConverter.v13
       }
    }
 
+   //The event offset was introduced in v13, so a protocol saved before lacks the parameter (issue 3489)
+   public abstract class concern_for_Converter12To13_protocols : ContextForIntegration<Converter12To13>
+   {
+      protected SimpleProtocol _protocol;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var protocolFactory = OSPSuite.Utility.Container.IoC.Resolve<IProtocolFactory>();
+         _protocol = protocolFactory.Create(ProtocolMode.Simple, ApplicationTypes.Oral).DowncastTo<SimpleProtocol>().WithName("Old protocol");
+      }
+
+      protected override void Because()
+      {
+         sut.Convert(_protocol, ProjectVersions.V12);
+      }
+
+      protected void ShouldHaveASingleWellDefinedEventOffsetParameter()
+      {
+         _protocol.GetChildren<IParameter>(x => x.IsNamed(CoreConstants.Parameters.EVENT_OFFSET)).Count().ShouldBeEqualTo(1);
+
+         var parameter = _protocol.EventOffsetParameter;
+         parameter.ShouldNotBeNull();
+         parameter.Value.ShouldBeEqualTo(0d);
+         parameter.Visible.ShouldBeFalse();
+         parameter.Dimension.Name.ShouldBeEqualTo(Constants.Dimension.TIME);
+         parameter.Info.MinValue.ShouldBeNull();
+         parameter.Info.MinIsAllowed.ShouldBeTrue();
+      }
+   }
+
+   public class When_converting_a_simple_protocol_saved_before_the_event_offset_parameter_existed : concern_for_Converter12To13_protocols
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _protocol.RemoveChild(_protocol.EventOffsetParameter);
+      }
+
+      [Observation]
+      public void should_have_added_the_event_offset_parameter_with_the_same_definition_as_a_new_protocol() =>
+         ShouldHaveASingleWellDefinedEventOffsetParameter();
+   }
+
+   public class When_converting_a_simple_protocol_that_already_has_the_event_offset_parameter : concern_for_Converter12To13_protocols
+   {
+      private IParameter _existingParameter;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _existingParameter = _protocol.EventOffsetParameter;
+      }
+
+      [Observation]
+      public void should_have_left_the_existing_parameter_untouched() =>
+         _protocol.EventOffsetParameter.ShouldBeEqualTo(_existingParameter);
+
+      [Observation]
+      public void should_not_have_created_a_duplicate() =>
+         ShouldHaveASingleWellDefinedEventOffsetParameter();
+   }
+
    //End to end check against the real v12 project provided by the model owner
    public abstract class concern_for_Converter12To13_with_the_test_project : ContextWithLoadedProject<Converter12To13>
    {
@@ -471,6 +534,44 @@ namespace PKSim.ProjectConverter.v13
          _allCompounds.Each(compound =>
             newCompoundParameterNames.Each(name =>
                (compound.Parameter(name) != null).ShouldBeTrue($"'{name}' was not added to compound '{compound.Name}'")));
+      }
+   }
+
+   public class When_converting_the_protocols_of_the_test_project : concern_for_Converter12To13_with_the_test_project
+   {
+      private List<SimpleProtocol> _allSimpleProtocols;
+      private List<Simulation> _allSimulations;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         All<Protocol>().Each(Load);
+         _allSimulations = All<Simulation>();
+         _allSimulations.Each(Load);
+         _allSimpleProtocols = All<Protocol>().OfType<SimpleProtocol>().ToList();
+      }
+
+      [Observation]
+      public void should_have_added_the_event_offset_parameter_to_every_simple_protocol()
+      {
+         _allSimpleProtocols.Any().ShouldBeTrue();
+         _allSimpleProtocols.Each(shouldHaveTheEventOffsetParameter);
+      }
+
+      //A simulation carries its own copies of the protocols, so they need the parameter too
+      [Observation]
+      public void should_have_added_the_event_offset_parameter_to_the_protocols_of_every_simulation()
+      {
+         var simulationProtocols = _allSimulations.SelectMany(x => x.AllBuildingBlocks<Protocol>()).OfType<SimpleProtocol>().ToList();
+         simulationProtocols.Any().ShouldBeTrue();
+         simulationProtocols.Each(shouldHaveTheEventOffsetParameter);
+      }
+
+      private static void shouldHaveTheEventOffsetParameter(SimpleProtocol protocol)
+      {
+         (protocol.EventOffsetParameter != null).ShouldBeTrue($"'{protocol.Name}' has no event offset parameter");
+         protocol.EventOffsetParameter.Value.ShouldBeEqualTo(0d);
+         protocol.EventOffsetParameter.Visible.ShouldBeFalse();
       }
    }
 


### PR DESCRIPTION
Fixes #3489

## Problem
`Converter12To13` never visits protocols, so a `SimpleProtocol` from a pre-v13 project permanently lacks the `EVENT_OFFSET` parameter that `ProtocolFactory` only adds to newly created protocols. Enabling the new event feature on such a converted protocol showed an inert "Event offset" field (bound to a `NullParameterDTO`) and simulations silently used an offset of 0. Contrary to the original report, no null crash exists — all consumers are null-tolerant — but the feature was half-broken on converted protocols.

## Fix
- `ProtocolFactory.AddEventOffsetParameterTo(SimpleProtocol)` is now part of `IProtocolFactory`, so the factory and the converter share one definition of the parameter (value 0, time dimension, no minimum, hidden).
- `Converter12To13` visits `SimpleProtocol` building blocks and the copies each simulation carries, adding the parameter when missing (idempotent, flags the conversion).

## Tests
- Unit: converting a degraded pre-v13 protocol restores the parameter with the factory definition; converting a protocol that already has it changes nothing.
- Integration: every simple protocol of the V12 test project — standalone and simulation-owned — carries the parameter after conversion.

Targeted specs are green; the full v13 converter suite (including the reconfigure-and-run specs) is running and results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
