### PR TITLE
Fixes #3648 Event protocol review follow-ups

### DIFF
--- a/src/PKSim.Assets/PKSimConstants.cs
+++ b/src/PKSim.Assets/PKSimConstants.cs
@@ -573,7 +573,6 @@ namespace PKSim.Assets
          public static string FormulationIsRequiredForType(string applicationType) => $"Formulation is required for type '{applicationType}'.";
 
          public static readonly string EventKeyRequired = "Event key is required for event entries.";
-         public static readonly string EventPlaceholderRequired = "A placeholder is required when 'Administer with event' is selected.";
 
          public static string BuildingBlockNotDefined(string buildingBlock) => $"No {buildingBlock} defined. Please use create.";
 
@@ -657,6 +656,12 @@ namespace PKSim.Assets
 
          public static string NoFormulationFoundForRoute(string protocolName, string applicationRoute) =>
             $"No formulation found for route '{applicationRoute}' in administration protocol '{protocolName}'.";
+
+         public static string NoEventFoundForPlaceholder(string protocolName, string eventKey) =>
+            $"No event found for placeholder '{eventKey}' in administration protocol '{protocolName}'.";
+
+         public static string NoEventFoundForSimulationEvent(string templateEventId) =>
+            $"No event found for simulation event with template id '{templateEventId}'.";
 
          public static string UnableToCreateSimulationWithMoleculesHavingSameName(string duplicateName)
          {

--- a/src/PKSim.Core/Model/NoEventFoundException.cs
+++ b/src/PKSim.Core/Model/NoEventFoundException.cs
@@ -1,0 +1,19 @@
+using PKSim.Assets;
+
+namespace PKSim.Core.Model
+{
+   public class NoEventFoundException : PKSimException
+   {
+      //event placeholder of a protocol that could not be resolved to an event building block
+      public NoEventFoundException(Protocol protocol, string eventKey)
+         : base(PKSimConstants.Error.NoEventFoundForPlaceholder(protocol.Name, eventKey))
+      {
+      }
+
+      //standalone simulation event mapping that could not be resolved to an event building block
+      public NoEventFoundException(string templateEventId)
+         : base(PKSimConstants.Error.NoEventFoundForSimulationEvent(templateEventId))
+      {
+      }
+   }
+}

--- a/src/PKSim.Core/Model/ParameterExtensions.cs
+++ b/src/PKSim.Core/Model/ParameterExtensions.cs
@@ -73,6 +73,15 @@ namespace PKSim.Core.Model
          return parameter;
       }
 
+      //removes the lower bound so that a time parameter can be negative (e.g. an event scheduled before an administration)
+      public static void AllowNegativeValues(this IParameter parameter)
+      {
+         if (parameter?.Info == null) return;
+
+         parameter.Info.MinValue = null;
+         parameter.Info.MinIsAllowed = true;
+      }
+
       public static bool NeedsDefault(this IParameter parameter)
       {
          if (parameter.NameIsOneOf(AllDistributionParameters))

--- a/src/PKSim.Core/Model/ProtocolFactory.cs
+++ b/src/PKSim.Core/Model/ProtocolFactory.cs
@@ -86,8 +86,7 @@ namespace PKSim.Core.Model
       public void AddEventOffsetParameterTo(SimpleProtocol protocol)
       {
          var eventOffsetParameter = _parameterFactory.CreateFor(CoreConstants.Parameters.EVENT_OFFSET, 0, Constants.Dimension.TIME, PKSimBuildingBlockType.Protocol);
-         eventOffsetParameter.Info.MinValue = null;
-         eventOffsetParameter.Info.MinIsAllowed = true;
+         eventOffsetParameter.AllowNegativeValues();
          eventOffsetParameter.Visible = false;
          protocol.AddParameter(eventOffsetParameter);
       }

--- a/src/PKSim.Core/Model/SchemaItem.cs
+++ b/src/PKSim.Core/Model/SchemaItem.cs
@@ -41,20 +41,10 @@ namespace PKSim.Core.Model
          set
          {
             SetProperty(ref _applicationType, value);
-            allowNegativeStartTimeForEvents();
+            //an event may be scheduled before its administration (negative offset), unlike an administration
+            if (IsEvent)
+               StartTime.AllowNegativeValues();
          }
-      }
-
-      //an event may be scheduled before its administration (negative offset), so an event's start time
-      //must accept negative values, unlike an administration's
-      private void allowNegativeStartTimeForEvents()
-      {
-         if (!IsEvent) return;
-         var startTime = StartTime;
-         if (startTime?.Info == null) return;
-
-         startTime.Info.MinValue = null;
-         startTime.Info.MinIsAllowed = true;
       }
 
       public string FormulationKey

