### PR TITLE
Fixes #3680 OPS: Unit and value origin of committed parameters are not shown in compound

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -291,6 +291,12 @@ namespace PKSim.Assets
          public static string UpdateParameterValueInOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
             $"Update value of '{parameterPath}' in {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 
+         public static string UpdateParameterValueUnitInOverwriteParameterSet(string parameterPath, string displayValue, string oldUnit, string newUnit, string overwriteParameterSetName, string compoundName) =>
+            $"Value of '{parameterPath}' in {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}' set from '{displayValue} {oldUnit}' to '{displayValue} {newUnit}'";
+
+         public static string UpdateValueOriginInOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
+            $"Update value origin of '{parameterPath}' in {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
+
          public static string RemoveParameterValueFromOverwriteParameterSet(string parameterPath, string overwriteParameterSetName, string compoundName) =>
             $"Remove '{parameterPath}' from {ObjectTypes.OverwriteParameterSet.ToLower()} '{overwriteParameterSetName}' of {ObjectTypes.Compound.ToLower()} '{compoundName}'";
 

--- a/src/PKSim.Core/Commands/UpdateParameterValueUnitInOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/UpdateParameterValueUnitInOverwriteSetCommand.cs
@@ -1,0 +1,71 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Format;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+/// <summary>
+///    Changes the display unit of a parameter value in an <see cref="OverwriteParameterSet" />. As for a parameter, the
+///    displayed number is kept and the value in base unit is recalculated, so switching '2 mm' to cm yields '2 cm'.
+/// </summary>
+public class UpdateParameterValueUnitInOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private static readonly NumericFormatter<double> _numericFormatter = new(NumericFormatterOptions.Instance);
+
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private readonly string _parameterPath;
+   private readonly string _newUnitName;
+   private string _oldUnitName;
+
+   public UpdateParameterValueUnitInOverwriteSetCommand(
+      OverwriteParameterSet overwriteParameterSet,
+      Compound compound,
+      string parameterPath,
+      string newUnitName)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      _parameterPath = parameterPath;
+      _newUnitName = newUnitName;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+      var parameterValue = _overwriteParameterSet.ParameterValueByPath(_parameterPath);
+      var oldDisplayUnit = parameterValue.DisplayUnit;
+      _oldUnitName = oldDisplayUnit.Name;
+
+      var newDisplayUnit = parameterValue.Dimension.Unit(_newUnitName);
+      var displayValue = parameterValue.ConvertToDisplayUnit(parameterValue.Value);
+
+      parameterValue.DisplayUnit = newDisplayUnit;
+      parameterValue.Value = parameterValue.Dimension.UnitValueToBaseUnitValue(newDisplayUnit, displayValue);
+
+      Description = PKSimConstants.Command.UpdateParameterValueUnitInOverwriteParameterSet(_parameterPath, _numericFormatter.Format(displayValue),
+         oldDisplayUnit.Name, newDisplayUnit.Name, _overwriteParameterSet.Name, _buildingBlock.Name);
+
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+      new UpdateParameterValueUnitInOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _parameterPath, _oldUnitName).AsInverseFor(this);
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+}

--- a/src/PKSim.Core/Commands/UpdateValueOriginInOverwriteSetCommand.cs
+++ b/src/PKSim.Core/Commands/UpdateValueOriginInOverwriteSetCommand.cs
@@ -1,0 +1,56 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using PKSim.Assets;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core.Commands;
+
+public class UpdateValueOriginInOverwriteSetCommand : BuildingBlockChangeCommand<Compound>
+{
+   private readonly string _overwriteParameterSetId;
+   private OverwriteParameterSet _overwriteParameterSet;
+   private readonly string _parameterPath;
+   private ValueOrigin _valueOrigin;
+   private ValueOrigin _oldValueOrigin;
+
+   public UpdateValueOriginInOverwriteSetCommand(
+      OverwriteParameterSet overwriteParameterSet,
+      Compound compound,
+      string parameterPath,
+      ValueOrigin valueOrigin)
+      : base(compound)
+   {
+      _overwriteParameterSet = overwriteParameterSet;
+      _overwriteParameterSetId = overwriteParameterSet.Id;
+      _parameterPath = parameterPath;
+      _valueOrigin = valueOrigin;
+      CommandType = PKSimConstants.Command.CommandTypeEdit;
+      Description = PKSimConstants.Command.UpdateValueOriginInOverwriteParameterSet(parameterPath, overwriteParameterSet.Name, compound.Name);
+   }
+
+   protected override void PerformExecuteWith(IExecutionContext context)
+   {
+      base.PerformExecuteWith(context);
+      var parameterValue = _overwriteParameterSet.ParameterValueByPath(_parameterPath);
+      _oldValueOrigin = parameterValue.ValueOrigin.Clone();
+      parameterValue.UpdateValueOriginFrom(_valueOrigin);
+      context.PublishEvent(new OverwriteParameterSetChangedEvent(_buildingBlock, _overwriteParameterSet));
+   }
+
+   protected override ICommand<IExecutionContext> GetInverseCommand(IExecutionContext context) =>
+      new UpdateValueOriginInOverwriteSetCommand(_overwriteParameterSet, _buildingBlock, _parameterPath, _oldValueOrigin).AsInverseFor(this);
+
+   protected override void ClearReferences()
+   {
+      base.ClearReferences();
+      _overwriteParameterSet = null;
+      _valueOrigin = null;
+   }
+
+   public override void RestoreExecutionData(IExecutionContext context)
+   {
+      base.RestoreExecutionData(context);
+      _overwriteParameterSet = context.Get<OverwriteParameterSet>(_overwriteParameterSetId);
+   }
+}

--- a/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
+++ b/src/PKSim.Core/Services/CommitSimulationParametersTask.cs
@@ -140,7 +140,7 @@ namespace PKSim.Core.Services
                if (parameter == null)
                   return null;
 
