### PR TITLE
Fixes #3682 No differences compound <=> simulation are shown when OPS parameters are modified in the simulation

### DIFF
--- a/src/PKSim.Core/Commands/EditParameterCommand.cs
+++ b/src/PKSim.Core/Commands/EditParameterCommand.cs
@@ -115,7 +115,7 @@ namespace PKSim.Core.Commands
 
       private void trackCompoundParameterChange(IParameter parameter, IExecutionContext context)
       {
-         if (parameter.BuildingBlockType != PKSimBuildingBlockType.Simulation)
+         if (string.IsNullOrEmpty(SimulationId) || !parameter.BuildingBlockType.IsOneOf(PKSimBuildingBlockType.Simulation, PKSimBuildingBlockType.Compound))
             return;
 
          var simulation = context.Get<Simulation>(SimulationId);
@@ -125,7 +125,11 @@ namespace PKSim.Core.Commands
          var entityPathResolver = context.Resolve<IEntityPathResolver>();
          var parameterPath = entityPathResolver.PathFor(parameter);
 
-         if (simulation.CompoundNameForParameterPath(parameterPath) == null)
+         var compoundName = simulation.CompoundNameForParameterPath(parameterPath);
+         if (compoundName == null)
+            return;
+
+         if (!isCompoundDependentSimulationParameter(parameter, simulation, compoundName, parameterPath))
             return;
 
          var tracker = simulation.ParameterChangeTracker;
@@ -141,6 +145,14 @@ namespace PKSim.Core.Commands
             ReverseTrackerUpdateForParameter(tracker, parameterPath);
          }
       }
+
+      /// <summary>
+      ///    A parameter overwritten by the overwrite parameter set applied to the simulation is flagged as a compound
+      ///    parameter, but remains a simulation parameter that can only be committed to the compound as part of a set.
+      /// </summary>
+      private static bool isCompoundDependentSimulationParameter(IParameter parameter, Simulation simulation, string compoundName, string parameterPath) =>
+         parameter.BuildingBlockType == PKSimBuildingBlockType.Simulation ||
+         simulation.IsOverwrittenParameterPath(compoundName, parameterPath);
 
       protected virtual void UpdateTrackerForParameter(SimulationParameterChangeTracker tracker, string parameterPath)
       {

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -514,6 +514,14 @@ namespace PKSim.Core.Model
       }
 
       /// <summary>
+      ///    Returns <c>true</c> if <paramref name="parameterPath" /> is one of the paths of the
+      ///    <see cref="OverwriteParameterSet" /> selected for the compound named <paramref name="compoundName" />,
+      ///    otherwise <c>false</c>.
+      /// </summary>
+      public virtual bool IsOverwrittenParameterPath(string compoundName, string parameterPath) =>
+         OverwriteParameterSetSelections.SelectedSetFor(compoundName)?.ParameterValueByPath(parameterPath) != null;
+
+      /// <summary>
       ///    gets or sets the simulation properties used to configure the simulation
       /// </summary>
       public virtual SimulationProperties Properties

--- a/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
@@ -4,7 +4,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
-using PKSim.Assets;
 using PKSim.Core.Model;
 
 namespace PKSim.Core.Services
@@ -15,7 +14,7 @@ namespace PKSim.Core.Services
       ///    Applies the values of the <see cref="OverwriteParameterSet" /> selected for each compound in the
       ///    <paramref name="simulation" /> to the matching simulation parameters (matched by path). Affected parameters
       ///    become <see cref="PKSimBuildingBlockType.Compound" /> so that they lose the reset behaviour of a simulation
-      ///    parameter, and their value origin is set to identify the originating overwrite parameter set. They keep an
+      ///    parameter, and their value origin is taken from the entry of the set. They keep an
       ///    empty <see cref="ParameterOrigin.BuilingBlockId" /> since they have no counterpart in the compound building
       ///    block, and are therefore committed to the compound through the overwrite parameter set workflow only.
       ///    Overwritten parameters are also flagged <see cref="IParameter.CanBeVariedInPopulation" />=false so that a
@@ -57,11 +56,11 @@ namespace PKSim.Core.Services
          removeAdvancedParametersFor(simulation, resolvedValues);
       }
 