--- a/src/PKSim.Core/Model/SimpleProtocol.cs
+++ b/src/PKSim.Core/Model/SimpleProtocol.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Utility.Validation;
-using PKSim.Assets;
 
 namespace PKSim.Core.Model
 {
@@ -18,13 +16,7 @@ namespace PKSim.Core.Model
       public SimpleProtocol()
       {
          Rules.AddRange(SchemaItemRules.All());
-         Rules.Add(eventPlaceholderValid);
       }
-
-      private static IBusinessRule eventPlaceholderValid { get; } = CreateRule.For<SimpleProtocol>()
-         .Property(x => x.EventKey)
-         .WithRule((protocol, eventKey) => !protocol.HasEvent || !string.IsNullOrEmpty(eventKey))
-         .WithError(PKSimConstants.Error.EventPlaceholderRequired);
 
       public virtual ApplicationType ApplicationType
       {

--- a/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
+++ b/src/PKSim.Core/Services/EventBuildingBlockCreator.cs
@@ -113,7 +113,8 @@ namespace PKSim.Core.Services
 
             var eventStartTime = mainSubContainer.StartTime();
             _parameterSetUpdater.UpdateValue(startTime, eventStartTime);
-            allowNegativeStartTime(eventStartTime);
+            //an event may be scheduled before an administration (negative protocol offset)
+            eventStartTime.AllowNegativeValues();
 
             eventGroup.Add(mainSubContainer);
          }
@@ -121,15 +122,6 @@ namespace PKSim.Core.Services
          _parameterIdUpdater.UpdateBuildingBlockId(eventGroup, pkSimEvent);
 
          _eventGroupBuildingBlock.Add(eventGroup);
-      }
-
-      //an event may be scheduled before an administration (negative protocol offset), so its start time must allow negative values
-      private static void allowNegativeStartTime(IParameter startTime)
-      {
-         if (startTime?.Info == null) return;
-
-         startTime.Info.MinValue = null;
-         startTime.Info.MinIsAllowed = true;
       }
 
       /// <summary>
@@ -144,20 +136,21 @@ namespace PKSim.Core.Services
          // Standalone events
          foreach (var eventMapping in _simulation.EventProperties.EventMappings)
          {
-            var pkSimEvent = resolveEvent(eventMapping.TemplateEventId);
+            var pkSimEvent = resolveEvent(eventMapping.TemplateEventId) ?? throw new NoEventFoundException(eventMapping.TemplateEventId);
             eventStartTimeFor(pkSimEvent).AddStartTime(eventMapping.StartTime);
          }
 
          // Protocol events
          foreach (var protocolProperties in _simulation.CompoundPropertiesList.Select(x => x.ProtocolProperties))
          {
-            if (protocolProperties.Protocol == null)
+            var protocol = protocolProperties.Protocol;
+            if (protocol == null)
                continue;
 
-            foreach (var schemaItem in _schemaItemsMapper.MapFrom(protocolProperties.Protocol).Where(item => item.IsEvent))
+            foreach (var schemaItem in _schemaItemsMapper.MapFrom(protocol).Where(item => item.IsEvent))
             {
                var mapping = protocolProperties.EventMappingWith(schemaItem.EventKey);
-               var pkSimEvent = resolveEvent(mapping?.TemplateEventId);
+               var pkSimEvent = resolveEvent(mapping?.TemplateEventId) ?? throw new NoEventFoundException(protocol, schemaItem.EventKey);
                eventStartTimeFor(pkSimEvent).AddStartTime(schemaItem.StartTime);
             }
          }