-               return new ParameterValue
+               var parameterValue = new ParameterValue
                {
                   Path = path.ToObjectPath(),
                   Value = parameter.Value,
@@ -148,6 +148,9 @@ namespace PKSim.Core.Services
                   DisplayUnit = parameter.DisplayUnit,
                   Info = parameter.Info.Clone()
                };
+
+               parameterValue.ValueOrigin.UpdateAllFrom(parameter.ValueOrigin);
+               return parameterValue;
             })
             .Where(pv => pv != null)
             .ToList();

--- a/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetTask.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
 using PKSim.Core.Commands;
 using PKSim.Core.Model;
@@ -15,6 +17,20 @@ public interface IOverwriteParameterSetTask
    ///    Returns an empty command if the parameter is not in the set or the value is unchanged.
    /// </summary>
    ICommand UpdateParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, double newValue);
+
+   /// <summary>
+   ///    Updates the display unit of a parameter (identified by path) in an <see cref="OverwriteParameterSet" />.
+   ///    As for a parameter, the displayed number is kept and the value in base unit is recalculated.
+   ///    Returns an empty command if the parameter is not in the set or the unit is unchanged.
+   /// </summary>
+   ICommand UpdateParameterValueUnit(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, Unit newUnit);
+
+   /// <summary>
+   ///    Updates the <see cref="ValueOrigin" /> of a parameter (identified by path) in an
+   ///    <see cref="OverwriteParameterSet" />.
+   ///    Returns an empty command if the parameter is not in the set or the value origin is unchanged.
+   /// </summary>
+   ICommand UpdateValueOrigin(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, ValueOrigin newValueOrigin);
 
    /// <summary>
    ///    Removes a parameter (identified by path) from an <see cref="OverwriteParameterSet" />.
@@ -56,6 +72,24 @@ public class OverwriteParameterSetTask : IOverwriteParameterSetTask
          return new PKSimEmptyCommand();
 
       return new UpdateParameterValueInOverwriteSetCommand(overwriteParameterSet, compound, parameterPath, newValue).Run(_executionContext);
+   }
+
+   public ICommand UpdateParameterValueUnit(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, Unit newUnit)
+   {
+      var existing = overwriteParameterSet.ParameterValueByPath(parameterPath);
+      if (existing == null || newUnit == null || Equals(existing.DisplayUnit, newUnit))
+         return new PKSimEmptyCommand();
+
+      return new UpdateParameterValueUnitInOverwriteSetCommand(overwriteParameterSet, compound, parameterPath, newUnit.Name).Run(_executionContext);
+   }
+
+   public ICommand UpdateValueOrigin(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath, ValueOrigin newValueOrigin)
+   {
+      var existing = overwriteParameterSet.ParameterValueByPath(parameterPath);
+      if (existing == null || Equals(existing.ValueOrigin, newValueOrigin))
+         return new PKSimEmptyCommand();
+
+      return new UpdateValueOriginInOverwriteSetCommand(overwriteParameterSet, compound, parameterPath, newValueOrigin).Run(_executionContext);
    }
 
    public ICommand RemoveParameterValue(OverwriteParameterSet overwriteParameterSet, Compound compound, string parameterPath)

--- a/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/ParameterValueMapper.cs
@@ -11,24 +11,30 @@ namespace PKSim.Core.Snapshots.Mappers;
 public class ParameterValueMapper : SnapshotMapperBase<ModelParameterValue, SnapshotParameterValue>
 {
    private readonly IDimensionRepository _dimensionRepository;
+   private readonly ValueOriginMapper _valueOriginMapper;
 
-   public ParameterValueMapper(IDimensionRepository dimensionRepository)
+   public ParameterValueMapper(IDimensionRepository dimensionRepository, ValueOriginMapper valueOriginMapper)
    {
       _dimensionRepository = dimensionRepository;
+      _valueOriginMapper = valueOriginMapper;
    }
 
-   public override Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
+   public override async Task<SnapshotParameterValue> MapToSnapshot(ModelParameterValue parameterValue)
    {
       //dimension, unit and allowed range are carried so the value can be displayed and validated in the compound,
       //where the parameter itself cannot be resolved
-      return SnapshotFrom(parameterValue, snapshot =>
+      var snapshot = await SnapshotFrom(parameterValue, x =>
       {
-         snapshot.Path = parameterValue.Path.ToString();
-         snapshot.Value = parameterValue.ConvertToDisplayUnit(parameterValue.Value);
-         snapshot.Dimension = dimensionNameFor(parameterValue);
-         snapshot.Unit = SnapshotValueFor(parameterValue.DisplayUnit.Name);
-         updateAllowedRange(snapshot, parameterValue);
+         x.Path = parameterValue.Path.ToString();
+         x.Value = parameterValue.ConvertToDisplayUnit(parameterValue.Value);
+         x.Dimension = dimensionNameFor(parameterValue);
+         x.Unit = SnapshotValueFor(parameterValue.DisplayUnit.Name);
+         updateAllowedRange(x, parameterValue);
       });
+
+      snapshot.ValueOrigin = await _valueOriginMapper.MapToSnapshot(parameterValue.ValueOrigin);
+
+      return snapshot;
    }
 
    public override Task<ModelParameterValue> MapToModel(SnapshotParameterValue snapshot, SnapshotContext snapshotContext)
@@ -44,6 +50,8 @@ public class ParameterValueMapper : SnapshotMapperBase<ModelParameterValue, Snap
          Value = dimension.UnitValueToBaseUnitValue(displayUnit, snapshot.Value),
          Info = allowedRangeFrom(snapshot, dimension, displayUnit)
       };
+
+      _valueOriginMapper.UpdateValueOrigin(parameterValue.ValueOrigin, snapshot.ValueOrigin);
 
       return Task.FromResult(parameterValue);
    }

--- a/src/PKSim.Core/Snapshots/ParameterValue.cs
+++ b/src/PKSim.Core/Snapshots/ParameterValue.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using ValueOrigin = OSPSuite.Core.Snapshots.ValueOrigin;
 
 namespace PKSim.Core.Snapshots;
 
@@ -21,4 +22,6 @@ public class ParameterValue
    public double? MaxValue { get; set; }
 
    public bool? MaxIsAllowed { get; set; }