-      private static void applyValues(IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues) =>
-         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.overwriteParameterSet));
+      private static void applyValues(IReadOnlyList<(IParameter parameter, ParameterValue parameterValue)> resolvedValues) =>
+         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue));
 
       private void removeAdvancedParametersFor(Simulation simulation,
-         IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues)
+         IReadOnlyList<(IParameter parameter, ParameterValue parameterValue)> resolvedValues)
       {
          if (simulation is not PopulationSimulation populationSimulation)
             return;
@@ -76,9 +75,9 @@ namespace PKSim.Core.Services
 
       public void ApplyOverwriteParameterSetsTo(ParameterValuesBuildingBlock parameterValues, Simulation simulation) => resolveOverwriteValues(simulation).Each(x => addToParameterValues(x.parameter, x.parameterValue, parameterValues));
 
-      private IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
+      private IReadOnlyList<(IParameter parameter, ParameterValue parameterValue)> resolveOverwriteValues(Simulation simulation)
       {
-         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)>();
+         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue)>();
 
          var selections = simulation.OverwriteParameterSetSelections.Selections
             .Where(x => x.OverwriteParameterSet != null)
@@ -99,29 +98,28 @@ namespace PKSim.Core.Services
       }
 
       private static void resolveSelection(OverwriteParameterSetSelection selection, PathCache<IParameter> parameterCache,
-         List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+         List<(IParameter parameter, ParameterValue parameterValue)> resolvedValues, List<string> unresolvedPaths)
       {
          selection.OverwriteParameterSet.ParameterValues.Each(parameterValue =>
-            resolveParameterValue(parameterValue, selection.OverwriteParameterSet, parameterCache, resolvedValues, unresolvedPaths));
+            resolveParameterValue(parameterValue, parameterCache, resolvedValues, unresolvedPaths));
       }
 
-      private static void resolveParameterValue(ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet, PathCache<IParameter> parameterCache,
-         List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+      private static void resolveParameterValue(ParameterValue parameterValue, PathCache<IParameter> parameterCache,
+         List<(IParameter parameter, ParameterValue parameterValue)> resolvedValues, List<string> unresolvedPaths)
       {
          var path = parameterValue.Path.PathAsString;
          var parameter = parameterCache[path];
          if (parameter == null)
             unresolvedPaths.Add(path);
          else
-            resolvedValues.Add((parameter, parameterValue, overwriteParameterSet));
+            resolvedValues.Add((parameter, parameterValue));
       }
 
-      private static void applyValue(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)
+      private static void applyValue(IParameter parameter, ParameterValue parameterValue)
       {
          parameter.Value = parameterValue.Value.Value;
          parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
-         parameter.ValueOrigin.Source = ValueOriginSources.Other;
-         parameter.ValueOrigin.Description = $"{PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}'";
+         parameter.ValueOrigin.UpdateAllFrom(parameterValue.ValueOrigin);
          parameter.CanBeVariedInPopulation = false;
       }
 

--- a/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
+++ b/src/PKSim.Core/Services/OverwriteParameterSetApplicationTask.cs
@@ -14,8 +14,10 @@ namespace PKSim.Core.Services
       /// <summary>
       ///    Applies the values of the <see cref="OverwriteParameterSet" /> selected for each compound in the
       ///    <paramref name="simulation" /> to the matching simulation parameters (matched by path). Affected parameters
-      ///    become <see cref="PKSimBuildingBlockType.Compound" /> so that subsequent changes follow normal compound
-      ///    parameter logic, and their value origin is set to identify the originating overwrite parameter set.
+      ///    become <see cref="PKSimBuildingBlockType.Compound" /> so that they lose the reset behaviour of a simulation
+      ///    parameter, and their value origin is set to identify the originating overwrite parameter set. They keep an
+      ///    empty <see cref="ParameterOrigin.BuilingBlockId" /> since they have no counterpart in the compound building
+      ///    block, and are therefore committed to the compound through the overwrite parameter set workflow only.
       ///    Overwritten parameters are also flagged <see cref="IParameter.CanBeVariedInPopulation" />=false so that a
       ///    population simulation keeps the overwritten value fixed; any advanced parameter already defined for such a
       ///    path in a <see cref="PopulationSimulation" /> is removed so it cannot override the value at run time.
@@ -55,11 +57,11 @@ namespace PKSim.Core.Services
          removeAdvancedParametersFor(simulation, resolvedValues);
       }
 
