### PR TITLE
Fixes #3695 Misleading "parameters will not be used" dialog when reconfiguring a simulation that uses an Overwrite Parameter Set

### DIFF
--- a/src/PKSim.Core/Services/SimulationParametersUpdater.cs
+++ b/src/PKSim.Core/Services/SimulationParametersUpdater.cs
@@ -1,4 +1,6 @@
-﻿using PKSim.Core.Model;
+﻿using System.Collections.Generic;
+using System.Linq;
+using PKSim.Core.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 
@@ -32,15 +34,18 @@ namespace PKSim.Core.Services
          var sourceParameters = simulationParametersCacheFor(sourceSimulation, buildingBlockType);
          var targetParameters = simulationParametersCacheFor(targetSimulation, buildingBlockType);
          _parameterSetUpdater.UpdateValues(sourceParameters, targetParameters);
-         return validateParameterUpdates(sourceParameters, targetParameters);
+         return validateParameterUpdates(sourceParameters, targetParameters, overwrittenCompoundParameterPathsFor(targetSimulation));
       }
 
-      private ValidationResult validateParameterUpdates(PathCache<IParameter> sourceParameters, PathCache<IParameter> targetParameters)
+      private ValidationResult validateParameterUpdates(PathCache<IParameter> sourceParameters, PathCache<IParameter> targetParameters, ISet<string> overwrittenCompoundParameterPaths)
       {
          var validationResult = new ValidationResult();
          foreach (var sourceParameterKeyValue in sourceParameters.KeyValues)
          {
             if (targetParameters.Contains(sourceParameterKeyValue.Key))
+               continue;
+
+            if (overwrittenCompoundParameterPaths.Contains(sourceParameterKeyValue.Key))
                continue;
 
             var sourceParameter = sourceParameterKeyValue.Value;
@@ -51,6 +56,21 @@ namespace PKSim.Core.Services
          }
 
          return validationResult;
+      }
+
+      private ISet<string> overwrittenCompoundParameterPathsFor(Simulation targetSimulation)
+      {
+         var overwritePaths = targetSimulation.OverwriteParameterSetSelections.Selections
+            .Where(x => x.OverwriteParameterSet != null)
+            .SelectMany(x => x.OverwriteParameterSet.ParameterValues)
+            .Select(x => x.Path.PathAsString)
+            .ToHashSet();
+
+         if (!overwritePaths.Any())
+            return overwritePaths;
+
+         var compoundParameters = simulationParametersCacheFor(targetSimulation, PKSimBuildingBlockType.Compound);
+         return compoundParameters.Keys.Where(overwritePaths.Contains).ToHashSet();
       }
 
       private PathCache<IParameter> simulationParametersCacheFor(Simulation simulation, PKSimBuildingBlockType buildingBlockType)