+
+   public ValueOrigin ValueOrigin { get; set; }
 }

--- a/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterValueDTO.cs
+++ b/src/PKSim.Presentation/DTO/Compounds/OverwriteParameterValueDTO.cs
@@ -2,13 +2,14 @@ using System.Collections.Generic;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Utility.Format;
 using OSPSuite.Utility.Validation;
 
 namespace PKSim.Presentation.DTO.Compounds;
 
-public class OverwriteParameterValueDTO : DxValidatableDTO
+public class OverwriteParameterValueDTO : DxValidatableDTO, IWithDisplayUnitDTO, IWithValueOrigin
 {
    private static readonly NumericFormatter<double> _numericFormatter = new(NumericFormatterOptions.Instance);
 
@@ -24,9 +25,31 @@ public class OverwriteParameterValueDTO : DxValidatableDTO
 
    public double? Value => ParameterValue.Value.HasValue ? ParameterValue.ConvertToDisplayUnit(ParameterValue.Value) : null;
 
-   public string Unit => ParameterValue.DisplayUnit.Name;
+   public IDimension Dimension
+   {
+      get => ParameterValue.Dimension;
+      set { /*dimension is defined by the committed parameter and never edited*/ }
+   }
 
-   public string ValueOrigin => ParameterValue.ValueOrigin.Display;
+   public Unit DisplayUnit
+   {
+      get => ParameterValue.DisplayUnit;
+      set { /*nothing to do here since the unit should be set in the command*/ }
+   }
+
+   public IEnumerable<Unit> AllUnits
+   {
+      get => Dimension.Units;
+      set { /*all units are defined by the dimension*/ }
+   }
+
+   public ValueOrigin ValueOrigin
+   {
+      get => ParameterValue.ValueOrigin;
+      set { /*nothing to do here since the value origin should be set in the command*/ }
+   }
+
+   public void UpdateValueOriginFrom(ValueOrigin sourceValueOrigin) => ParameterValue.UpdateValueOriginFrom(sourceValueOrigin);
 
    public double ValueInBaseUnit(double valueInDisplayUnit) => ParameterValue.ConvertToBaseUnit(valueInDisplayUnit);
 
@@ -52,19 +75,19 @@ public class OverwriteParameterValueDTO : DxValidatableDTO
          if (info.MinValue.HasValue)
          {
             if (value < info.MinValue.Value)
-               return Validation.ValueBiggerThanMin(parameterName, dto.displayValueFor(info.MinValue), dto.Unit);
+               return Validation.ValueBiggerThanMin(parameterName, dto.displayValueFor(info.MinValue), dto.DisplayUnit.Name);
 
             if (value == info.MinValue.Value && !info.MinIsAllowed)
-               return Validation.ValueStrictBiggerThanMin(parameterName, dto.displayValueFor(info.MinValue), dto.Unit);
+               return Validation.ValueStrictBiggerThanMin(parameterName, dto.displayValueFor(info.MinValue), dto.DisplayUnit.Name);
          }
 
          if (info.MaxValue.HasValue)
          {
             if (value > info.MaxValue.Value)
-               return Validation.ValueSmallerThanMax(parameterName, dto.displayValueFor(info.MaxValue), dto.Unit);
+               return Validation.ValueSmallerThanMax(parameterName, dto.displayValueFor(info.MaxValue), dto.DisplayUnit.Name);
 
             if (value == info.MaxValue.Value && !info.MaxIsAllowed)
-               return Validation.ValueStrictSmallerThanMax(parameterName, dto.displayValueFor(info.MaxValue), dto.Unit);
+               return Validation.ValueStrictSmallerThanMax(parameterName, dto.displayValueFor(info.MaxValue), dto.DisplayUnit.Name);
          }
 
          return null;

--- a/src/PKSim.Presentation/DTO/Mappers/ParameterToParameterCommitDTOMapper.cs
+++ b/src/PKSim.Presentation/DTO/Mappers/ParameterToParameterCommitDTOMapper.cs
@@ -16,7 +16,9 @@ namespace PKSim.Presentation.DTO.Mappers
          {
             Path = path,
             DisplayPath = path,
-            Value = parameter?.Value ?? double.NaN
+            Value = parameter?.ValueInDisplayUnit ?? double.NaN,
+            Unit = parameter?.DisplayUnit?.Name,
+            ValueOrigin = parameter?.ValueOrigin?.Display
          };
       }
    }

--- a/src/PKSim.Presentation/DTO/Simulations/ParameterCommitDTO.cs
+++ b/src/PKSim.Presentation/DTO/Simulations/ParameterCommitDTO.cs
@@ -7,6 +7,8 @@ namespace PKSim.Presentation.DTO.Simulations
       public string Path { get; init; }
       public string DisplayPath { get; init; }
       public double Value { get; init; }
+      public string Unit { get; init; }
+      public string ValueOrigin { get; init; }
       public bool Selected { get; set; } = true;
    }
 }

--- a/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Compounds/OverwriteParameterSetsPresenter.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
@@ -20,6 +22,8 @@ namespace PKSim.Presentation.Presenters.Compounds;
 public interface IOverwriteParameterSetsPresenter : ICompoundItemPresenter, IListener<OverwriteParameterSetChangedEvent>, IListener<RenamedEvent>
 {
    void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValueInDisplayUnit);
+   void UpdateParameterValueUnit(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, Unit newUnit);
+   void UpdateValueOrigin(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, ValueOrigin newValueOrigin);
    void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO);
    void SetIsDefault(OverwriteParameterSetDTO setDTO, bool isDefault);
    void RemoveSet(OverwriteParameterSetDTO setDTO);
@@ -94,6 +98,12 @@ public class OverwriteParameterSetsPresenter : AbstractSubPresenter<IOverwritePa
    public void UpdateParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, double newValueInDisplayUnit) =>
       AddCommand(_overwriteParameterSetTask.UpdateParameterValue(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString,
          parameterValueDTO.ValueInBaseUnit(newValueInDisplayUnit)));