-      private static void applyValues(IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues) =>
-         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.compound, x.overwriteParameterSet));
+      private static void applyValues(IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues) =>
+         resolvedValues.Each(x => applyValue(x.parameter, x.parameterValue, x.overwriteParameterSet));
 
       private void removeAdvancedParametersFor(Simulation simulation,
-         IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues)
+         IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues)
       {
          if (simulation is not PopulationSimulation populationSimulation)
             return;
@@ -74,9 +76,9 @@ namespace PKSim.Core.Services
 
       public void ApplyOverwriteParameterSetsTo(ParameterValuesBuildingBlock parameterValues, Simulation simulation) => resolveOverwriteValues(simulation).Each(x => addToParameterValues(x.parameter, x.parameterValue, parameterValues));
 
-      private IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
+      private IReadOnlyList<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolveOverwriteValues(Simulation simulation)
       {
-         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)>();
+         var resolvedValues = new List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)>();
 
          var selections = simulation.OverwriteParameterSetSelections.Selections
             .Where(x => x.OverwriteParameterSet != null)
@@ -88,7 +90,7 @@ namespace PKSim.Core.Services
          var parameterCache = _containerTask.CacheAllChildren<IParameter>(simulation.Model.Root);
          var unresolvedPaths = new List<string>();
 
-         selections.Each(selection => resolveSelection(selection, simulation, parameterCache, resolvedValues, unresolvedPaths));
+         selections.Each(selection => resolveSelection(selection, parameterCache, resolvedValues, unresolvedPaths));
 
          if (unresolvedPaths.Any())
             throw new CannotApplyOverwriteParameterSetException(unresolvedPaths);
@@ -96,31 +98,28 @@ namespace PKSim.Core.Services
          return resolvedValues;
       }
 