--- a/tests/PKSim.Tests/Core/SimulationParametersUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimulationParametersUpdaterSpecs.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using PKSim.Core.Model;
@@ -79,6 +80,68 @@ namespace PKSim.Core
       {
          _result.Messages.Count().ShouldBeEqualTo(1);
          _result.Messages.ElementAt(0).Object.ShouldBeEqualTo(_sourceP2);
+      }
+   }
+
+   public class When_reconciling_a_parameter_that_was_converted_to_a_compound_parameter_by_an_overwrite_parameter_set : concern_for_SimulationParametersUpdater
+   {
+      private Simulation _sourceSimulation;
+      private Simulation _targetSimulation;
+      private ValidationResult _result;
+      private IParameter _sourceP1;
+      private IParameter _sourceP2;
+      private IParameter _sourceP3;
+      private IParameter _targetP1;
+      private IParameter _targetCompoundP2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _sourceSimulation = A.Fake<Simulation>();
+         _targetSimulation = A.Fake<Simulation>();
+         _sourceP1 = A.Fake<IParameter>();
+         _sourceP2 = A.Fake<IParameter>();
+         _sourceP3 = A.Fake<IParameter>();
+         _targetP1 = A.Fake<IParameter>();
+         _targetCompoundP2 = A.Fake<IParameter>();
+
+         A.CallTo(() => _sourceSimulation.ParametersOfType(PKSimBuildingBlockType.Simulation)).Returns(new[] { _sourceP1, _sourceP2, _sourceP3 });
+         A.CallTo(() => _targetSimulation.ParametersOfType(PKSimBuildingBlockType.Simulation)).Returns(new[] { _targetP1 });
+         A.CallTo(() => _targetSimulation.ParametersOfType(PKSimBuildingBlockType.Compound)).Returns(new[] { _targetCompoundP2 });
+
+         A.CallTo(() => _entityPathResolver.PathFor(_sourceP1)).Returns("P1");
+         A.CallTo(() => _entityPathResolver.PathFor(_sourceP2)).Returns("P2");
+         A.CallTo(() => _entityPathResolver.PathFor(_sourceP3)).Returns("P3");
+         A.CallTo(() => _entityPathResolver.PathFor(_targetP1)).Returns("P1");
+         A.CallTo(() => _entityPathResolver.PathFor(_targetCompoundP2)).Returns("P2");
+
+         //P2 was hand edited but is now supplied by the overwrite parameter set as a compound parameter
+         _sourceP2.Formula = new ExplicitFormula();
+         _sourceP2.Editable = true;
+         _sourceP2.IsFixedValue = true;
+
+         //P3 was hand edited and is genuinely lost (not covered by the overwrite parameter set)
+         _sourceP3.Formula = new ExplicitFormula();
+         _sourceP3.Editable = true;
+         _sourceP3.IsFixedValue = true;
+
+         var overwriteParameterSet = new OverwriteParameterSet();
+         overwriteParameterSet.Add(new ParameterValue { Path = new ObjectPath("P2") });
+         var selections = new OverwriteParameterSetSelections();
+         selections.SetSelectionForCompound("Aspirin", overwriteParameterSet);
+         A.CallTo(() => _targetSimulation.OverwriteParameterSetSelections).Returns(selections);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.ReconciliateSimulationParametersBetween(_sourceSimulation, _targetSimulation);
+      }
+
+      [Observation]
+      public void should_not_warn_for_the_parameter_supplied_by_the_overwrite_parameter_set_but_warn_for_the_genuinely_lost_one()
+      {
+         _result.Messages.Count().ShouldBeEqualTo(1);
+         _result.Messages.ElementAt(0).Object.ShouldBeEqualTo(_sourceP3);
       }
    }
 }	


### PR DESCRIPTION
Fixes #3695 

## Problem

When reconfiguring a simulation that uses an Overwrite Parameter Set (OPS), the "parameters will not be used" info dialog appeared even when nothing was actually lost.

## Root cause

On reconfigure, `SimulationParametersUpdater.ReconciliateSimulationParametersBetween` carries over hand edits by comparing only parameters of `BuildingBlockType.Simulation` between the original and the rebuilt simulation, and warns about any that had a non-default value in the original but are missing from the rebuilt one.

Applying an OPS during model construction (`OverwriteParameterSetApplicationTask.applyValue`) flips each affected parameter from `Simulation` to `Compound`, and this runs *before* reconciliation. So the reconciler sees the parameter as present-and-changed in the original (`Simulation`) but absent from the rebuilt one's `Simulation` set (it is now `Compound`), and reports it as a lost hand edit — even though its value is supplied by the OPS. This fired for every OPS-covered parameter, even when the OPS value equalled the hand edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter validation when overwrite selections convert parameters into compound parameters.
  * Prevented incorrect validation warnings for parameters supplied through overwrite selections.
  * Continued reporting warnings for genuinely missing parameters.

* **Tests**
  * Added coverage to verify correct handling of converted and genuinely lost parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->