+
+   public void UpdateParameterValueUnit(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, Unit newUnit) =>
+      AddCommand(_overwriteParameterSetTask.UpdateParameterValueUnit(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString, newUnit));
+
+   public void UpdateValueOrigin(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO, ValueOrigin newValueOrigin) =>
+      AddCommand(_overwriteParameterSetTask.UpdateValueOrigin(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString, newValueOrigin));
 
    public void RemoveParameterValue(OverwriteParameterSetDTO setDTO, OverwriteParameterValueDTO parameterValueDTO) =>
       AddCommand(_overwriteParameterSetTask.RemoveParameterValue(setDTO.OverwriteParameterSet, _compound, parameterValueDTO.ParameterValue.Path.PathAsString));

--- a/src/PKSim.Presentation/Services/ValueWithUnitFormatter.cs
+++ b/src/PKSim.Presentation/Services/ValueWithUnitFormatter.cs
@@ -1,0 +1,17 @@
+using System;
+using OSPSuite.Utility.Format;
+
+namespace PKSim.Presentation.Services
+{
+   public class ValueWithUnitFormatter<TValue> : NumericFormatter<TValue>
+   {
+      private readonly Func<string> _displayUnitName;
+
+      public ValueWithUnitFormatter(Func<string> displayUnitName) : base(NumericFormatterOptions.Instance)
+      {
+         _displayUnitName = displayUnitName;
+      }
+
+      public override string Format(TValue valueToFormat) => $"{base.Format(valueToFormat)} {_displayUnitName()}".TrimEnd();
+   }
+}

--- a/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
+++ b/src/PKSim.UI/Views/Compounds/OverwriteParameterSetsView.cs
@@ -8,19 +8,21 @@ using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.Presentation.Extensions;
+using OSPSuite.UI.Binders;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.RepositoryItems;
 using OSPSuite.UI.Services;
 using OSPSuite.Utility.Extensions;
-using OSPSuite.Utility.Format;
 using PKSim.Assets;
 using PKSim.Presentation.DTO.Compounds;
 using PKSim.Presentation.Presenters.Compounds;
+using PKSim.Presentation.Services;
 using PKSim.Presentation.Views.Compounds;
 using PKSim.UI.Views.Core;
 using static OSPSuite.UI.UIConstants.Size;
@@ -33,6 +35,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
    private IOverwriteParameterSetsPresenter _presenter;
    private readonly IImageListRetriever _imageListRetriever;
+   private readonly ValueOriginBinder<OverwriteParameterValueDTO> _valueOriginBinder;
    private readonly GridViewBinder<OverwriteParameterSetDTO> _gridViewBinderSets;
    private readonly GridViewBinder<OverwriteParameterValueDTO> _gridViewBinderParameterValues;
    private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRemoveButtonRepository();
@@ -40,13 +43,15 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
    private readonly UxRepositoryItemCheckEdit _isDefaultRepository;
    private readonly UxRepositoryItemImageComboBox _speciesRepository;
    private readonly UxRepositoryItemImageComboBox _diseaseStateRepository;
+   private readonly UxComboBoxUnit<OverwriteParameterValueDTO> _unitControl;
    private readonly ToolTipController _metadataToolTipController = new();
    private readonly List<BaseEdit> _metadataEditors = new();
    private LayoutControlGroup _metadataGroup;
 
-   public OverwriteParameterSetsView(IImageListRetriever imageListRetriever)
+   public OverwriteParameterSetsView(IImageListRetriever imageListRetriever, ValueOriginBinder<OverwriteParameterValueDTO> valueOriginBinder)
    {
       _imageListRetriever = imageListRetriever;
+      _valueOriginBinder = valueOriginBinder;
       InitializeComponent();
 
       _gridViewBinderSets = new GridViewBinder<OverwriteParameterSetDTO>(gridViewSets)
@@ -60,6 +65,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       };
 
       _isDefaultRepository = new UxRepositoryItemCheckEdit(gridViewSets);
+      _unitControl = new UxComboBoxUnit<OverwriteParameterValueDTO>(gridParameterValues);
       _speciesRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
       _diseaseStateRepository = new UxRepositoryItemImageComboBox(gridViewSets, imageListRetriever);
 
@@ -73,6 +79,7 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
       gridViewSets.EditorShowMode = EditorShowMode.MouseDown;
 
       gridViewSets.FocusedRowChanged += (o, e) => OnEvent(selectedSetChanged);
+      gridViewParameterValues.HiddenEditor += (o, e) => _unitControl.Hide();
    }
 
    public void AttachPresenter(IOverwriteParameterSetsPresenter presenter)
@@ -118,16 +125,13 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
       _gridViewBinderParameterValues.Bind(x => x.Value)
          .WithCaption(Captions.Value)
-         .WithFormat(new NumericFormatter<double?>(NumericFormatterOptions.Instance))
+         .WithFormat(dto => new ValueWithUnitFormatter<double?>(() => dto.DisplayUnit.Name))
+         .WithEditorConfiguration((activeEditor, dto) => _unitControl.UpdateUnitsFor(activeEditor, dto))
          .WithOnValueUpdating((dto, e) => OnEvent(() => onParameterValueUpdating(dto, e.NewValue)));
 
-      _gridViewBinderParameterValues.Bind(x => x.Unit)
-         .WithCaption(Captions.Unit)
-         .AsReadOnly();
+      _unitControl.ParameterUnitSet += onUnitUpdating;
 
-      _gridViewBinderParameterValues.Bind(x => x.ValueOrigin)
-         .WithCaption(Captions.ValueOrigin)
-         .AsReadOnly();
+      _valueOriginBinder.InitializeBinding(_gridViewBinderParameterValues, onValueOriginUpdating);
 
       _gridViewBinderParameterValues.AddUnboundColumn()
          .WithCaption(Captions.EmptyColumn)
@@ -279,5 +283,27 @@ public partial class OverwriteParameterSetsView : BaseUserControl, IOverwritePar
 
       _presenter.UpdateParameterValue(selectedSet, dto, newValue.Value);
       gridViewParameterValues.CloseEditor();