-      private void resolveSelection(OverwriteParameterSetSelection selection, Simulation simulation, PathCache<IParameter> parameterCache,
-         List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+      private static void resolveSelection(OverwriteParameterSetSelection selection, PathCache<IParameter> parameterCache,
+         List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
       {
-         var compound = simulation.Compounds.FindByName(selection.CompoundName);
-
          selection.OverwriteParameterSet.ParameterValues.Each(parameterValue =>
-            resolveParameterValue(parameterValue, compound, selection.OverwriteParameterSet, parameterCache, resolvedValues, unresolvedPaths));
+            resolveParameterValue(parameterValue, selection.OverwriteParameterSet, parameterCache, resolvedValues, unresolvedPaths));
       }
 
-      private static void resolveParameterValue(ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet, PathCache<IParameter> parameterCache,
-         List<(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
+      private static void resolveParameterValue(ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet, PathCache<IParameter> parameterCache,
+         List<(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)> resolvedValues, List<string> unresolvedPaths)
       {
          var path = parameterValue.Path.PathAsString;
          var parameter = parameterCache[path];
          if (parameter == null)
             unresolvedPaths.Add(path);
          else
-            resolvedValues.Add((parameter, parameterValue, compound, overwriteParameterSet));
+            resolvedValues.Add((parameter, parameterValue, overwriteParameterSet));
       }
 
-      private static void applyValue(IParameter parameter, ParameterValue parameterValue, Compound compound, OverwriteParameterSet overwriteParameterSet)
+      private static void applyValue(IParameter parameter, ParameterValue parameterValue, OverwriteParameterSet overwriteParameterSet)
       {
          parameter.Value = parameterValue.Value.Value;
          parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
-         parameter.Origin.BuilingBlockId = compound.Id;
          parameter.ValueOrigin.Source = ValueOriginSources.Other;
          parameter.ValueOrigin.Description = $"{PKSimConstants.ObjectTypes.OverwriteParameterSet} '{overwriteParameterSet.Name}'";
          parameter.CanBeVariedInPopulation = false;

--- a/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
+++ b/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
@@ -771,6 +771,49 @@ namespace PKSim.Core
       }
    }
 
+   public class When_checking_whether_a_parameter_path_is_overwritten_by_the_selected_overwrite_parameter_set : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _renalImpairmentSet.Add(new ParameterValue { Path = "Aspirin|Intestinal permeability (transcellular)".ToObjectPath() });
+         sut.AddOverwriteParameterSetSelection(_compound.Name, _renalImpairmentSet);
+      }
+
+      [Observation]
+      public void should_return_true_for_a_path_defined_in_the_selected_set()
+      {
+         sut.IsOverwrittenParameterPath(_compound.Name, "Aspirin|Intestinal permeability (transcellular)").ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_false_for_a_path_that_is_not_defined_in_the_selected_set()
+      {
+         sut.IsOverwrittenParameterPath(_compound.Name, "Aspirin|Lipophilicity").ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_return_false_for_a_compound_without_a_selection()
+      {
+         sut.IsOverwrittenParameterPath("Metabolite", "Aspirin|Intestinal permeability (transcellular)").ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_whether_a_parameter_path_is_overwritten_for_a_compound_whose_selection_is_none : concern_for_IndividualSimulation_with_compound
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.AddOverwriteParameterSetSelection(_compound.Name, null);
+      }
+
+      [Observation]
+      public void should_return_false()
+      {
+         sut.IsOverwrittenParameterPath(_compound.Name, "Aspirin|Intestinal permeability (transcellular)").ShouldBeFalse();
+      }
+   }
+
    public class When_updating_an_overwrite_parameter_set_selection_for_an_existing_compound : concern_for_IndividualSimulation_with_compound
    {
       protected override void Context()

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
@@ -5,7 +5,6 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
-using PKSim.Assets;
 using PKSim.Core.Model;
 using PKSim.Core.Services;
 
@@ -108,10 +107,10 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_set_the_value_origin_of_the_applied_parameter_to_the_overwrite_parameter_set()
+      public void should_clear_the_value_origin_of_the_applied_parameter_when_the_set_does_not_define_one()
       {
-         _lipophilicityParam.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Other);
-         _lipophilicityParam.ValueOrigin.Description.ShouldBeEqualTo($"{PKSimConstants.ObjectTypes.OverwriteParameterSet} 'MySet'");
+         _lipophilicityParam.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Undefined);
+         _lipophilicityParam.ValueOrigin.Description.ShouldBeNull();
       }
 
       [Observation]
@@ -119,6 +118,58 @@ namespace PKSim.Core
       {
          _permeabilityParam.Value.ShouldBeEqualTo(7.2);
          _permeabilityParam.BuildingBlockType.ShouldBeEqualTo(PKSimBuildingBlockType.Simulation);
+      }
+   }
+
+   public class When_applying_an_overwrite_parameter_set_whose_entry_defines_a_value_origin : concern_for_OverwriteParameterSetApplicationTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _lipophilicityParam.ValueOrigin.Source = ValueOriginSources.Other;
+         _lipophilicityParam.ValueOrigin.Description = "replaced by the value origin of the set";
+
+         var set = overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0));
+         var parameterValue = set.ParameterValueByPath("Organism|Aspirin|Lipophilicity");
+         parameterValue.ValueOrigin.Source = ValueOriginSources.Publication;
+         parameterValue.ValueOrigin.Description = "Smith 2019";
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", set);
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_simulation);
+      }
+
+      [Observation]
+      public void should_take_the_value_origin_of_the_applied_parameter_from_the_entry_of_the_set()
+      {
+         _lipophilicityParam.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Publication);
+         _lipophilicityParam.ValueOrigin.Description.ShouldBeEqualTo("Smith 2019");
+      }
+   }
+
+   public class When_applying_an_overwrite_parameter_set_whose_entry_has_no_value_origin_to_a_parameter_that_has_one : concern_for_OverwriteParameterSetApplicationTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _lipophilicityParam.ValueOrigin.Source = ValueOriginSources.Publication;
+         _lipophilicityParam.ValueOrigin.Description = "Smith 2019";
+
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSetWith(("Organism|Aspirin|Lipophilicity", 5.0)));
+      }
+
+      protected override void Because()
+      {
+         sut.ApplyOverwriteParameterSetsTo(_simulation);
+      }
+
+      [Observation]
+      public void should_clear_the_value_origin_of_the_applied_parameter()
+      {
+         _lipophilicityParam.ValueOrigin.Source.ShouldBeEqualTo(ValueOriginSources.Undefined);
+         _lipophilicityParam.ValueOrigin.Description.ShouldBeNull();
       }
    }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetApplicationTaskSpecs.cs