@@ -165,15 +158,13 @@ namespace PKSim.Core.Services
          return result;
       }
 
+      //returns null if the template id is not defined or does not reference an event used by the simulation
       private PKSimEvent resolveEvent(string templateEventId)
       {
-         var usedBuildingBlock = string.IsNullOrEmpty(templateEventId) ? null : _simulation.UsedBuildingBlockByTemplateId(templateEventId);
-         var pkSimEvent = usedBuildingBlock?.BuildingBlock.DowncastTo<PKSimEvent>();
+         if (string.IsNullOrEmpty(templateEventId))
+            return null;
 
-         if (pkSimEvent == null)
-            throw new PKSimException($"Could not resolve event building block for template id '{templateEventId}'.");
-
-         return pkSimEvent;
+         return _simulation.UsedBuildingBlockByTemplateId(templateEventId)?.BuildingBlock as PKSimEvent;
       }
 
       private static Func<PKSimEvent, EventStartTimeCollection> eventStartTimeForDef(Cache<string, EventStartTimeCollection> cache) => pkSimEvent =>

--- a/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
+++ b/src/PKSim.Presentation/Presenters/Simulations/SimulationCompoundProtocolEventPresenter.cs
@@ -84,11 +84,14 @@ namespace PKSim.Presentation.Presenters.Simulations
          return hashSet;
       }
 