+   }
+
+   private void onUnitUpdating(OverwriteParameterValueDTO dto, Unit newUnit)
+   {
+      OnEvent(() =>
+      {
+         var selectedSet = _gridViewBinderSets.FocusedElement;
+         if (selectedSet == null)
+            return;
+
+         gridViewParameterValues.CloseEditor();
+         _presenter.UpdateParameterValueUnit(selectedSet, dto, newUnit);
+      });
+   }
+
+   private void onValueOriginUpdating(OverwriteParameterValueDTO dto, ValueOrigin newValueOrigin)
+   {
+      var selectedSet = _gridViewBinderSets.FocusedElement;
+      if (selectedSet == null)
+         return;
+
+      OnEvent(() => _presenter.UpdateValueOrigin(selectedSet, dto, newValueOrigin));
    }
 }

--- a/src/PKSim.UI/Views/Simulations/CommitSimulationParametersView.cs
+++ b/src/PKSim.UI/Views/Simulations/CommitSimulationParametersView.cs
@@ -12,6 +12,7 @@ using OSPSuite.UI.Views;
 using PKSim.Assets;
 using PKSim.Presentation.DTO.Simulations;
 using PKSim.Presentation.Presenters.Simulations;
+using PKSim.Presentation.Services;
 using PKSim.Presentation.Views.Simulations;
 
 namespace PKSim.UI.Views.Simulations
@@ -65,7 +66,12 @@ namespace PKSim.UI.Views.Simulations
 
          _parameterGridBinder.Bind(x => x.Value)
             .WithCaption(PKSimConstants.UI.Value)
+            .WithFormat(dto => new ValueWithUnitFormatter<double>(() => dto.Unit))
             .WithFixedWidth(120)
+            .AsReadOnly();
+
+         _parameterGridBinder.Bind(x => x.ValueOrigin)
+            .WithCaption(Captions.ValueOrigin)
             .AsReadOnly();
 
          _screenBinder.Bind(x => x.NewSetName)

--- a/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/CommitSimulationParametersTaskSpecs.cs
@@ -46,6 +46,9 @@ namespace PKSim.Core
          _permeabilityParam.DisplayUnit = _permeabilityParam.Dimension.Unit("cm");
          _permeabilityParam.MinValue = 0;
          _permeabilityParam.MinIsAllowed = true;
+         _permeabilityParam.ValueOrigin.Id = 42;
+         _permeabilityParam.ValueOrigin.Source = ValueOriginSources.ParameterIdentification;
+         _permeabilityParam.ValueOrigin.Description = "Fitted to data";
 
          var root = new Container { Name = "Sim" };
          root.Add(_lipophilicityParam);
@@ -153,6 +156,16 @@ namespace PKSim.Core
          parameterValue.DisplayUnit.ShouldBeEqualTo(_permeabilityParam.DisplayUnit);
          parameterValue.Info.MinValue.ShouldBeEqualTo(_permeabilityParam.MinValue);
          parameterValue.Info.MinIsAllowed.ShouldBeEqualTo(_permeabilityParam.MinIsAllowed);
+      }
+
+      [Observation]
+      public void should_take_over_the_value_origin_of_the_committed_simulation_parameter()
+      {
+         var valueOrigin = _templateCompound.OverwriteParameterSets[0].ParameterValueByPath("Organism|Aspirin|Permeability").ValueOrigin;
+         valueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.ParameterIdentification);
+         valueOrigin.Description.ShouldBeEqualTo("Fitted to data");
+         //the id keeps the link to the value origin database entry, so it is not written to the snapshot again
+         valueOrigin.Id.ShouldBeEqualTo(42);
       }
    }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetMapperSpecs.cs
@@ -29,7 +29,7 @@ namespace PKSim.Core
       {
          _dimensionRepository = A.Fake<IDimensionRepository>();
          A.CallTo(() => _dimensionRepository.DimensionByName(A<string>._)).Returns(Constants.Dimension.NO_DIMENSION);
-         _parameterValueMapper = new ParameterValueMapper(_dimensionRepository);
+         _parameterValueMapper = new ParameterValueMapper(_dimensionRepository, valueOriginMapperForSpecs());
          _extendedPropertyMapper = new ExtendedPropertyMapper();
          _objectBaseFactory = A.Fake<IObjectBaseFactory>();
          A.CallTo(() => _objectBaseFactory.Create<ModelOverwriteParameterSet>()).ReturnsLazily(() => new ModelOverwriteParameterSet { Id = "NewSetId" });
@@ -47,6 +47,13 @@ namespace PKSim.Core
          _modelOverwriteParameterSet.Add(new ModelParameterValue { Path = "Compound|Solubility".ToObjectPath(), Value = 0.5 });
 
          return _completed;
+      }
+
+      protected static PKSim.Core.Snapshots.Mappers.ValueOriginMapper valueOriginMapperForSpecs()
+      {
+         var valueOriginRepository = A.Fake<IValueOriginRepository>();
+         A.CallTo(() => valueOriginRepository.FindBy(A<int?>._)).Returns(new OSPSuite.Core.Domain.ValueOrigin());
+         return new PKSim.Core.Snapshots.Mappers.ValueOriginMapper(valueOriginRepository);
       }
    }
 