@@ -102,9 +102,9 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_point_the_applied_parameter_origin_to_the_compound_building_block()
+      public void should_not_point_the_applied_parameter_origin_to_the_compound_building_block()
       {
-         _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
+         string.IsNullOrEmpty(_lipophilicityParam.Origin.BuilingBlockId).ShouldBeTrue();
       }
 
       [Observation]
@@ -210,10 +210,10 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_point_each_applied_parameter_origin_to_the_matching_compound()
+      public void should_not_point_any_applied_parameter_origin_to_a_compound_building_block()
       {
-         _lipophilicityParam.Origin.BuilingBlockId.ShouldBeEqualTo(_compound.Id);
-         _secondCompoundParam.Origin.BuilingBlockId.ShouldBeEqualTo(_secondCompound.Id);
+         string.IsNullOrEmpty(_lipophilicityParam.Origin.BuilingBlockId).ShouldBeTrue();
+         string.IsNullOrEmpty(_secondCompoundParam.Origin.BuilingBlockId).ShouldBeTrue();
       }
    }
 

--- a/tests/PKSim.Tests/Core/SetParameterValueCommandSpecs.cs
+++ b/tests/PKSim.Tests/Core/SetParameterValueCommandSpecs.cs
@@ -4,6 +4,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
@@ -315,6 +316,155 @@ namespace PKSim.Core
       {
          _simulation.ParameterChangeTracker.HasUncommittedChanges.ShouldBeTrue();
          _simulation.ParameterChangeTracker.ChangedPaths[0].PathAsString.ShouldBeEqualTo("Organism|Aspirin|Lipophilicity");
+      }
+   }
+
+   public class When_setting_the_value_of_a_parameter_overwritten_by_the_overwrite_parameter_set_applied_to_the_simulation : concern_for_SetParameterValueCommand
+   {
+      private IndividualSimulation _simulation;
+      private IEntityPathResolver _entityPathResolver;
+      private UsedBuildingBlock _usedCompound;
+
+      protected override void Context()
+      {
+         base.Context();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+         var container = new Container();
+         _parameter = DomainHelperForSpecs.ConstantParameterWithValue(_oldValue)
+            .WithId("Id")
+            .WithDimension(_dimension)
+            .WithName("Intestinal permeability (transcellular)");
+
+         //the overwrite parameter set application flags the parameter as a compound parameter
+         _parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
+         _parameter.Origin.SimulationId = "SimId";
+         container.Add(_parameter);
+         _parameter.DisplayUnit = _unit;
+
+         var compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _usedCompound = new UsedBuildingBlock("TemplateCompId", PKSimBuildingBlockType.Compound) { BuildingBlock = compound };
+         _simulation = new IndividualSimulation { Id = "SimId" };
+         _simulation.AddUsedBuildingBlock(_usedCompound);
+
+         var overwriteParameterSet = new OverwriteParameterSet { Name = "MySet" };
+         overwriteParameterSet.Add(new ParameterValue { Path = "Aspirin|Intestinal permeability (transcellular)".ToObjectPath(), Value = _oldValue });
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSet);
+
+         A.CallTo(() => _executionContext.Get<Simulation>("SimId")).Returns(_simulation);
+         A.CallTo(() => _executionContext.Resolve<IEntityPathResolver>()).Returns(_entityPathResolver);
+         A.CallTo(() => _entityPathResolver.PathFor(_parameter)).Returns("Aspirin|Intestinal permeability (transcellular)");
+
+         sut = new SetParameterValueCommand(_parameter, _valueToSet);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_executionContext);
+      }
+
+      [Observation]
+      public void should_track_the_parameter_path_in_the_simulation_change_tracker()
+      {
+         _simulation.ParameterChangeTracker.ChangedPaths.Select(x => x.PathAsString)
+            .ShouldOnlyContain("Aspirin|Intestinal permeability (transcellular)");
+      }
+
+      [Observation]
+      public void should_not_flag_the_compound_used_in_the_simulation_as_altered()
+      {
+         _usedCompound.Altered.ShouldBeFalse();
+      }
+   }
+
+   public class When_setting_the_value_of_a_compound_parameter_in_a_simulation_that_is_not_part_of_the_applied_overwrite_parameter_set : concern_for_SetParameterValueCommand
+   {
+      private IndividualSimulation _simulation;
+      private IEntityPathResolver _entityPathResolver;
+
+      protected override void Context()
+      {
+         base.Context();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+         var container = new Container();
+         _parameter = DomainHelperForSpecs.ConstantParameterWithValue(_oldValue)
+            .WithId("Id")
+            .WithDimension(_dimension)
+            .WithName("Lipophilicity");
+
+         _parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
+         _parameter.Origin.SimulationId = "SimId";
+         _parameter.Origin.BuilingBlockId = "CompId";
+         container.Add(_parameter);
+         _parameter.DisplayUnit = _unit;
+
+         var compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _simulation = new IndividualSimulation { Id = "SimId" };
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId", PKSimBuildingBlockType.Compound) { BuildingBlock = compound });
+
+         A.CallTo(() => _executionContext.Get<Simulation>("SimId")).Returns(_simulation);
+         A.CallTo(() => _executionContext.Resolve<IEntityPathResolver>()).Returns(_entityPathResolver);
+         A.CallTo(() => _entityPathResolver.PathFor(_parameter)).Returns("Aspirin|Lipophilicity");
+
+         sut = new SetParameterValueCommand(_parameter, _valueToSet);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_executionContext);
+      }
+
+      [Observation]
+      public void should_not_track_the_parameter_path()
+      {
+         _simulation.ParameterChangeTracker.HasUncommittedChanges.ShouldBeFalse();
+      }
+   }
+
+   public class When_undoing_the_value_change_of_a_parameter_overwritten_by_the_overwrite_parameter_set_applied_to_the_simulation : concern_for_SetParameterValueCommand
+   {
+      private IndividualSimulation _simulation;
+      private IEntityPathResolver _entityPathResolver;
+
+      protected override void Context()
+      {
+         base.Context();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+         var container = new Container();
+         _parameter = DomainHelperForSpecs.ConstantParameterWithValue(_oldValue)
+            .WithId("Id")
+            .WithDimension(_dimension)
+            .WithName("Intestinal permeability (transcellular)");
+
+         _parameter.BuildingBlockType = PKSimBuildingBlockType.Compound;
+         _parameter.Origin.SimulationId = "SimId";
+         container.Add(_parameter);
+         _parameter.DisplayUnit = _unit;
+
+         var compound = new Compound { Name = "Aspirin", Id = "CompId" };
+         _simulation = new IndividualSimulation { Id = "SimId" };
+         _simulation.AddUsedBuildingBlock(new UsedBuildingBlock("TemplateCompId", PKSimBuildingBlockType.Compound) { BuildingBlock = compound });
+
+         var overwriteParameterSet = new OverwriteParameterSet { Name = "MySet" };
+         overwriteParameterSet.Add(new ParameterValue { Path = "Aspirin|Intestinal permeability (transcellular)".ToObjectPath(), Value = _oldValue });
+         _simulation.AddOverwriteParameterSetSelection("Aspirin", overwriteParameterSet);
+
+         A.CallTo(() => _executionContext.Get<Simulation>("SimId")).Returns(_simulation);
+         A.CallTo(() => _executionContext.Get<IParameter>(_parameter.Id)).Returns(_parameter);
+         A.CallTo(() => _executionContext.Resolve<IEntityPathResolver>()).Returns(_entityPathResolver);
+         A.CallTo(() => _entityPathResolver.PathFor(_parameter)).Returns("Aspirin|Intestinal permeability (transcellular)");
+
+         sut = new SetParameterValueCommand(_parameter, _valueToSet);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_executionContext);
+      }
+
+      [Observation]
+      public void should_untrack_the_parameter_path()
+      {
+         _simulation.ParameterChangeTracker.HasUncommittedChanges.ShouldBeFalse();
       }
    }
 

