### PR TITLE
Show the orange uncommitted-changes indicator on the simulation icon

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.Core/CoreConstants.cs
+++ b/src/PKSim.Core/CoreConstants.cs
@@ -7,7 +7,7 @@ namespace PKSim.Core
 {
    public static class CoreConstants
    {
-      public const int LAYOUT_VERSION = 38;
+      public const int LAYOUT_VERSION = 39;
       public const int DEFAULT_NUMBER_OF_BINS = 20;
       public const int DEFAULT_NUMBER_OF_INDIVIDUALS_PER_BIN = 100;
       public const int DEFAULT_NUMBER_OF_INDIVIDUALS_IN_POPULATION = 100;

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -691,6 +691,11 @@ namespace PKSim.Core.Model
          CompoundNames.FirstOrDefault(pathElements.Contains);
 
       /// <summary>
+      ///    Returns <c>true</c> if the simulation has any uncommitted compound-dependent parameter changes.
+      /// </summary>
+      public virtual bool HasUncommittedChanges => ParameterChangeTracker.HasUncommittedChanges;
+
+      /// <summary>
       ///    Returns <c>true</c> if the simulation has uncommitted compound-dependent parameter changes
       ///    for the compound with the given <paramref name="compoundName"/>.
       /// </summary>

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.159" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,11 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/Services/BuildingBlockIconRetriever.cs
+++ b/src/PKSim.Presentation/Services/BuildingBlockIconRetriever.cs
@@ -42,7 +42,9 @@ namespace PKSim.Presentation.Services
          if (simulation.AllowAging)
             iconName = $"Aging{iconName}";
 
-         return retrieveIconForStatus(iconName, _buildingBlockInProjectManager.StatusFor(simulation));
+         var icon = retrieveIconForStatus(iconName, _buildingBlockInProjectManager.StatusFor(simulation));
+
+         return simulation.HasUncommittedChanges ? ApplicationIcons.OrangeOverlayFor(icon) : icon;
       }
 
       public ApplicationIcon IconFor(UsedBuildingBlock usedBuildingBlock)

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -60,14 +60,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.153" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
+++ b/tests/PKSim.Tests/Core/IndividualSimulationSpecs.cs
@@ -705,6 +705,22 @@ namespace PKSim.Core
       }
    }
 
+   public class When_checking_if_a_simulation_has_uncommitted_changes : concern_for_IndividualSimulation_compound_path_matching
+   {
+      [Observation]
+      public void should_return_false_when_no_parameter_change_is_tracked()
+      {
+         sut.HasUncommittedChanges.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_return_true_once_a_parameter_change_is_tracked()
+      {
+         sut.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+         sut.HasUncommittedChanges.ShouldBeTrue();
+      }
+   }
+
    public abstract class concern_for_IndividualSimulation_with_compound : concern_for_IndividualSimulation
    {
       protected Compound _compound;

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.153" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.153" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Presentation/BuildingBlockIconRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Presentation/BuildingBlockIconRetrieverSpecs.cs
@@ -159,6 +159,86 @@ namespace PKSim.Presentation
       }
    }
 
+   public class When_retrieving_the_icon_for_a_simulation_with_uncommitted_changes : concern_for_BuildingBlockIconRetriever
+   {
+      private ApplicationIcon _result;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = new IndividualSimulation { Properties = new SimulationProperties(), ModelProperties = new ModelProperties() };
+         _simulation.ModelConfiguration = A.Fake<ModelConfiguration>();
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+
+         A.CallTo(() => _buildingBlockInProjectManager.StatusFor(_simulation)).Returns(BuildingBlockStatus.Green);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.IconFor(_simulation);
+      }
+
+      [Observation]
+      public void should_return_the_orange_overlay_variant_of_the_status_icon()
+      {
+         _result.ShouldBeEqualTo(ApplicationIcons.SimulationGreenOrange);
+      }
+   }
+
+   public class When_retrieving_the_icon_for_a_simulation_with_uncommitted_changes_and_red_status : concern_for_BuildingBlockIconRetriever
+   {
+      private ApplicationIcon _result;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = new IndividualSimulation { Properties = new SimulationProperties(), ModelProperties = new ModelProperties() };
+         _simulation.ModelConfiguration = A.Fake<ModelConfiguration>();
+         _simulation.ParameterChangeTracker.Track("Organism|Aspirin|Lipophilicity");
+
+         A.CallTo(() => _buildingBlockInProjectManager.StatusFor(_simulation)).Returns(BuildingBlockStatus.Red);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.IconFor(_simulation);
+      }
+
+      [Observation]
+      public void should_return_the_orange_overlay_variant_of_the_status_icon()
+      {
+         _result.ShouldBeEqualTo(ApplicationIcons.SimulationRedOrange);
+      }
+   }
+
+   public class When_retrieving_the_icon_for_a_simulation_without_uncommitted_changes : concern_for_BuildingBlockIconRetriever
+   {
+      private ApplicationIcon _result;
+      private IndividualSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = new IndividualSimulation { Properties = new SimulationProperties(), ModelProperties = new ModelProperties() };
+         _simulation.ModelConfiguration = A.Fake<ModelConfiguration>();
+
+         A.CallTo(() => _buildingBlockInProjectManager.StatusFor(_simulation)).Returns(BuildingBlockStatus.Green);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.IconFor(_simulation);
+      }
+
+      [Observation]
+      public void should_return_the_plain_status_icon()
+      {
+         _result.ShouldBeEqualTo(ApplicationIcons.SimulationGreen);
+      }
+   }
+
    public class When_retrieving_icon_for_non_compound_building_block_with_simulation : concern_for_BuildingBlockIconRetriever
    {
       private ApplicationIcon _result;

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.153" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.153" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.159" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.153" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.159" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Overlays the orange "!" badge on the simulation icon when it has uncommitted compound-parameter changes, so the change is visible at the simulation level (previously only shown on the compound icon).

Bumps the OSPSuite packages to 13.0.159 for the new overlay icons (OSPSuite.Core#2955).

Also bumps `LAYOUT_VERSION` so persisted ribbon/dock layouts reset — the new icons shift the ordinal image indices, which would otherwise show stale icons for existing dev/beta profiles.

Fixes #3660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulations now indicate when they contain uncommitted parameter changes.
  - Simulation icons display an orange overlay when changes are pending, while preserving the simulation’s status color.

- **Improvements**
  - Updated the application’s underlying platform components for improved compatibility and consistency.
  - Updated the layout version to support the latest simulation data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->