@@ -96,7 +103,7 @@ namespace PKSim.Core
       {
          _dimensionRepository = A.Fake<IDimensionRepository>();
          A.CallTo(() => _dimensionRepository.DimensionByName(A<string>._)).Returns(Constants.Dimension.NO_DIMENSION);
-         _parameterValueMapper = new ParameterValueMapper(_dimensionRepository);
+         _parameterValueMapper = new ParameterValueMapper(_dimensionRepository, valueOriginMapperForSpecs());
          _extendedPropertyMapper = new ExtendedPropertyMapper();
          _objectBaseFactory = A.Fake<IObjectBaseFactory>();
          sut = new OverwriteParameterSetMapper(_parameterValueMapper, _extendedPropertyMapper, _objectBaseFactory);

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetTaskSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
@@ -85,6 +86,107 @@ public class When_updating_a_parameter_value_for_a_path_not_in_the_set : concern
    protected override void Because()
    {
       _result = sut.UpdateParameterValue(_overwriteParameterSet, _compound, "Organism|Aspirin|Permeability", 9.0);
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_updating_the_unit_of_a_parameter_value : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+   private IDimension _lengthDimension;
+   private ParameterValue _parameterValue;
+
+   protected override void Context()
+   {
+      base.Context();
+      _lengthDimension = DomainHelperForSpecs.LengthDimensionForSpecs();
+      _parameterValue = _overwriteParameterSet.ParameterValueByPath(_path);
+      _parameterValue.Dimension = _lengthDimension;
+      _parameterValue.DisplayUnit = _lengthDimension.Unit("cm");
+   }
+
+   protected override void Because()
+   {
+      _result = sut.UpdateParameterValueUnit(_overwriteParameterSet, _compound, _path, _lengthDimension.Unit("mm"));
+   }
+
+   [Observation]
+   public void should_keep_the_displayed_number_and_recalculate_the_value_in_base_unit()
+   {
+      _parameterValue.DisplayUnit.Name.ShouldBeEqualTo("mm");
+      _parameterValue.ConvertToDisplayUnit(_parameterValue.Value).ShouldBeEqualTo(100);
+      _parameterValue.Value.ShouldBeEqualTo(0.1);
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_updating_the_unit_of_a_parameter_value_with_the_unit_already_used : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+   private IDimension _lengthDimension;
+
+   protected override void Context()
+   {
+      base.Context();
+      _lengthDimension = DomainHelperForSpecs.LengthDimensionForSpecs();
+      var parameterValue = _overwriteParameterSet.ParameterValueByPath(_path);
+      parameterValue.Dimension = _lengthDimension;
+      parameterValue.DisplayUnit = _lengthDimension.Unit("cm");
+   }
+
+   protected override void Because()
+   {
+      _result = sut.UpdateParameterValueUnit(_overwriteParameterSet, _compound, _path, _lengthDimension.Unit("cm"));
+   }
+
+   [Observation]
+   public void should_return_an_empty_command()
+   {
+      _result.IsEmpty().ShouldBeTrue();
+   }
+}
+
+public class When_updating_the_value_origin_of_a_parameter_value : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.UpdateValueOrigin(_overwriteParameterSet, _compound, _path, new ValueOrigin { Source = ValueOriginSources.Publication, Description = "Some publication" });
+   }
+
+   [Observation]
+   public void should_update_the_value_origin_of_the_parameter_value()
+   {
+      var valueOrigin = _overwriteParameterSet.ParameterValueByPath(_path).ValueOrigin;
+      valueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Publication);
+      valueOrigin.Description.ShouldBeEqualTo("Some publication");
+   }
+
+   [Observation]
+   public void should_return_a_non_empty_command()
+   {
+      _result.IsEmpty().ShouldBeFalse();
+   }
+}
+
+public class When_updating_the_value_origin_of_a_parameter_value_with_the_value_origin_already_set : concern_for_OverwriteParameterSetTask
+{
+   private ICommand _result;
+
+   protected override void Because()
+   {
+      _result = sut.UpdateValueOrigin(_overwriteParameterSet, _compound, _path, _overwriteParameterSet.ParameterValueByPath(_path).ValueOrigin.Clone());
    }
 
    [Observation]

--- a/tests/PKSim.Tests/Core/ParameterValueMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterValueMapperSpecs.cs
@@ -30,7 +30,10 @@ namespace PKSim.Core
          A.CallTo(() => _dimensionRepository.DimensionByName(null)).Returns(Constants.Dimension.NO_DIMENSION);
 
          _snapshotContext = new SnapshotContext(new PKSimProject(), SnapshotVersions.Current);
-         sut = new ParameterValueMapper(_dimensionRepository);
+
+         var valueOriginRepository = A.Fake<IValueOriginRepository>();
+         A.CallTo(() => valueOriginRepository.FindBy(A<int?>._)).Returns(new OSPSuite.Core.Domain.ValueOrigin());
+         sut = new ParameterValueMapper(_dimensionRepository, new PKSim.Core.Snapshots.Mappers.ValueOriginMapper(valueOriginRepository));
 
          _parameterValue = new ModelParameterValue
          {
@@ -40,6 +43,8 @@ namespace PKSim.Core
             DisplayUnit = _dimension.Unit("cm"),
             Info = new ParameterInfo { MinValue = 0, MinIsAllowed = true, MaxValue = 0.2, MaxIsAllowed = false }
          };
+
+         _parameterValue.ValueOrigin.Description = "From literature";
 
          return _completed;
       }
@@ -83,6 +88,12 @@ namespace PKSim.Core
       {
          _snapshot.MinIsAllowed.ShouldBeNull();
          _snapshot.MaxIsAllowed.ShouldBeEqualTo(false);
+      }
+
+      [Observation]
+      public void should_map_the_value_origin()
+      {
+         _snapshot.ValueOrigin.Description.ShouldBeEqualTo("From literature");
       }
    }
 
@@ -174,6 +185,12 @@ namespace PKSim.Core
          _result.Info.MinIsAllowed.ShouldBeTrue();
          _result.Info.MaxValue.ShouldBeEqualTo(0.2);
          _result.Info.MaxIsAllowed.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_restore_the_value_origin()
+      {
+         _result.ValueOrigin.Description.ShouldBeEqualTo("From literature");
       }
    }
 