--- a/tests/PKSim.Tests/IntegrationTests/OverwriteParameterSetInSimulationSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/OverwriteParameterSetInSimulationSpecs.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using PKSim.Core;
+using PKSim.Core.Commands;
+using PKSim.Core.Model;
+using PKSim.Infrastructure;
+
+namespace PKSim.IntegrationTests
+{
+   public class When_changing_a_simulation_parameter_overwritten_by_the_applied_overwrite_parameter_set : ContextForSimulationIntegration<IExecutionContext>
+   {
+      private Compound _compound;
+      private string _parameterPath;
+      private IParameter _overwrittenParameter;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         sut = IoC.Resolve<IExecutionContext>();
+
+         var templateIndividual = DomainFactoryForSpecs.CreateStandardIndividual();
+         _compound = DomainFactoryForSpecs.CreateStandardCompound();
+         var protocol = DomainFactoryForSpecs.CreateStandardIVBolusProtocol();
+
+         _simulation = DomainFactoryForSpecs.CreateModelLessSimulationWith(templateIndividual, _compound, protocol).DowncastTo<IndividualSimulation>();
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+
+         var compoundParameter = firstValidCompoundParameter();
+         _parameterPath = compoundParameter.Key;
+
+         var overwriteParameterSet = new OverwriteParameterSet { Name = "TestSet" };
+         overwriteParameterSet.Add(new ParameterValue { Path = _parameterPath.ToObjectPath(), Value = compoundParameter.Value.Value + 1.0 });
+         _simulation.AddOverwriteParameterSetSelection(_compound.Name, overwriteParameterSet);
+
+         //rebuild the model so the selected overwrite parameter set is applied during construction
+         DomainFactoryForSpecs.AddModelToSimulation(_simulation);
+         _overwrittenParameter = parameterCache()[_parameterPath];
+      }
+
+      private KeyValuePair<string, IParameter> firstValidCompoundParameter()
+      {
+         return parameterCache().KeyValues
+            .First(kv => kv.Value.BuildingBlockType == PKSimBuildingBlockType.Simulation &&
+                         _simulation.CompoundNameForParameterPath(kv.Key) == _compound.Name &&
+                         !double.IsNaN(kv.Value.Value));
+      }
+
+      private PathCache<IParameter> parameterCache() => IoC.Resolve<IContainerTask>().CacheAllChildren<IParameter>(_simulation.Model.Root);
+
+      protected override void Because()
+      {
+         new SetParameterValueCommand(_overwrittenParameter, _overwrittenParameter.Value + 1.0).Run(sut);
+      }
+
+      [Observation]
+      public void should_track_the_change_as_an_uncommitted_change_of_the_compound()
+      {
+         _simulation.ParameterChangeTracker.IsTracked(_parameterPath).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_flag_the_compound_used_in_the_simulation_as_altered()
+      {
+         _simulation.UsedBuildingBlockByTemplateId(_compound.Id).Altered.ShouldBeFalse();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #3682
The parameters an overwrite parameter set overwrites are compound-dependent *simulation* parameters with no counterpart in the compound building block. Applying a set nevertheless set `Origin.BuilingBlockId` and `BuildingBlockType = Compound`, which broke change reporting in both directions:

- the origin flipped the altered flag of the compound in the simulation, so it turned red and offered *Show Differences* — but with no origin parameter to write to, the two compounds stayed identical and the comparison reported "No difference found";
- the building block type hid the edit from the change tracker, so it was never offered in *Commit Simulation Parameters to Compound* and never reached the project compound for the comparison to report.

The origin is no longer set, and the tracker now also picks up parameters overwritten by the set applied to the simulation. `BuildingBlockType` stays `Compound` so these parameters keep losing the reset behaviour of a simulation parameter.

**Second commit** — applying a set also stamped a synthetic `Overwrite Parameter Set '<name>'` value origin onto the parameter and ignored the one stored in the entry, so a value origin recorded in the compound survived a single commit and was then overwritten by the label on the next one. The label predates entries having a value origin of their own; it is dropped, and the value origin is now applied together with the value. Committing this here because the first commit is what makes the overwriting reachable — previously these parameters could not be committed at all.

> [!IMPORTANT]
> Projects saved before this change persist the bad origin and `altered="1"`, so reopening one still shows the old behaviour — the fix applies when the model is rebuilt. Verify with a simulation configured after this change.