-      private EventSelectionDTO selectionFrom(PKSimEvent pkSimEvent) => new EventSelectionDTO
-      {
-         BuildingBlock = pkSimEvent,
-         DisplayName = _buildingBlockSelectionDisplayer.DisplayNameFor(pkSimEvent)
-      };
+      //no selection at all (rather than a blank one) when the project has no event to offer
+      private EventSelectionDTO selectionFrom(PKSimEvent pkSimEvent) => pkSimEvent == null
+         ? null
+         : new EventSelectionDTO
+         {
+            BuildingBlock = pkSimEvent,
+            DisplayName = _buildingBlockSelectionDisplayer.DisplayNameFor(pkSimEvent)
+         };
 
       public void CreateEventFor(EventPlaceholderMappingDTO eventPlaceholderMappingDTO)
       {
@@ -117,7 +120,8 @@ namespace PKSim.Presentation.Presenters.Simulations
       {
          _protocolProperties.ClearEventPlaceholderMappings();
 
-         _allEventMappingDTO.Each(dto =>
+         //an unmapped placeholder is rejected by validation before we get here; skipping it keeps this safe regardless
+         _allEventMappingDTO.Where(dto => dto.Event != null).Each(dto =>
          {
             _eventTask.Load(dto.Event);
             _protocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping

--- a/tests/PKSim.Tests/Core/EventBuildingBlockCreatorSpecs.cs
+++ b/tests/PKSim.Tests/Core/EventBuildingBlockCreatorSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FakeItEasy;
@@ -8,6 +9,7 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
+using PKSim.Assets;
 using PKSim.Core.Mappers;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
@@ -83,6 +85,19 @@ namespace PKSim.Core
          startTime.Info.MinValue = minValue;
          startTime.Info.MinIsAllowed = true;
          return startTime;
+      }
+
+      protected static NoEventFoundException exceptionThrownBy(Action action)
+      {
+         try
+         {
+            action();
+            return null;
+         }
+         catch (NoEventFoundException e)
+         {
+            return e;
+         }
       }
    }
 
@@ -184,12 +199,46 @@ namespace PKSim.Core
 
    public class When_creating_event_building_block_with_no_event_mapping_for_key : concern_for_EventBuildingBlockCreator
    {
+      private Protocol _protocol;
+      private NoEventFoundException _exception;
+
       protected override void Context()
       {
          base.Context();
 
-         var protocol = A.Fake<Protocol>();
+         _protocol = A.Fake<Protocol>().WithName("MyProtocol");
+         var protocolProperties = new ProtocolProperties { Protocol = _protocol };
+         var compoundProperties = new CompoundProperties { ProtocolProperties = protocolProperties };
+         _simulation.Properties.AddCompoundProperties(compoundProperties);
+
+         var eventSchemaItem = createEventSchemaItem("EVENT_1", 10);
+         A.CallTo(() => _schemaItemsMapper.MapFrom(_protocol)).Returns(new List<SchemaItem> { eventSchemaItem });
+      }
+
+      protected override void Because()
+      {
+         _exception = exceptionThrownBy(() => sut.CreateFor(_simulation));
+      }
+
+      [Observation]
+      public void should_throw_an_exception_naming_the_protocol_and_the_placeholder()
+      {
+         _exception.ShouldNotBeNull();
+         _exception.Message.ShouldBeEqualTo(PKSimConstants.Error.NoEventFoundForPlaceholder("MyProtocol", "EVENT_1"));
+      }
+   }
+
+   public class When_creating_event_building_block_with_a_placeholder_mapped_to_an_event_not_used_by_the_simulation : concern_for_EventBuildingBlockCreator
+   {
+      private NoEventFoundException _exception;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         var protocol = A.Fake<Protocol>().WithName("MyProtocol");
          var protocolProperties = new ProtocolProperties { Protocol = protocol };
+         protocolProperties.AddEventPlaceholderMapping(new EventPlaceholderMapping { EventKey = "EVENT_1", TemplateEventId = "unknown-event-id" });
          var compoundProperties = new CompoundProperties { ProtocolProperties = protocolProperties };
          _simulation.Properties.AddCompoundProperties(compoundProperties);
 
@@ -197,10 +246,41 @@ namespace PKSim.Core
          A.CallTo(() => _schemaItemsMapper.MapFrom(protocol)).Returns(new List<SchemaItem> { eventSchemaItem });
       }
 
-      [Observation]
-      public void should_throw_when_event_cannot_be_resolved()
+      protected override void Because()
       {
-         The.Action(() => sut.CreateFor(_simulation)).ShouldThrowAn<PKSimException>();
+         _exception = exceptionThrownBy(() => sut.CreateFor(_simulation));
+      }
+
+      [Observation]
+      public void should_throw_an_exception_naming_the_protocol_and_the_placeholder()
+      {
+         _exception.ShouldNotBeNull();
+         _exception.Message.ShouldBeEqualTo(PKSimConstants.Error.NoEventFoundForPlaceholder("MyProtocol", "EVENT_1"));
+      }
+   }
+
+   public class When_creating_event_building_block_with_a_standalone_event_mapping_that_cannot_be_resolved : concern_for_EventBuildingBlockCreator
+   {
+      private NoEventFoundException _exception;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         var startTime = new PKSimParameter().WithName(Constants.Parameters.START_TIME);
+         _simulation.EventProperties.AddEventMapping(new EventMapping { TemplateEventId = "unknown-event-id", StartTime = startTime });
+      }
+
+      protected override void Because()
+      {
+         _exception = exceptionThrownBy(() => sut.CreateFor(_simulation));
+      }
+
+      [Observation]
+      public void should_throw_an_exception_naming_the_template_event_id()
+      {
+         _exception.ShouldNotBeNull();
+         _exception.Message.ShouldBeEqualTo(PKSimConstants.Error.NoEventFoundForSimulationEvent("unknown-event-id"));
       }
    }
 

--- a/tests/PKSim.Tests/Core/ParameterExtensionsSpecs.cs
+++ b/tests/PKSim.Tests/Core/ParameterExtensionsSpecs.cs
@@ -297,4 +297,56 @@ namespace PKSim.Core
          _parameter.WithName(CoreConstants.Parameters.HALF_LIFE_LIVER).IsIndividualMoleculeGlobal().ShouldBeTrue();
       }
    }