--- a/tests/PKSim.Tests/Core/UpdateParameterValueUnitInOverwriteSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/UpdateParameterValueUnitInOverwriteSetCommandSpecs.cs
@@ -1,0 +1,92 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Utility.Format;
+using PKSim.Core.Commands;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core;
+
+public abstract class concern_for_UpdateParameterValueUnitInOverwriteSetCommand : ContextSpecification<UpdateParameterValueUnitInOverwriteSetCommand>
+{
+   protected Compound _compound;
+   protected OverwriteParameterSet _overwriteParameterSet;
+   protected IExecutionContext _executionContext;
+   protected ParameterValue _existingPV;
+   protected IDimension _lengthDimension;
+   protected const string _path = "Organism|Aspirin|Radius";
+
+   protected override void Context()
+   {
+      _executionContext = A.Fake<IExecutionContext>();
+      _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+      _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
+      _lengthDimension = DomainHelperForSpecs.LengthDimensionForSpecs();
+
+      _existingPV = new ParameterValue
+      {
+         Path = _path.ToObjectPath(),
+         Value = 1.0,
+         Dimension = _lengthDimension,
+         DisplayUnit = _lengthDimension.Unit("cm")
+      };
+      _overwriteParameterSet.Add(_existingPV);
+      _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+      A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
+
+      sut = new UpdateParameterValueUnitInOverwriteSetCommand(_overwriteParameterSet, _compound, _path, "mm");
+   }
+}
+
+public class When_executing_the_update_parameter_value_unit_in_overwrite_set_command : concern_for_UpdateParameterValueUnitInOverwriteSetCommand
+{
+   protected override void Because()
+   {
+      sut.Execute(_executionContext);
+   }
+
+   [Observation]
+   public void should_keep_the_displayed_number_and_recalculate_the_value_in_base_unit()
+   {
+      //1 m displayed as 100 cm becomes 100 mm, so the base unit value drops to 0.1 m
+      _existingPV.DisplayUnit.Name.ShouldBeEqualTo("mm");
+      _existingPV.ConvertToDisplayUnit(_existingPV.Value).ShouldBeEqualTo(100);
+      _existingPV.Value.ShouldBeEqualTo(0.1);
+   }
+
+   [Observation]
+   public void should_describe_the_change_as_a_value_change()
+   {
+      //the same number appears on both sides: the unit change is a value change, not a re-display
+      var displayValue = new NumericFormatter<double>(NumericFormatterOptions.Instance).Format(100);
+      sut.Description.Contains($"from '{displayValue} cm' to '{displayValue} mm'").ShouldBeTrue();
+   }
+
+   [Observation]
+   public void should_publish_an_overwrite_parameter_set_changed_event()
+   {
+      A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
+   }
+}
+
+public class When_undoing_an_update_parameter_value_unit_in_overwrite_set_command : concern_for_UpdateParameterValueUnitInOverwriteSetCommand
+{
+   protected override void Because()
+   {
+      sut.ExecuteAndInvokeInverse(_executionContext);
+   }
+
+   [Observation]
+   public void should_restore_the_previous_display_unit_and_value()
+   {
+      _existingPV.DisplayUnit.Name.ShouldBeEqualTo("cm");
+      _existingPV.Value.ShouldBeEqualTo(1.0);
+   }
+}

--- a/tests/PKSim.Tests/Core/UpdateValueOriginInOverwriteSetCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/UpdateValueOriginInOverwriteSetCommandSpecs.cs
@@ -1,0 +1,75 @@
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using PKSim.Core.Commands;
+using PKSim.Core.Events;
+using PKSim.Core.Model;
+
+namespace PKSim.Core;
+
+public abstract class concern_for_UpdateValueOriginInOverwriteSetCommand : ContextSpecification<UpdateValueOriginInOverwriteSetCommand>
+{
+   protected Compound _compound;
+   protected OverwriteParameterSet _overwriteParameterSet;
+   protected IExecutionContext _executionContext;
+   protected ParameterValue _existingPV;
+   protected const string _path = "Organism|Aspirin|Lipophilicity";
+
+   protected override void Context()
+   {
+      _executionContext = A.Fake<IExecutionContext>();
+      _compound = new Compound { Name = "Aspirin", Id = "CompId" };
+      _overwriteParameterSet = new OverwriteParameterSet { Name = "MySet", Id = "SetId" };
+
+      _existingPV = new ParameterValue { Path = _path.ToObjectPath(), Value = 1.0 };
+      _existingPV.ValueOrigin.Source = ValueOriginSources.Unknown;
+      _existingPV.ValueOrigin.Description = "Old description";
+      _overwriteParameterSet.Add(_existingPV);
+      _compound.AddOverwriteParameterSet(_overwriteParameterSet);
+
+      A.CallTo(() => _executionContext.BuildingBlockContaining(_compound)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<Compound>(_compound.Id)).Returns(_compound);
+      A.CallTo(() => _executionContext.Get<OverwriteParameterSet>(_overwriteParameterSet.Id)).Returns(_overwriteParameterSet);
+
+      sut = new UpdateValueOriginInOverwriteSetCommand(_overwriteParameterSet, _compound, _path,
+         new ValueOrigin { Source = ValueOriginSources.Publication, Description = "New description" });
+   }
+}
+
+public class When_executing_the_update_value_origin_in_overwrite_set_command : concern_for_UpdateValueOriginInOverwriteSetCommand
+{
+   protected override void Because()
+   {
+      sut.Execute(_executionContext);
+   }
+
+   [Observation]
+   public void should_update_the_value_origin_of_the_parameter_value()
+   {
+      _existingPV.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Publication);
+      _existingPV.ValueOrigin.Description.ShouldBeEqualTo("New description");
+   }
+
+   [Observation]
+   public void should_publish_an_overwrite_parameter_set_changed_event()
+   {
+      A.CallTo(() => _executionContext.PublishEvent(A<OverwriteParameterSetChangedEvent>.That.Matches(x => x.Compound == _compound && x.OverwriteParameterSet == _overwriteParameterSet))).MustHaveHappened();
+   }
+}
+
+public class When_undoing_an_update_value_origin_in_overwrite_set_command : concern_for_UpdateValueOriginInOverwriteSetCommand
+{
+   protected override void Because()
+   {
+      sut.ExecuteAndInvokeInverse(_executionContext);
+   }
+
+   [Observation]
+   public void should_restore_the_previous_value_origin()
+   {
+      _existingPV.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Unknown);
+      _existingPV.ValueOrigin.Description.ShouldBeEqualTo("Old description");
+   }
+}

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterSetsPresenterSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using PKSim.Assets;
@@ -165,6 +166,56 @@ namespace PKSim.Presentation
       public void should_pass_the_value_converted_to_the_base_unit_to_the_overwrite_parameter_set_task()
       {
          A.CallTo(() => _task.UpdateParameterValue(_overwriteParameterSet, _compound, _path, 0.055)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_updating_the_unit_of_a_parameter_value_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+      private Unit _newUnit;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         _newUnit = DomainHelperForSpecs.LengthDimensionForSpecs().Unit("cm");
+         A.CallTo(() => _task.UpdateParameterValueUnit(_overwriteParameterSet, _compound, _path, _newUnit)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateParameterValueUnit(_setDTO, _valueDTO, _newUnit);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.UpdateParameterValueUnit(_overwriteParameterSet, _compound, _path, _newUnit)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_updating_the_value_origin_of_a_parameter_value_through_the_presenter : concern_for_OverwriteParameterSetsPresenter_editing
+   {
+      private ICommand _command;
+      private ValueOrigin _newValueOrigin;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = A.Fake<ICommand>();
+         _newValueOrigin = new ValueOrigin { Source = ValueOriginSources.Publication };
+         A.CallTo(() => _task.UpdateValueOrigin(_overwriteParameterSet, _compound, _path, _newValueOrigin)).Returns(_command);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateValueOrigin(_setDTO, _valueDTO, _newValueOrigin);
+      }
+
+      [Observation]
+      public void should_delegate_to_the_overwrite_parameter_set_task()
+      {
+         A.CallTo(() => _task.UpdateValueOrigin(_overwriteParameterSet, _compound, _path, _newValueOrigin)).MustHaveHappenedOnceExactly();
       }
    }
 

--- a/tests/PKSim.Tests/Presentation/OverwriteParameterValueDTOSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/OverwriteParameterValueDTOSpecs.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using OSPSuite.Assets;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -29,6 +30,8 @@ namespace PKSim.Presentation
             Info = new ParameterInfo { MinValue = 0, MinIsAllowed = true, MaxValue = 0.2, MaxIsAllowed = true }
          };
 
+         _parameterValue.ValueOrigin.Description = "From literature";
+
          sut = new OverwriteParameterValueDTO(_parameterValue);
       }
    }
