### PR TITLE
Fail a qualification run when errors are logged

### DIFF
--- a/src/PKSim.CLI/ErrorCountingLoggerProvider.cs
+++ b/src/PKSim.CLI/ErrorCountingLoggerProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace PKSim.CLI
+{
+   public class ErrorCountingLoggerProvider : ILoggerProvider
+   {
+      private int _errorCount;
+
+      public bool HasErrors => _errorCount > 0;
+
+      public ILogger CreateLogger(string categoryName) => new ErrorCountingLogger(this);
+
+      private void increment() => Interlocked.Increment(ref _errorCount);
+
+      public void Dispose()
+      {
+      }
+
+      private class ErrorCountingLogger : ILogger
+      {
+         private readonly ErrorCountingLoggerProvider _provider;
+
+         public ErrorCountingLogger(ErrorCountingLoggerProvider provider) => _provider = provider;
+
+         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+         {
+            if (logLevel >= LogLevel.Error)
+               _provider.increment();
+         }
+
+         public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+         public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+      }
+
+      private class NullScope : IDisposable
+      {
+         public static readonly NullScope Instance = new NullScope();
+
+         public void Dispose()
+         {
+         }
+      }
+   }
+}

--- a/src/PKSim.CLI/Program.cs
+++ b/src/PKSim.CLI/Program.cs
@@ -41,6 +41,7 @@ namespace PKSim.CLI
 
       private static void startCommand<TRunOptions>(CLICommand<TRunOptions> command)
       {
+         // If a qualification workflow logs errors, the return code should be non-zero
          var errorCounter = command is QualificationRunCommand ? new ErrorCountingLoggerProvider() : null;
 
          var logger = initializeLogger(command, errorCounter);

--- a/src/PKSim.CLI/Program.cs
+++ b/src/PKSim.CLI/Program.cs
@@ -41,7 +41,9 @@ namespace PKSim.CLI
 
       private static void startCommand<TRunOptions>(CLICommand<TRunOptions> command)
       {
-         var logger = initializeLogger(command);
+         var errorCounter = command is QualificationRunCommand ? new ErrorCountingLoggerProvider() : null;
+
+         var logger = initializeLogger(command, errorCounter);
          if (command.LogCommandName)
             logger.AddInfo($"Starting {command.Name.ToLower()} run");
 
@@ -58,11 +60,17 @@ namespace PKSim.CLI
             _valid = false;
          }
 
+         if (errorCounter != null && errorCounter.HasErrors)
+         {
+            logger.AddError("Qualification run finished with errors. See the log for details.");
+            _valid = false;
+         }
+
          if (command.LogCommandName)
             logger.AddInfo($"{command.Name} run finished");
       }
 
-      private static IOSPSuiteLogger initializeLogger(CLICommand runCommand)
+      private static IOSPSuiteLogger initializeLogger(CLICommand runCommand, ErrorCountingLoggerProvider errorCounter)
       {
          var loggerCreator = IoC.Resolve<ILoggerCreator>();
 
@@ -80,6 +88,9 @@ namespace PKSim.CLI
                builder
                   .SetMinimumLevel(runCommand.LogLevel)
                   .AddFile(runCommand.LogFilesFullPath.ToArray(), runCommand.LogLevel, true));
+
+         if (errorCounter != null)
+            loggerCreator.AddLoggingBuilderConfiguration(builder => builder.AddProvider(errorCounter));
 
          return logger;
       }

--- a/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/CompoundPropertiesMapper.cs
@@ -174,7 +174,7 @@ public class CompoundPropertiesMapper : SnapshotMapperBase<ModelCompoundProperti
          {
             //No process found and a name was specified. This is a snapshot that is corrupted
             if (!string.IsNullOrEmpty(snapshotProcess.Name))
-               _logger.AddWarning(PKSimConstants.Error.ProcessNotFoundInCompound(snapshotProcess.Name, compound.Name));
+               _logger.AddError(PKSimConstants.Error.ProcessNotFoundInCompound(snapshotProcess.Name, compound.Name));
 
             continue;
          }

--- a/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/OverwriteParameterSetSelectionMapper.cs
@@ -35,14 +35,14 @@ public class OverwriteParameterSetSelectionMapper : SnapshotMapperBase<ModelOver
       var compound = project.BuildingBlockByName<ModelCompound>(snapshot.CompoundName);
       if (compound == null)
       {
-         _logger.AddWarning(PKSimConstants.Error.SimulationTemplateBuildingBlockNotFoundInProject(snapshot.CompoundName, nameof(ModelCompound)));
+         _logger.AddError(PKSimConstants.Error.SimulationTemplateBuildingBlockNotFoundInProject(snapshot.CompoundName, nameof(ModelCompound)));
          return Task.FromResult<ModelOverwriteParameterSetSelection>(null);
       }
 
       var overwriteParameterSet = compound.OverwriteParameterSets.FirstOrDefault(x => x.IsNamed(snapshot.OverwriteParameterSetName));
       if (overwriteParameterSet == null)
       {
-         _logger.AddWarning(PKSimConstants.Error.OverWriteParameterSetNotFoundInCompound(snapshot.OverwriteParameterSetName, snapshot.CompoundName));
+         _logger.AddError(PKSimConstants.Error.OverWriteParameterSetNotFoundInCompound(snapshot.OverwriteParameterSetName, snapshot.CompoundName));
          return Task.FromResult<ModelOverwriteParameterSetSelection>(null);
       }
 

--- a/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
+++ b/src/PKSim.Core/Snapshots/Mappers/SimulationMapper.cs
@@ -357,7 +357,7 @@ namespace PKSim.Core.Snapshots.Mappers
          //No process found and a name was specified. This is a snapshot that is corrupted
          if (!string.IsNullOrEmpty(snapshotInteraction.Name))
          {
-            _logger.AddWarning(PKSimConstants.Error.ProcessNotFoundInCompound(snapshotInteraction.Name, snapshotInteraction.CompoundName));
+            _logger.AddError(PKSimConstants.Error.ProcessNotFoundInCompound(snapshotInteraction.Name, snapshotInteraction.CompoundName));
             return null;
          }
 

--- a/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionMapperSpecs.cs
+++ b/tests/PKSim.Tests/Core/OverwriteParameterSetSelectionMapperSpecs.cs
@@ -128,9 +128,9 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_log_a_warning()
+      public void should_log_an_error()
       {
-         A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Warning, A<string>._)).MustHaveHappened();
+         A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Error, A<string>._)).MustHaveHappened();
       }
    }
 
@@ -153,6 +153,12 @@ namespace PKSim.Core
       public void should_return_null()
       {
          _result.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_log_an_error()
+      {
+         A.CallTo(() => _logger.AddToLog(A<string>._, LogLevel.Error, A<string>._)).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #3705

Logged errors during a qualification run now set a non-zero exit code so the QualificationRunner stops instead of reporting success with wrong results.

- Add an error-counting logger provider to `PKSim.CLI`, registered for the qualification command; any `Error`/`Critical` message logged during the run fails it.
- Promote result-changing snapshot-mapping warnings (missing process, missing overwrite parameter set) to errors so they trip the gate.