+
+   public class When_allowing_negative_values_for_a_parameter_with_a_lower_bound : StaticContextSpecification
+   {
+      private IParameter _parameter;
+
+      protected override void Context()
+      {
+         _parameter = DomainHelperForSpecs.ConstantParameterWithValue(10);
+         _parameter.Info.MinValue = 0;
+         _parameter.Info.MinIsAllowed = false;
+      }
+
+      protected override void Because()
+      {
+         _parameter.AllowNegativeValues();
+      }
+
+      [Observation]
+      public void should_remove_the_lower_bound()
+      {
+         _parameter.Info.MinValue.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_allow_the_minimum_value()
+      {
+         _parameter.Info.MinIsAllowed.ShouldBeTrue();
+      }
+   }
+
+   public class When_allowing_negative_values_for_a_parameter_without_info_or_for_an_undefined_parameter : StaticContextSpecification
+   {
+      private IParameter _parameterWithoutInfo;
+
+      protected override void Context()
+      {
+         _parameterWithoutInfo = A.Fake<IParameter>();
+         A.CallTo(() => _parameterWithoutInfo.Info).Returns(null);
+      }
+
+      [Observation]
+      public void should_not_throw_for_a_parameter_without_info()
+      {
+         _parameterWithoutInfo.AllowNegativeValues();
+      }
+
+      [Observation]
+      public void should_not_throw_for_an_undefined_parameter()
+      {
+         ((IParameter)null).AllowNegativeValues();
+      }
+   }
 }

--- a/tests/PKSim.Tests/Core/SimpleProtocolEventSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimpleProtocolEventSpecs.cs
@@ -4,6 +4,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Validation;
 using PKSim.Core.Model;
 
 namespace PKSim.Core
@@ -12,7 +13,7 @@ namespace PKSim.Core
    {
       protected override void Context()
       {
-         sut = new SimpleProtocol();
+         sut = new SimpleProtocol().WithName("Protocol");
          sut.ApplicationType = ApplicationTypes.IntravenousBolus;
          sut.DosingInterval = DosingIntervals.Single;
          sut.Add(DomainHelperForSpecs.ConstantParameterWithValue(0).WithName(CoreConstants.Parameters.EVENT_OFFSET));
@@ -31,6 +32,12 @@ namespace PKSim.Core
       public void used_event_keys_should_be_empty()
       {
          sut.UsedEventKeys.ShouldBeEmpty();
+      }
+
+      [Observation]
+      public void should_be_valid()
+      {
+         sut.IsValid().ShouldBeTrue();
       }
    }
 
@@ -58,6 +65,12 @@ namespace PKSim.Core
       public void used_event_keys_should_have_exactly_one_entry()
       {
          sut.UsedEventKeys.Count().ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_be_valid()
+      {
+         sut.IsValid().ShouldBeTrue();
       }
    }
 
@@ -133,6 +146,12 @@ namespace PKSim.Core
       public void used_event_keys_should_be_empty()
       {
          sut.UsedEventKeys.ShouldBeEmpty();
+      }
+
+      [Observation]
+      public void should_remain_valid()
+      {
+         sut.IsValid().ShouldBeTrue();
       }
    }
 }

--- a/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/SimulationCompoundProtocolEventPresenterSpecs.cs
@@ -4,6 +4,7 @@ using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Validation;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 using PKSim.Presentation.DTO.Simulations;
@@ -221,6 +222,81 @@ namespace PKSim.Presentation
          _protocolProperties.EventPlaceholderMappings.Count.ShouldBeEqualTo(1);
          _protocolProperties.EventPlaceholderMappings[0].EventKey.ShouldBeEqualTo(_eventKey1);
          _protocolProperties.EventPlaceholderMappings[0].Event.ShouldNotBeNull();