@@ -44,7 +47,19 @@ namespace PKSim.Presentation
       [Observation]
       public void should_return_the_display_unit_of_the_parameter_value()
       {
-         sut.Unit.ShouldBeEqualTo("cm");
+         sut.DisplayUnit.Name.ShouldBeEqualTo("cm");
+      }
+
+      [Observation]
+      public void should_return_all_units_of_the_dimension()
+      {
+         sut.AllUnits.ShouldOnlyContain(_dimension.Units.ToArray());
+      }
+
+      [Observation]
+      public void should_return_the_value_origin_of_the_parameter_value()
+      {
+         sut.ValueOrigin.Description.ShouldBeEqualTo("From literature");
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Presentation/ParameterToParameterCommitDTOMapperSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/ParameterToParameterCommitDTOMapperSpecs.cs
@@ -24,6 +24,10 @@ namespace PKSim.Presentation
       {
          base.Context();
          _parameter = DomainHelperForSpecs.ConstantParameterWithValue(3.5).WithName("Lipophilicity");
+         _parameter.Dimension = DomainHelperForSpecs.LengthDimensionForSpecs();
+         _parameter.DisplayUnit = _parameter.Dimension.Unit("cm");
+         _parameter.ValueOrigin.Source = ValueOriginSources.Publication;
+         _parameter.ValueOrigin.Description = "From literature";
       }
 
       protected override void Because()
@@ -38,9 +42,21 @@ namespace PKSim.Presentation
       }
 
       [Observation]
-      public void should_set_the_value()
+      public void should_set_the_value_in_the_display_unit()
       {
-         _result.Value.ShouldBeEqualTo(3.5);
+         _result.Value.ShouldBeEqualTo(350);
+      }
+
+      [Observation]
+      public void should_set_the_display_unit()
+      {
+         _result.Unit.ShouldBeEqualTo("cm");
+      }
+
+      [Observation]
+      public void should_set_the_value_origin()
+      {
+         _result.ValueOrigin.ShouldBeEqualTo(_parameter.ValueOrigin.Display);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #3680 

Committing a parameter to an `OverwriteParameterSet` dropped its value origin, and unit and value origin were read only in the compound.

- Commit carries the simulation parameter's `ValueOrigin` into the OPS entry, and the snapshot `ParameterValue` keeps it over a round trip. `UpdateAllFrom` is used so the id survives and a database value origin is still omitted from the snapshot.
- Unit and value origin are editable in the compound, each through its own undoable command.
- The unit follows the parameter paradigm: shown and edited inside the value cell (`UxComboBoxUnit`), and changing it keeps the displayed number while recalculating the value in base unit, as `SetParameterUnitCommand` does. The separate Unit column is gone.
- The commit dialog shows the value in its display unit plus the value origin, both read only.

Dimension, display unit and the display-unit conversion were already handled by #3687.

Read Only during commit dialog, but displayed for info
<img width="733" height="508" alt="image" src="https://github.com/user-attachments/assets/d3ece7f5-c851-494c-bf75-091aee535c30" />

standard editors in the compound editor
<img width="1080" height="443" alt="image" src="https://github.com/user-attachments/assets/420da767-aa9f-47f2-83e9-6e8d45321bfe" />

The display of these two new fields was already covered in another PR, so this just makes them editable in the compound and visible in the commit dialog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editing of display units for overwrite parameter values while preserving displayed numbers.
  - Added editing and display of value-origin metadata.
  - Added unit-aware formatting and value-origin columns to parameter views.
  - Preserved value-origin information when committing parameters and saving or loading snapshots.

- **Bug Fixes**
  - Improved validation and display of parameter values using their selected units.
  - Added undo support for unit and value-origin changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->