### PR TITLE
Fixes #3699 Exclude `PK-Sim Ontogeny Database Version 7.3.pdf` from Setup

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -44,7 +44,7 @@ task :create_setup, [:product_version, :configuration] do |t, args|
 		'examples/*.txt',
 		'src/PKSim.UI/Resources/*.ico',
 		'Open Systems Pharmacology Suite License.pdf',
-		'documentation/*.pdf',
+		*documentation_files,
 		'dimensions/*.xml',
 		'pkparameters/*.xml',
 		'setup/setup.wxs',
@@ -81,7 +81,7 @@ task :create_portable_setup, [:product_version, :configuration, :package_name] d
 	#Files required for setup creation only and that will not be harvested automatically
 	setup_files	 = [
 		'Open Systems Pharmacology Suite License.pdf',
-		'documentation/*.pdf',
+		*documentation_files,
 		'dimensions/*.xml',
 		'pkparameters/*.xml',
 		'setup/**/*.{rtf}'
@@ -157,6 +157,20 @@ end
 
 def solution_dir
 	File.dirname(__FILE__)
+end
+
+#Documentation files that are kept in the documentation repo as legacy only and that should not be shipped
+def legacy_documentation_files
+	[
+		'PK-Sim Ontogeny Database Version 7.3.pdf'
+	]
+end
+
+def documentation_files
+	Dir.glob(File.join(solution_dir, 'documentation', '*.pdf'))
+		.map { |file| File.basename(file) }
+		.reject { |file| legacy_documentation_files.include?(file) }
+		.map { |file| "documentation/#{file}" }
 end
 
 def	manufacturer


### PR DESCRIPTION
Fixes #3699

`PK-Sim Ontogeny Database Version 7.3.pdf` was shipped because both setup tasks glob `documentation/*.pdf`. The file is outdated and only kept in the documentation repo as legacy, so it should not be installed.

### Change

Both `create_setup` and `create_portable_setup` now use a `documentation_files` helper instead of the raw glob. The helper expands `documentation/*.pdf` itself and rejects entries listed in `legacy_documentation_files`:

```ruby
def documentation_files
	Dir.glob(File.join(solution_dir, 'documentation', '*.pdf'))
		.map { |file| File.basename(file) }
		.reject { |file| legacy_documentation_files.include?(file) }
		.map { |file| "documentation/#{file}" }
end
```

Exclusion is by name rather than by replacing the glob with an explicit include list, so the new ontogeny documentation will still be picked up automatically once the documentation submodule is updated — no further rakefile change needed.

### Note on the MSI

Only the portable package actually shipped the file. The MSI declares its pdf components explicitly in `setup/setup.wxs` (license + `Open Systems Pharmacology Suite.pdf`) and the heat harvest only covers the src dir, so the ontogeny pdf was copied into the deploy folder and then ignored. Both call sites are changed anyway, since the issue references both and leaving them divergent would be confusing.

The corollary is that the new ontogeny documentation will flow into the portable zip automatically but will need its own `<Component>` in `setup.wxs` to appear in the MSI. Out of scope here — happy to open a follow-up if wanted.

### Verification

- `ruby -c rakefile.rb` → Syntax OK
- Running the helper against the current submodule content returns exactly `["documentation/Open Systems Pharmacology Suite.pdf"]`, and that relative path re-globs correctly through `copy_setup_files`' `File.join(@solution_dir, file)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)