+      }
+   }
+
+   public class When_saving_event_placeholder_configuration_with_an_unmapped_placeholder : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _eventTask.All()).Returns(new PKSimEvent[0]);
+         A.CallTo(() => _eventFromMappingRetriever.TemplateEventUsedBy(_simulation, A<EventPlaceholderMapping>._)).Returns(null);
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { "EVENT_1" });
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      protected override void Because()
+      {
+         sut.SaveConfiguration();
+      }
+
+      [Observation]
+      public void should_not_add_a_mapping_for_the_unmapped_placeholder()
+      {
+         _protocolProperties.EventPlaceholderMappings.ShouldBeEmpty();
+      }
+
+      [Observation]
+      public void should_not_try_to_load_an_undefined_event()
+      {
+         A.CallTo(() => _eventTask.Load(A<PKSimEvent>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_the_event_presenter_is_editing_a_protocol_with_event_placeholders_in_a_project_without_events : concern_for_SimulationCompoundProtocolEventPresenter
+   {
+      private IList<EventPlaceholderMappingDTO> _eventMappingDtoList;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _eventTask.All()).Returns(new PKSimEvent[0]);
+         A.CallTo(() => _eventFromMappingRetriever.TemplateEventUsedBy(_simulation, A<EventPlaceholderMapping>._)).Returns(null);
+         A.CallTo(() => _protocol.UsedEventKeys).Returns(new[] { "EVENT_1" });
+         A.CallTo(() => _view.BindTo(A<IEnumerable<EventPlaceholderMappingDTO>>._))
+            .Invokes(x => _eventMappingDtoList = x.GetArgument<IEnumerable<EventPlaceholderMappingDTO>>(0).ToList());
+      }
+
+      protected override void Because()
+      {
+         sut.EditSimulation(_simulation, _compound);
+      }
+
+      [Observation]
+      public void should_display_the_placeholder_without_a_selected_event()
+      {
+         _eventMappingDtoList.Count.ShouldBeEqualTo(1);
+         _eventMappingDtoList[0].EventKey.ShouldBeEqualTo("EVENT_1");
+         _eventMappingDtoList[0].Selection.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_mark_the_mapping_as_invalid()
+      {
+         _eventMappingDtoList[0].IsValid().ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_not_offer_any_event_for_selection()
+      {
+         sut.AllEventsFor(_eventMappingDtoList[0]).ShouldBeEmpty();
+      }
+
+      [Observation]
+      public void should_make_event_mapping_visible()
+      {
+         A.CallToSet(() => _view.EventVisible).To(true).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #3648

# Description

Code-quality follow-ups from the review of the event-protocol feature (PR #3617), as specified in the agent brief on #3648. Rebased onto `develop` after #3691 (event offset parameter) was merged.

- **Clear unresolved-event error** – `EventBuildingBlockCreator` now throws `NoEventFoundException` (mirrors `NoFormulationFoundForRouteException`) naming the protocol and placeholder key, or the template id of an unresolvable standalone event mapping, instead of `PKSimException("Could not resolve event building block for template id ''.")`.
- **Dead rule removed** – `SimpleProtocol.eventPlaceholderValid` was a tautology (`HasEvent` ⇔ `EventKey` non-empty); removed together with the unused `PKSimConstants.Error.EventPlaceholderRequired`. `SchemaItemRules.eventKeyValid` remains the single rule.
- **One helper for "allow negative time"** – new `IParameter.AllowNegativeValues()` replaces the three copies of `Info.MinValue = null; Info.MinIsAllowed = true;` in `SchemaItem`, `EventBuildingBlockCreator` and `ProtocolFactory.AddEventOffsetParameterTo`.
- **Presenter hardening** – `SimulationCompoundProtocolEventPresenter.SaveConfiguration()` skips unmapped placeholders instead of dereferencing a null event, and no longer creates a blank `EventSelectionDTO` when the project has no event (so `AllEventsFor` is empty instead of offering a blank entry).
- Default event pre-selection (finding 1 of the issue) is intentionally unchanged, per triage decision.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes
- [ ] Algorithm update
- [x] Other (please describe): code-quality / hardening follow-ups, dev-only

# How Has This Been Tested?

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests
- [ ] No tests required

New / updated specs:
- `EventBuildingBlockCreatorSpecs`: unmapped placeholder, placeholder mapped to an event not used by the simulation, unresolvable standalone mapping – each asserts `NoEventFoundException` and the exact message.
- `ParameterExtensionsSpecs`: `AllowNegativeValues()` removes the bound, tolerates null `Info` / null parameter.
- `SimpleProtocolEventSpecs`: protocol with / without event and after clearing the event is valid.
- `SimulationCompoundProtocolEventPresenterSpecs`: zero-events project (null selection, invalid DTO, empty `AllEventsFor`, mapping visible) and save with an unmapped placeholder (no throw, no mapping, no `Load`).

Full `PKSim.Tests` suite run locally: 5677 passed, 0 failed, 6 skipped.

# Reviewer checklist

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
