### PR TITLE
Fixes #3709 Make the building-block lazy-load chain thread-safe

### DIFF
--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Assets/PKSim.Assets.csproj
+++ b/src/PKSim.Assets/PKSim.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.BatchTool/PKSim.BatchTool.csproj
+++ b/src/PKSim.BatchTool/PKSim.BatchTool.csproj
@@ -40,8 +40,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
+++ b/src/PKSim.CLI.Core/PKSim.CLI.Core.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.165" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.CLI/PKSim.CLI.csproj
+++ b/src/PKSim.CLI/PKSim.CLI.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />

--- a/src/PKSim.Core/Chart/IndividualSimulationComparison.cs
+++ b/src/PKSim.Core/Chart/IndividualSimulationComparison.cs
@@ -9,7 +9,15 @@ namespace PKSim.Core.Chart
    {
       private readonly ICache<string, IndividualSimulation> _allSimulations;
 
-      public bool IsLoaded { get; set; }
+      //see ILazyLoadable: lazy loading reads this flag without holding the lock that guards the load, so it is
+      //published with a volatile field to make the writes that loaded the object visible with it
+      private volatile bool _isLoaded;
+
+      public bool IsLoaded
+      {
+         get => _isLoaded;
+         set => _isLoaded = value;
+      }
 
       public IndividualSimulationComparison()
       {

--- a/src/PKSim.Core/Model/PKSimBuildingBlock.cs
+++ b/src/PKSim.Core/Model/PKSimBuildingBlock.cs
@@ -31,7 +31,15 @@ namespace PKSim.Core.Model
 
    public abstract class PKSimBuildingBlock : Entity, IPKSimBuildingBlock
    {
-      public virtual bool IsLoaded { get; set; }
+      //see ILazyLoadable: lazy loading reads this flag without holding the lock that guards the load, so it is
+      //published with a volatile field to make the writes that loaded the object visible with it
+      private volatile bool _isLoaded;
+
+      public virtual bool IsLoaded
+      {
+         get => _isLoaded;
+         set => _isLoaded = value;
+      }
       public virtual bool HasChanged { get; set; }
       public virtual string ExtendedDescription { get; set; }
       public virtual CreationMetaData Creation { get; set; }

--- a/src/PKSim.Core/Model/Population.cs
+++ b/src/PKSim.Core/Model/Population.cs
@@ -140,9 +140,11 @@ namespace PKSim.Core.Model
       {
          set
          {
-            base.IsLoaded = value;
+            //the individual is flagged first so that a reader seeing the population loaded also sees its
+            //individual loaded (the base setter is the volatile publication)
             if (FirstIndividual != null)
                FirstIndividual.IsLoaded = value;
+            base.IsLoaded = value;
          }
       }
 

--- a/src/PKSim.Core/Model/Population.cs
+++ b/src/PKSim.Core/Model/Population.cs
@@ -140,8 +140,8 @@ namespace PKSim.Core.Model
       {
          set
          {
-            //the individual is flagged first so that a reader seeing the population loaded also sees its
-            //individual loaded (the base setter is the volatile publication)
+            //the individual is flagged first so that a load never publishes the population as loaded
+            //before its individual (the base setter is the volatile publication)
             if (FirstIndividual != null)
                FirstIndividual.IsLoaded = value;
             base.IsLoaded = value;

--- a/src/PKSim.Core/Model/PopulationSimulationComparison.cs
+++ b/src/PKSim.Core/Model/PopulationSimulationComparison.cs
@@ -15,7 +15,15 @@ namespace PKSim.Core.Model
    {
       private readonly ICache<string, PopulationSimulation> _allSimulations = new Cache<string, PopulationSimulation>(x => x.Id);
       private readonly IList<ISimulationAnalysis> _allSimulationAnalyses = new List<ISimulationAnalysis>();
-      public bool IsLoaded { get; set; }
+      //see ILazyLoadable: lazy loading reads this flag without holding the lock that guards the load, so it is
+      //published with a volatile field to make the writes that loaded the object visible with it
+      private volatile bool _isLoaded;
+
+      public bool IsLoaded
+      {
+         get => _isLoaded;
+         set => _isLoaded = value;
+      }
       public virtual PopulationSimulation ReferenceSimulation { get; set; }
       public virtual GroupingItem ReferenceGroupingItem { get; set; }
       public virtual ParameterDistributionSettingsCache SelectedDistributions { get; }

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -618,8 +618,8 @@ namespace PKSim.Core.Model
       {
          set
          {
-            //the used building blocks are flagged first so that a reader seeing the simulation loaded also
-            //sees its building blocks loaded (the base setter is the volatile publication)
+            //the used building blocks are flagged first so that a load never publishes the simulation as
+            //loaded before its building blocks (the base setter is the volatile publication)
             UsedBuildingBlocks.Each(bb => bb.IsLoaded = value);
             base.IsLoaded = value;
          }

--- a/src/PKSim.Core/Model/Simulation.cs
+++ b/src/PKSim.Core/Model/Simulation.cs
@@ -618,8 +618,10 @@ namespace PKSim.Core.Model
       {
          set
          {
-            base.IsLoaded = value;
+            //the used building blocks are flagged first so that a reader seeing the simulation loaded also
+            //sees its building blocks loaded (the base setter is the volatile publication)
             UsedBuildingBlocks.Each(bb => bb.IsLoaded = value);
+            base.IsLoaded = value;
          }
       }
 

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.165" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/PKSim.Core.csproj
+++ b/src/PKSim.Core/PKSim.Core.csproj
@@ -26,10 +26,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.164" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
+++ b/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
@@ -14,6 +14,7 @@ namespace PKSim.Core.Services
       private readonly IIndividualFactory _individualFactory;
       private readonly OriginDataMapper _originDataMapper;
       private readonly ICache<SpeciesPopulation, Individual> _individualCacheProSpecies = new Cache<SpeciesPopulation, Individual>();
+      private readonly object _locker = new object();
 
       public DefaultIndividualRetriever(
          ISpeciesRepository speciesRepository,
@@ -49,21 +50,24 @@ namespace PKSim.Core.Services
 
       public Individual DefaultIndividualFor(SpeciesPopulation speciesPopulation)
       {
-         if (!_individualCacheProSpecies.Contains(speciesPopulation))
+         lock (_locker)
          {
-            var originDataSnapshot = new OriginData
+            if (!_individualCacheProSpecies.Contains(speciesPopulation))
             {
-               Species = speciesPopulation.Species,
-               Population = speciesPopulation.Name,
-               Gender = DefaultGenderFor(speciesPopulation).Name
-            };
+               var originDataSnapshot = new OriginData
+               {
+                  Species = speciesPopulation.Species,
+                  Population = speciesPopulation.Name,
+                  Gender = DefaultGenderFor(speciesPopulation).Name
+               };
 
-            //We do not need to pass any valid snapshot context in this case.
-            var originData = _originDataMapper.MapToModel(originDataSnapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current)).Result;
-            _individualCacheProSpecies[speciesPopulation] = _individualFactory.CreateStandardFor(originData);
+               //We do not need to pass any valid snapshot context in this case.
+               var originData = _originDataMapper.MapToModel(originDataSnapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current)).Result;
+               _individualCacheProSpecies[speciesPopulation] = _individualFactory.CreateStandardFor(originData);
+            }
+
+            return _individualCacheProSpecies[speciesPopulation];
          }
-
-         return _individualCacheProSpecies[speciesPopulation];
       }
    }
 }

--- a/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
+++ b/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
@@ -1,6 +1,8 @@
-﻿using OSPSuite.Core.Snapshots;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using OSPSuite.Core.Snapshots;
 using OSPSuite.Core.Snapshots.Mappers;
-using OSPSuite.Utility.Collections;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
 using PKSim.Core.Snapshots.Mappers;
@@ -13,8 +15,7 @@ namespace PKSim.Core.Services
       private readonly ISpeciesRepository _speciesRepository;
       private readonly IIndividualFactory _individualFactory;
       private readonly OriginDataMapper _originDataMapper;
-      private readonly ICache<SpeciesPopulation, Individual> _individualCacheProSpecies = new Cache<SpeciesPopulation, Individual>();
-      private readonly object _locker = new object();
+      private readonly ConcurrentDictionary<SpeciesPopulation, Lazy<Individual>> _individualCacheProSpecies = new ConcurrentDictionary<SpeciesPopulation, Lazy<Individual>>();
 
       public DefaultIndividualRetriever(
          ISpeciesRepository speciesRepository,
@@ -50,24 +51,22 @@ namespace PKSim.Core.Services
 
       public Individual DefaultIndividualFor(SpeciesPopulation speciesPopulation)
       {
-         lock (_locker)
+         return _individualCacheProSpecies.GetOrAdd(speciesPopulation,
+            population => new Lazy<Individual>(() => createDefaultIndividualFor(population), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+      }
+
+      private Individual createDefaultIndividualFor(SpeciesPopulation speciesPopulation)
+      {
+         var originDataSnapshot = new OriginData
          {
-            if (!_individualCacheProSpecies.Contains(speciesPopulation))
-            {
-               var originDataSnapshot = new OriginData
-               {
-                  Species = speciesPopulation.Species,
-                  Population = speciesPopulation.Name,
-                  Gender = DefaultGenderFor(speciesPopulation).Name
-               };
+            Species = speciesPopulation.Species,
+            Population = speciesPopulation.Name,
+            Gender = DefaultGenderFor(speciesPopulation).Name
+         };
 
-               //We do not need to pass any valid snapshot context in this case.
-               var originData = _originDataMapper.MapToModel(originDataSnapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current)).Result;
-               _individualCacheProSpecies[speciesPopulation] = _individualFactory.CreateStandardFor(originData);
-            }
-
-            return _individualCacheProSpecies[speciesPopulation];
-         }
+         //We do not need to pass any valid snapshot context in this case.
+         var originData = _originDataMapper.MapToModel(originDataSnapshot, new SnapshotContext(new PKSimProject(), SnapshotVersions.Current)).Result;
+         return _individualFactory.CreateStandardFor(originData);
       }
    }
 }

--- a/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
+++ b/src/PKSim.Core/Services/DefaultIndividualRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using OSPSuite.Core.Snapshots;
 using OSPSuite.Core.Snapshots.Mappers;
@@ -51,8 +52,19 @@ namespace PKSim.Core.Services
 
       public Individual DefaultIndividualFor(SpeciesPopulation speciesPopulation)
       {
-         return _individualCacheProSpecies.GetOrAdd(speciesPopulation,
-            population => new Lazy<Individual>(() => createDefaultIndividualFor(population), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+         var cachedIndividual = _individualCacheProSpecies.GetOrAdd(speciesPopulation,
+            population => new Lazy<Individual>(() => createDefaultIndividualFor(population), LazyThreadSafetyMode.ExecutionAndPublication));
+
+         try
+         {
+            return cachedIndividual.Value;
+         }
+         catch
+         {
+            //a lazy that faulted keeps throwing the same exception, so the entry is dropped to let the next call retry
+            _individualCacheProSpecies.TryRemove(new KeyValuePair<SpeciesPopulation, Lazy<Individual>>(speciesPopulation, cachedIndividual));
+            throw;
+         }
       }
 
       private Individual createDefaultIndividualFor(SpeciesPopulation speciesPopulation)

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.165" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
+++ b/src/PKSim.Infrastructure/PKSim.Infrastructure.csproj
@@ -36,13 +36,13 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -18,8 +18,12 @@ namespace PKSim.Infrastructure.Services
       private readonly ISimulationAnalysesLoader _simulationAnalysesLoader;
       private readonly IParameterIdentificationContentLoader _parameterIdentificationContentLoader;
       private readonly ISensitivityAnalysisContentLoader _sensitivityAnalysisContentLoader;
-      //lazy loading is gated per object rather than on the object itself, whose monitor any other code could take.
-      //The table is keyed by reference and holds its keys weakly, so a gate never outlives the object it guards.
+      //each object is loaded under its own gate, taken on a private object rather than on the object's own monitor,
+      //which any other code could take as well. The table is keyed by reference and holds its keys weakly, so a gate
+      //never outlives the object it guards.
+      //A load holds its gate while nested loads happen: deserializing a comparison, a parameter identification or a
+      //chart loads the simulations it references. Those references only point from a container to a simulation and
+      //never back, so gates are always taken in that one direction and cannot deadlock.
       private static readonly ConditionalWeakTable<object, object> _loadGates = new ConditionalWeakTable<object, object>();
 
       public LazyLoadTask(
@@ -44,9 +48,11 @@ namespace PKSim.Infrastructure.Services
 
       private static object gateFor(object objectToLoad) => _loadGates.GetValue(objectToLoad, x => new object());
 
+      //the gate is held for the whole load, so nothing reached from here may wait on the UI thread
       public void Load<TObject>(TObject objectToLoad) where TObject : class, ILazyLoadable
       {
-         if (objectToLoad == null) return;
+         //an object that is already loaded is the common case and must not pay for the gate
+         if (objectToLoad == null || objectToLoad.IsLoaded) return;
 
          lock (gateFor(objectToLoad))
          {
@@ -76,10 +82,11 @@ namespace PKSim.Infrastructure.Services
          if (simulation == null)
             return;
 
-         Load(simulation);
-
+         //one gate for both steps: loading the simulation may already have loaded its results
          lock (gateFor(simulation))
          {
+            Load(simulation);
+
             if (simulation.HasResults)
                return;
 

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -25,9 +25,11 @@ namespace PKSim.Infrastructure.Services
       //chart loads the simulations it references. Those references only point from a container to a simulation and
       //never back, so gates are always taken in that one direction and cannot deadlock.
       //Completing a load also flags owned children as loaded without taking their gates (a simulation flags its
-      //used building blocks, a population its base individual). That is safe because those children are private
-      //copies deserialized as part of their owner's content: they are not reachable until the owner's load
-      //completes and no other load path targets the same instances.
+      //used building blocks, a population its base individual). That is safe because a child only becomes
+      //reachable once its owner is loaded, and a load flags the children before publishing the owner's flag,
+      //so a later Load on a child fast-paths out. The guarantee belongs to the load, not to the object graph:
+      //BuildingBlockInSimulationSynchronizer can hand a loaded simulation an unloaded clone, which is then
+      //loaded under its own gate like any other object.
       private static readonly ConditionalWeakTable<object, object> _loadGates = new ConditionalWeakTable<object, object>();
 
       public LazyLoadTask(
@@ -82,8 +84,8 @@ namespace PKSim.Infrastructure.Services
          }
       }
 
-      //no already-loaded fast path here: unlike IsLoaded, HasResults carries no publication guarantee, and
-      //results are loaded per chart or analysis rather than on hot paths, so the uncontended gate is cheap
+      //no already-loaded fast path here: unlike IsLoaded, HasResults carries no publication guarantee, so the
+      //gate is always taken - uncontended, it costs a few nanoseconds per call
       public void LoadResults<TSimulation>(TSimulation simulation) where TSimulation : Simulation
       {
          if (simulation == null)

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -38,26 +38,34 @@ namespace PKSim.Infrastructure.Services
          _sensitivityAnalysisContentLoader = sensitivityAnalysisContentLoader;
       }
 
+      //instances are transient: the gate is shared so that the same object is never loaded by two threads at once
+      private static readonly object _loadLock = new object();
+
       public void Load<TObject>(TObject objectToLoad) where TObject : class, ILazyLoadable
       {
          if (objectToLoad == null || objectToLoad.IsLoaded) return;
 
-         if (objectToLoad.IsAnImplementationOf<ISimulationComparison>())
-            _simulationComparisonContentLoader.LoadContentFor(objectToLoad.DowncastTo<ISimulationComparison>());
+         lock (_loadLock)
+         {
+            if (objectToLoad.IsLoaded) return;
 
-         else if (objectToLoad.IsAnImplementationOf<ParameterIdentification>())
-            _parameterIdentificationContentLoader.LoadContentFor(objectToLoad.DowncastTo<ParameterIdentification>());
+            if (objectToLoad.IsAnImplementationOf<ISimulationComparison>())
+               _simulationComparisonContentLoader.LoadContentFor(objectToLoad.DowncastTo<ISimulationComparison>());
 
-         else if (objectToLoad.IsAnImplementationOf<SensitivityAnalysis>())
-            _sensitivityAnalysisContentLoader.LoadContentFor(objectToLoad.DowncastTo<SensitivityAnalysis>());
+            else if (objectToLoad.IsAnImplementationOf<ParameterIdentification>())
+               _parameterIdentificationContentLoader.LoadContentFor(objectToLoad.DowncastTo<ParameterIdentification>());
 
-         else if (objectToLoad.IsAnImplementationOf<IObjectBase>())
-            loadObjectBase(objectToLoad as IObjectBase);
+            else if (objectToLoad.IsAnImplementationOf<SensitivityAnalysis>())
+               _sensitivityAnalysisContentLoader.LoadContentFor(objectToLoad.DowncastTo<SensitivityAnalysis>());
 
-         else
-            return;
+            else if (objectToLoad.IsAnImplementationOf<IObjectBase>())
+               loadObjectBase(objectToLoad as IObjectBase);
 
-         objectToLoad.IsLoaded = true;
+            else
+               return;
+
+            objectToLoad.IsLoaded = true;
+         }
       }
 
       public void LoadResults<TSimulation>(TSimulation simulation) where TSimulation : Simulation

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -38,7 +38,6 @@ namespace PKSim.Infrastructure.Services
          _sensitivityAnalysisContentLoader = sensitivityAnalysisContentLoader;
       }
 
-      //instances are transient: the gate is shared so that the same object is never loaded by two threads at once
       private static readonly object _loadLock = new object();
 
       public void Load<TObject>(TObject objectToLoad) where TObject : class, ILazyLoadable

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -18,6 +18,8 @@ namespace PKSim.Infrastructure.Services
       private readonly ISimulationAnalysesLoader _simulationAnalysesLoader;
       private readonly IParameterIdentificationContentLoader _parameterIdentificationContentLoader;
       private readonly ISensitivityAnalysisContentLoader _sensitivityAnalysisContentLoader;
+      //lazy loading is gated per object rather than on the object itself, whose monitor any other code could take.
+      //The table is keyed by reference and holds its keys weakly, so a gate never outlives the object it guards.
       private static readonly ConditionalWeakTable<object, object> _loadGates = new ConditionalWeakTable<object, object>();
 
       public LazyLoadTask(

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.ParameterIdentifications;
 using OSPSuite.Core.Domain.SensitivityAnalyses;
@@ -17,6 +18,7 @@ namespace PKSim.Infrastructure.Services
       private readonly ISimulationAnalysesLoader _simulationAnalysesLoader;
       private readonly IParameterIdentificationContentLoader _parameterIdentificationContentLoader;
       private readonly ISensitivityAnalysisContentLoader _sensitivityAnalysisContentLoader;
+      private static readonly ConditionalWeakTable<object, object> _loadGates = new ConditionalWeakTable<object, object>();
 
       public LazyLoadTask(
          IContentLoader contentLoader,
@@ -38,13 +40,13 @@ namespace PKSim.Infrastructure.Services
          _sensitivityAnalysisContentLoader = sensitivityAnalysisContentLoader;
       }
 
-      private static readonly object _loadLock = new object();
+      private static object gateFor(object objectToLoad) => _loadGates.GetValue(objectToLoad, x => new object());
 
       public void Load<TObject>(TObject objectToLoad) where TObject : class, ILazyLoadable
       {
-         if (objectToLoad == null || objectToLoad.IsLoaded) return;
+         if (objectToLoad == null) return;
 
-         lock (_loadLock)
+         lock (gateFor(objectToLoad))
          {
             if (objectToLoad.IsLoaded) return;
 
@@ -74,10 +76,13 @@ namespace PKSim.Infrastructure.Services
 
          Load(simulation);
 
-         if (simulation.HasResults)
-            return;
+         lock (gateFor(simulation))
+         {
+            if (simulation.HasResults)
+               return;
 
-         _simulationResultsLoader.LoadResultsFor(simulation);
+            _simulationResultsLoader.LoadResultsFor(simulation);
+         }
       }
 
       public void LoadResults(IPopulationDataCollector populationDataCollector)

--- a/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
+++ b/src/PKSim.Infrastructure/Services/LazyLoadTask.cs
@@ -24,6 +24,10 @@ namespace PKSim.Infrastructure.Services
       //A load holds its gate while nested loads happen: deserializing a comparison, a parameter identification or a
       //chart loads the simulations it references. Those references only point from a container to a simulation and
       //never back, so gates are always taken in that one direction and cannot deadlock.
+      //Completing a load also flags owned children as loaded without taking their gates (a simulation flags its
+      //used building blocks, a population its base individual). That is safe because those children are private
+      //copies deserialized as part of their owner's content: they are not reachable until the owner's load
+      //completes and no other load path targets the same instances.
       private static readonly ConditionalWeakTable<object, object> _loadGates = new ConditionalWeakTable<object, object>();
 
       public LazyLoadTask(
@@ -49,6 +53,7 @@ namespace PKSim.Infrastructure.Services
       private static object gateFor(object objectToLoad) => _loadGates.GetValue(objectToLoad, x => new object());
 
       //the gate is held for the whole load, so nothing reached from here may wait on the UI thread
+      //(the closest edge is loadSimulations -> SimulationChartsLoader/ChartTask in PKSim.Presentation, clean today)
       public void Load<TObject>(TObject objectToLoad) where TObject : class, ILazyLoadable
       {
          //an object that is already loaded is the common case and must not pay for the gate
@@ -77,6 +82,8 @@ namespace PKSim.Infrastructure.Services
          }
       }
 
+      //no already-loaded fast path here: unlike IsLoaded, HasResults carries no publication guarantee, and
+      //results are loaded per chart or analysis rather than on hot paths, so the uncontended gate is cheap
       public void LoadResults<TSimulation>(TSimulation simulation) where TSimulation : Simulation
       {
          if (simulation == null)

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,11 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.Presentation/PKSim.Presentation.csproj
+++ b/src/PKSim.Presentation/PKSim.Presentation.csproj
@@ -22,11 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.R/PKSim.R.csproj
+++ b/src/PKSim.R/PKSim.R.csproj
@@ -36,10 +36,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.165" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.Starter/PKSim.Starter.csproj
+++ b/src/PKSim.Starter/PKSim.Starter.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.165" />
   </ItemGroup>
 
 </Project>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim.UI/PKSim.UI.csproj
+++ b/src/PKSim.UI/PKSim.UI.csproj
@@ -46,13 +46,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -60,14 +60,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PKSim/PKSim.csproj
+++ b/src/PKSim/PKSim.csproj
@@ -60,14 +60,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.165" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
+++ b/tests/PKSim.R.Tests/PKSim.R.Tests.csproj
@@ -17,9 +17,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Utility.Exceptions;
 using PKSim.Core.Model;
 using PKSim.Core.Repositories;
 using PKSim.Core.Services;
@@ -37,17 +38,20 @@ namespace PKSim.Core
       private Individual _secondResult;
       private ManualResetEventSlim _creationStarted;
       private ManualResetEventSlim _releaseCreation;
+      private ManualResetEventSlim _secondRetrievalStarted;
+      private bool _secondRetrievalWasBlocked;
 
       protected override void Context()
       {
          base.Context();
          _creationStarted = new ManualResetEventSlim();
          _releaseCreation = new ManualResetEventSlim();
+         _secondRetrievalStarted = new ManualResetEventSlim();
 
          A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).ReturnsLazily(() =>
          {
             _creationStarted.Set();
-            _releaseCreation.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+            _releaseCreation.Wait(TimeSpan.FromSeconds(5));
             return A.Fake<Individual>();
          });
       }
@@ -55,15 +59,35 @@ namespace PKSim.Core
       protected override void Because()
       {
          var firstRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
-         //the second retrieval only starts once the first is creating, so it has to wait for that creation
-         _creationStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         _creationStarted.Wait(TimeSpan.FromSeconds(5));
 
-         var secondRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
+         var secondRetrieval = Task.Run(() =>
+         {
+            _secondRetrievalStarted.Set();
+            return sut.DefaultIndividualFor(_speciesPopulation);
+         });
+
+         //the second retrieval is running and has to wait for the creation already in progress
+         _secondRetrievalStarted.Wait(TimeSpan.FromSeconds(5));
+         _secondRetrievalWasBlocked = !secondRetrieval.Wait(TimeSpan.FromMilliseconds(500));
+
          _releaseCreation.Set();
-
-         Task.WaitAll(new[] { firstRetrieval, secondRetrieval }, TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         Task.WaitAll(new[] {firstRetrieval, secondRetrieval}, TimeSpan.FromSeconds(5));
          _firstResult = firstRetrieval.Result;
          _secondResult = secondRetrieval.Result;
+      }
+
+      public override void Cleanup()
+      {
+         _creationStarted.Dispose();
+         _releaseCreation.Dispose();
+         _secondRetrievalStarted.Dispose();
+      }
+
+      [Observation]
+      public void should_make_the_second_retrieval_wait_for_the_creation()
+      {
+         _secondRetrievalWasBlocked.ShouldBeTrue();
       }
 
       [Observation]
@@ -76,6 +100,77 @@ namespace PKSim.Core
       public void should_serve_both_callers_from_the_same_cache_entry()
       {
          ReferenceEquals(_firstResult, _secondResult).ShouldBeTrue();
+      }
+   }
+
+   public class When_retrieving_the_default_individual_for_different_populations_from_multiple_threads : concern_for_DefaultIndividualRetriever
+   {
+      private SpeciesPopulation _otherPopulation;
+      private ManualResetEventSlim _creationStarted;
+      private ManualResetEventSlim _releaseCreation;
+      private bool _otherRetrievalCompleted;
+
+      protected override void Context()
+      {
+         base.Context();
+         _creationStarted = new ManualResetEventSlim();
+         _releaseCreation = new ManualResetEventSlim();
+
+         _otherPopulation = new SpeciesPopulation {Name = "OTHER_POP", Species = "HUMAN"};
+         _otherPopulation.AddGender(new Gender {Name = "MALE"});
+
+         //the mapper is a fake, so the created individuals cannot be told apart by origin data: the first creation
+         //is the blocked one and any later creation returns straight away
+         A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).ReturnsLazily(() =>
+         {
+            _creationStarted.Set();
+            _releaseCreation.Wait(TimeSpan.FromSeconds(5));
+            return A.Fake<Individual>();
+         }).Once().Then.ReturnsLazily(() => A.Fake<Individual>());
+      }
+
+      protected override void Because()
+      {
+         var blockedRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
+         _creationStarted.Wait(TimeSpan.FromSeconds(5));
+
+         //a different population must not wait for the creation already in progress
+         _otherRetrievalCompleted = Task.Run(() => sut.DefaultIndividualFor(_otherPopulation)).Wait(TimeSpan.FromSeconds(2));
+
+         _releaseCreation.Set();
+         blockedRetrieval.Wait(TimeSpan.FromSeconds(5));
+      }
+
+      public override void Cleanup()
+      {
+         _creationStarted.Dispose();
+         _releaseCreation.Dispose();
+      }
+
+      [Observation]
+      public void should_not_block_the_retrieval_for_an_unrelated_population()
+      {
+         _otherRetrievalCompleted.ShouldBeTrue();
+      }
+   }
+
+   public class When_the_creation_of_the_default_individual_fails : concern_for_DefaultIndividualRetriever
+   {
+      private Individual _individual;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individual = A.Fake<Individual>();
+         A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).Throws<OSPSuiteException>().Once()
+            .Then.Returns(_individual);
+      }
+
+      [Observation]
+      public void should_not_cache_the_failure_and_create_the_individual_on_the_next_call()
+      {
+         The.Action(() => sut.DefaultIndividualFor(_speciesPopulation)).ShouldThrowAn<OSPSuiteException>();
+         sut.DefaultIndividualFor(_speciesPopulation).ShouldBeEqualTo(_individual);
       }
    }
 }

--- a/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -34,13 +35,19 @@ namespace PKSim.Core
    {
       private Individual _firstResult;
       private Individual _secondResult;
+      private ManualResetEventSlim _creationStarted;
+      private ManualResetEventSlim _releaseCreation;
 
       protected override void Context()
       {
          base.Context();
+         _creationStarted = new ManualResetEventSlim();
+         _releaseCreation = new ManualResetEventSlim();
+
          A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).ReturnsLazily(() =>
          {
-            Thread.Sleep(300);
+            _creationStarted.Set();
+            _releaseCreation.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
             return A.Fake<Individual>();
          });
       }
@@ -48,8 +55,13 @@ namespace PKSim.Core
       protected override void Because()
       {
          var firstRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
+         //the second retrieval only starts once the first is creating, so it has to wait for that creation
+         _creationStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
          var secondRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
-         Task.WaitAll(firstRetrieval, secondRetrieval);
+         _releaseCreation.Set();
+
+         Task.WaitAll(new[] { firstRetrieval, secondRetrieval }, TimeSpan.FromSeconds(5)).ShouldBeTrue();
          _firstResult = firstRetrieval.Result;
          _secondResult = secondRetrieval.Result;
       }
@@ -61,9 +73,9 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_return_the_same_cached_instance_to_all_callers()
+      public void should_serve_both_callers_from_the_same_cache_entry()
       {
-         _firstResult.ShouldBeEqualTo(_secondResult);
+         ReferenceEquals(_firstResult, _secondResult).ShouldBeTrue();
       }
    }
 }

--- a/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
@@ -59,7 +59,7 @@ namespace PKSim.Core
       protected override void Because()
       {
          var firstRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
-         _creationStarted.Wait(TimeSpan.FromSeconds(5));
+         _creationStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
          var secondRetrieval = Task.Run(() =>
          {
@@ -67,18 +67,21 @@ namespace PKSim.Core
             return sut.DefaultIndividualFor(_speciesPopulation);
          });
 
-         //the second retrieval is running and has to wait for the creation already in progress
-         _secondRetrievalStarted.Wait(TimeSpan.FromSeconds(5));
+         //the second retrieval is running and has to wait for the creation already in progress. A retrieval
+         //that never reached the cache in time would also read as blocked here: the guard was verified by
+         //making the creation eager, which makes the observation fail
+         _secondRetrievalStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
          _secondRetrievalWasBlocked = !secondRetrieval.Wait(TimeSpan.FromMilliseconds(500));
 
          _releaseCreation.Set();
-         Task.WaitAll(new[] {firstRetrieval, secondRetrieval}, TimeSpan.FromSeconds(5));
+         Task.WaitAll(new[] {firstRetrieval, secondRetrieval}, TimeSpan.FromSeconds(5)).ShouldBeTrue();
          _firstResult = firstRetrieval.Result;
          _secondResult = secondRetrieval.Result;
       }
 
       public override void Cleanup()
       {
+         base.Cleanup();
          _creationStarted.Dispose();
          _releaseCreation.Dispose();
          _secondRetrievalStarted.Dispose();
@@ -132,17 +135,18 @@ namespace PKSim.Core
       protected override void Because()
       {
          var blockedRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
-         _creationStarted.Wait(TimeSpan.FromSeconds(5));
+         _creationStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
          //a different population must not wait for the creation already in progress
          _otherRetrievalCompleted = Task.Run(() => sut.DefaultIndividualFor(_otherPopulation)).Wait(TimeSpan.FromSeconds(2));
 
          _releaseCreation.Set();
-         blockedRetrieval.Wait(TimeSpan.FromSeconds(5));
+         blockedRetrieval.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
       }
 
       public override void Cleanup()
       {
+         base.Cleanup();
          _creationStarted.Dispose();
          _releaseCreation.Dispose();
       }
@@ -170,7 +174,7 @@ namespace PKSim.Core
       public void should_not_cache_the_failure_and_create_the_individual_on_the_next_call()
       {
          The.Action(() => sut.DefaultIndividualFor(_speciesPopulation)).ShouldThrowAn<OSPSuiteException>();
-         sut.DefaultIndividualFor(_speciesPopulation).ShouldBeEqualTo(_individual);
+         ReferenceEquals(sut.DefaultIndividualFor(_speciesPopulation), _individual).ShouldBeTrue();
       }
    }
 }

--- a/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/Core/DefaultIndividualRetrieverSpecs.cs
@@ -1,0 +1,69 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+using PKSim.Core.Snapshots.Mappers;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_DefaultIndividualRetriever : ContextSpecification<IDefaultIndividualRetriever>
+   {
+      protected ISpeciesRepository _speciesRepository;
+      protected IIndividualFactory _individualFactory;
+      protected OriginDataMapper _originDataMapper;
+      protected SpeciesPopulation _speciesPopulation;
+
+      protected override void Context()
+      {
+         _speciesRepository = A.Fake<ISpeciesRepository>();
+         _individualFactory = A.Fake<IIndividualFactory>();
+         _originDataMapper = A.Fake<OriginDataMapper>();
+
+         _speciesPopulation = new SpeciesPopulation {Name = "POP", Species = "HUMAN"};
+         _speciesPopulation.AddGender(new Gender {Name = "MALE"});
+
+         sut = new DefaultIndividualRetriever(_speciesRepository, _individualFactory, _originDataMapper);
+      }
+   }
+
+   public class When_retrieving_the_default_individual_for_the_same_population_from_multiple_threads : concern_for_DefaultIndividualRetriever
+   {
+      private Individual _firstResult;
+      private Individual _secondResult;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).ReturnsLazily(() =>
+         {
+            Thread.Sleep(300);
+            return A.Fake<Individual>();
+         });
+      }
+
+      protected override void Because()
+      {
+         var firstRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
+         var secondRetrieval = Task.Run(() => sut.DefaultIndividualFor(_speciesPopulation));
+         Task.WaitAll(firstRetrieval, secondRetrieval);
+         _firstResult = firstRetrieval.Result;
+         _secondResult = secondRetrieval.Result;
+      }
+
+      [Observation]
+      public void should_create_the_default_individual_only_once()
+      {
+         A.CallTo(() => _individualFactory.CreateStandardFor(A<OriginData>._)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_return_the_same_cached_instance_to_all_callers()
+      {
+         _firstResult.ShouldBeEqualTo(_secondResult);
+      }
+   }
+}

--- a/tests/PKSim.Tests/Core/RandomPopulationSpecs.cs
+++ b/tests/PKSim.Tests/Core/RandomPopulationSpecs.cs
@@ -270,4 +270,55 @@ namespace PKSim.Core
          sut.IsPreterm.ShouldBeFalse();
       }
    }
+
+   public class When_a_population_load_flags_it_as_loaded : concern_for_RandomPopulation
+   {
+      private IndividualObservingOwnerFlag _individual;
+
+      //records the owner's flag at the moment the individual is flagged, pinning that a load flags the
+      //individual before publishing the owner's flag
+      private class IndividualObservingOwnerFlag : Individual
+      {
+         private readonly Population _owner;
+         public bool? OwnerFlagWhenFlagged { get; private set; }
+
+         public IndividualObservingOwnerFlag(Population owner)
+         {
+            _owner = owner;
+         }
+
+         public override bool IsLoaded
+         {
+            set
+            {
+               OwnerFlagWhenFlagged = _owner.IsLoaded;
+               base.IsLoaded = value;
+            }
+         }
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         _individual = new IndividualObservingOwnerFlag(sut);
+         sut.Settings = new RandomPopulationSettings {BaseIndividual = _individual};
+      }
+
+      protected override void Because()
+      {
+         sut.IsLoaded = true;
+      }
+
+      [Observation]
+      public void should_flag_its_individual_before_publishing_its_own_flag()
+      {
+         _individual.OwnerFlagWhenFlagged.ShouldBeEqualTo(false);
+      }
+
+      [Observation]
+      public void should_flag_its_individual()
+      {
+         _individual.IsLoaded.ShouldBeTrue();
+      }
+   }
 }

--- a/tests/PKSim.Tests/Core/SimulationSpecs.cs
+++ b/tests/PKSim.Tests/Core/SimulationSpecs.cs
@@ -1,4 +1,5 @@
 using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
 using OSPSuite.BDDHelper.Extensions;
 using PKSim.Core.Model;
 
@@ -68,6 +69,57 @@ namespace PKSim.Core
       public void should_return_false()
       {
          sut.UsesEventTemplate("templateEventId").ShouldBeFalse();
+      }
+   }
+
+   public class When_a_simulation_load_flags_it_as_loaded : concern_for_Simulation
+   {
+      private BuildingBlockObservingOwnerFlag _buildingBlock;
+
+      //records the owner's flag at the moment the child is flagged, pinning that a load flags the
+      //children before publishing the owner's flag
+      private class BuildingBlockObservingOwnerFlag : Individual
+      {
+         private readonly Simulation _owner;
+         public bool? OwnerFlagWhenFlagged { get; private set; }
+
+         public BuildingBlockObservingOwnerFlag(Simulation owner)
+         {
+            _owner = owner;
+         }
+
+         public override bool IsLoaded
+         {
+            set
+            {
+               OwnerFlagWhenFlagged = _owner.IsLoaded;
+               base.IsLoaded = value;
+            }
+         }
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         _buildingBlock = new BuildingBlockObservingOwnerFlag(sut);
+         sut.AddUsedBuildingBlock(new UsedBuildingBlock("template", PKSimBuildingBlockType.Individual) {BuildingBlock = _buildingBlock});
+      }
+
+      protected override void Because()
+      {
+         sut.IsLoaded = true;
+      }
+
+      [Observation]
+      public void should_flag_the_used_building_blocks_before_publishing_its_own_flag()
+      {
+         _buildingBlock.OwnerFlagWhenFlagged.ShouldBeEqualTo(false);
+      }
+
+      [Observation]
+      public void should_flag_the_used_building_blocks()
+      {
+         _buildingBlock.IsLoaded.ShouldBeTrue();
       }
    }
 }

--- a/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
@@ -68,34 +68,57 @@ namespace PKSim.Infrastructure
       private Individual _individual;
       private ManualResetEventSlim _firstLoadStarted;
       private ManualResetEventSlim _releaseFirstLoad;
+      private ManualResetEventSlim _secondLoadStarted;
+      private bool _secondLoadWasBlocked;
 
       protected override void Context()
       {
          base.Context();
          _firstLoadStarted = new ManualResetEventSlim();
          _releaseFirstLoad = new ManualResetEventSlim();
+         _secondLoadStarted = new ManualResetEventSlim();
 
          //a real building block so that the spec exercises the actual IsLoaded field
-         _individual = new Individual { Id = "IND" };
+         _individual = new Individual {Id = "IND"};
 
          //the task loads the object as IObjectBase: the stub must match that generic instantiation
          A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _individual)).Invokes(() =>
          {
             _firstLoadStarted.Set();
-            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5));
          });
       }
 
       protected override void Because()
       {
          var firstLoad = Task.Run(() => sut.Load(_individual));
-         //the second load only starts once the first is inside the guarded region, so it has to wait for it
-         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5));
 
-         var secondLoad = Task.Run(() => sut.Load(_individual));
+         var secondLoad = Task.Run(() =>
+         {
+            _secondLoadStarted.Set();
+            sut.Load(_individual);
+         });
+
+         //the second load is running and cannot get past the gate while the first one holds it
+         _secondLoadStarted.Wait(TimeSpan.FromSeconds(5));
+         _secondLoadWasBlocked = !secondLoad.Wait(TimeSpan.FromMilliseconds(500));
+
          _releaseFirstLoad.Set();
+         Task.WaitAll(new[] {firstLoad, secondLoad}, TimeSpan.FromSeconds(5));
+      }
 
-         Task.WaitAll(new[] { firstLoad, secondLoad }, TimeSpan.FromSeconds(5)).ShouldBeTrue();
+      public override void Cleanup()
+      {
+         _firstLoadStarted.Dispose();
+         _releaseFirstLoad.Dispose();
+         _secondLoadStarted.Dispose();
+      }
+
+      [Observation]
+      public void should_make_the_second_load_wait_for_the_first_one()
+      {
+         _secondLoadWasBlocked.ShouldBeTrue();
       }
 
       [Observation]
@@ -130,26 +153,32 @@ namespace PKSim.Infrastructure
          base.Context();
          _firstLoadStarted = new ManualResetEventSlim();
          _releaseFirstLoad = new ManualResetEventSlim();
-         _blockedIndividual = new Individual { Id = "BLOCKED" };
-         _otherIndividual = new Individual { Id = "OTHER" };
+         _blockedIndividual = new Individual {Id = "BLOCKED"};
+         _otherIndividual = new Individual {Id = "OTHER"};
 
          A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _blockedIndividual)).Invokes(() =>
          {
             _firstLoadStarted.Set();
-            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5));
          });
       }
 
       protected override void Because()
       {
          var blockedLoad = Task.Run(() => sut.Load(_blockedIndividual));
-         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5));
 
          //the load of an unrelated object must not wait for the blocked one
-         _otherLoadCompleted = Task.Run(() => sut.Load(_otherIndividual)).Wait(TimeSpan.FromSeconds(5));
+         _otherLoadCompleted = Task.Run(() => sut.Load(_otherIndividual)).Wait(TimeSpan.FromSeconds(2));
 
          _releaseFirstLoad.Set();
-         blockedLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         blockedLoad.Wait(TimeSpan.FromSeconds(5));
+      }
+
+      public override void Cleanup()
+      {
+         _firstLoadStarted.Dispose();
+         _releaseFirstLoad.Dispose();
       }
 
       [Observation]

--- a/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
@@ -92,7 +92,7 @@ namespace PKSim.Infrastructure
       protected override void Because()
       {
          var firstLoad = Task.Run(() => sut.Load(_individual));
-         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5));
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
          var secondLoad = Task.Run(() =>
          {
@@ -100,16 +100,19 @@ namespace PKSim.Infrastructure
             sut.Load(_individual);
          });
 
-         //the second load is running and cannot get past the gate while the first one holds it
-         _secondLoadStarted.Wait(TimeSpan.FromSeconds(5));
+         //the second load is running and cannot get past the gate while the first one holds it. A load that
+         //never reached the gate in time would also read as blocked here: the guard was verified by removing
+         //the gate, which makes the observation fail
+         _secondLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
          _secondLoadWasBlocked = !secondLoad.Wait(TimeSpan.FromMilliseconds(500));
 
          _releaseFirstLoad.Set();
-         Task.WaitAll(new[] {firstLoad, secondLoad}, TimeSpan.FromSeconds(5));
+         Task.WaitAll(new[] {firstLoad, secondLoad}, TimeSpan.FromSeconds(5)).ShouldBeTrue();
       }
 
       public override void Cleanup()
       {
+         base.Cleanup();
          _firstLoadStarted.Dispose();
          _releaseFirstLoad.Dispose();
          _secondLoadStarted.Dispose();
@@ -166,17 +169,18 @@ namespace PKSim.Infrastructure
       protected override void Because()
       {
          var blockedLoad = Task.Run(() => sut.Load(_blockedIndividual));
-         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5));
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
          //the load of an unrelated object must not wait for the blocked one
          _otherLoadCompleted = Task.Run(() => sut.Load(_otherIndividual)).Wait(TimeSpan.FromSeconds(2));
 
          _releaseFirstLoad.Set();
-         blockedLoad.Wait(TimeSpan.FromSeconds(5));
+         blockedLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
       }
 
       public override void Cleanup()
       {
+         base.Cleanup();
          _firstLoadStarted.Dispose();
          _releaseFirstLoad.Dispose();
       }

--- a/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -64,31 +65,97 @@ namespace PKSim.Infrastructure
 
    public class When_loading_the_same_object_concurrently_from_multiple_threads : concern_for_LazyLoadTask
    {
+      private Individual _individual;
+      private ManualResetEventSlim _firstLoadStarted;
+      private ManualResetEventSlim _releaseFirstLoad;
+
       protected override void Context()
       {
          base.Context();
-         _objectToLoad.IsLoaded = false;
+         _firstLoadStarted = new ManualResetEventSlim();
+         _releaseFirstLoad = new ManualResetEventSlim();
+
+         //a real building block so that the spec exercises the actual IsLoaded field
+         _individual = new Individual { Id = "IND" };
+
          //the task loads the object as IObjectBase: the stub must match that generic instantiation
-         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _objectToLoad)).Invokes(() => Thread.Sleep(300));
+         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _individual)).Invokes(() =>
+         {
+            _firstLoadStarted.Set();
+            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         });
       }
 
       protected override void Because()
       {
-         var firstLoad = Task.Run(() => sut.Load(_objectToLoad));
-         var secondLoad = Task.Run(() => sut.Load(_objectToLoad));
-         Task.WaitAll(firstLoad, secondLoad);
+         var firstLoad = Task.Run(() => sut.Load(_individual));
+         //the second load only starts once the first is inside the guarded region, so it has to wait for it
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+         var secondLoad = Task.Run(() => sut.Load(_individual));
+         _releaseFirstLoad.Set();
+
+         Task.WaitAll(new[] { firstLoad, secondLoad }, TimeSpan.FromSeconds(5)).ShouldBeTrue();
       }
 
       [Observation]
       public void should_load_the_content_only_once()
       {
-         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _objectToLoad)).MustHaveHappenedOnceExactly();
+         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _individual)).MustHaveHappenedOnceExactly();
       }
 
       [Observation]
       public void should_register_the_object_only_once()
       {
-         A.CallTo(() => _registrationTask.Register(_objectToLoad)).MustHaveHappenedOnceExactly();
+         A.CallTo(() => _registrationTask.Register(_individual)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_have_loaded_the_object()
+      {
+         _individual.IsLoaded.ShouldBeTrue();
+      }
+   }
+
+   public class When_loading_different_objects_concurrently_from_multiple_threads : concern_for_LazyLoadTask
+   {
+      private Individual _blockedIndividual;
+      private Individual _otherIndividual;
+      private ManualResetEventSlim _firstLoadStarted;
+      private ManualResetEventSlim _releaseFirstLoad;
+      private bool _otherLoadCompleted;
+
+      protected override void Context()
+      {
+         base.Context();
+         _firstLoadStarted = new ManualResetEventSlim();
+         _releaseFirstLoad = new ManualResetEventSlim();
+         _blockedIndividual = new Individual { Id = "BLOCKED" };
+         _otherIndividual = new Individual { Id = "OTHER" };
+
+         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _blockedIndividual)).Invokes(() =>
+         {
+            _firstLoadStarted.Set();
+            _releaseFirstLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+         });
+      }
+
+      protected override void Because()
+      {
+         var blockedLoad = Task.Run(() => sut.Load(_blockedIndividual));
+         _firstLoadStarted.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+
+         //the load of an unrelated object must not wait for the blocked one
+         _otherLoadCompleted = Task.Run(() => sut.Load(_otherIndividual)).Wait(TimeSpan.FromSeconds(5));
+
+         _releaseFirstLoad.Set();
+         blockedLoad.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_block_the_load_of_an_unrelated_object()
+      {
+         _otherLoadCompleted.ShouldBeTrue();
       }
    }
 

--- a/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/LazyLoadTaskSpecs.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -57,6 +59,36 @@ namespace PKSim.Infrastructure
       public void should_do_nothing()
       {
          A.CallTo(() => _contentLoader.LoadContentFor(_objectToLoad)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_loading_the_same_object_concurrently_from_multiple_threads : concern_for_LazyLoadTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _objectToLoad.IsLoaded = false;
+         //the task loads the object as IObjectBase: the stub must match that generic instantiation
+         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _objectToLoad)).Invokes(() => Thread.Sleep(300));
+      }
+
+      protected override void Because()
+      {
+         var firstLoad = Task.Run(() => sut.Load(_objectToLoad));
+         var secondLoad = Task.Run(() => sut.Load(_objectToLoad));
+         Task.WaitAll(firstLoad, secondLoad);
+      }
+
+      [Observation]
+      public void should_load_the_content_only_once()
+      {
+         A.CallTo(() => _contentLoader.LoadContentFor((IObjectBase) _objectToLoad)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_register_the_object_only_once()
+      {
+         A.CallTo(() => _registrationTask.Register(_objectToLoad)).MustHaveHappenedOnceExactly();
       }
    }
 

--- a/tests/PKSim.Tests/IntegrationTests/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/DefaultIndividualRetrieverSpecs.cs
@@ -31,5 +31,14 @@ namespace PKSim.IntegrationTests
          _individual.OriginData.Gender.Name.ShouldBeEqualTo(CoreConstants.Gender.MALE);
          _individual.OriginData.Age.Value.ShouldBeEqualTo(30);
       }
+      public class When_resolving_the_default_individual_retriever_more_than_once : ContextForIntegration<IDefaultIndividualRetriever>
+   {
+      //the cache lives on the instance, so two effective registrations would hand out two different default individuals
+      [Observation]
+      public void should_always_resolve_the_same_instance()
+      {
+         ReferenceEquals(IoC.Resolve<IDefaultIndividualRetriever>(), IoC.Resolve<IDefaultIndividualRetriever>()).ShouldBeTrue();
+      }
    }
+}
 }

--- a/tests/PKSim.Tests/IntegrationTests/DefaultIndividualRetrieverSpecs.cs
+++ b/tests/PKSim.Tests/IntegrationTests/DefaultIndividualRetrieverSpecs.cs
@@ -31,14 +31,15 @@ namespace PKSim.IntegrationTests
          _individual.OriginData.Gender.Name.ShouldBeEqualTo(CoreConstants.Gender.MALE);
          _individual.OriginData.Age.Value.ShouldBeEqualTo(30);
       }
-      public class When_resolving_the_default_individual_retriever_more_than_once : ContextForIntegration<IDefaultIndividualRetriever>
+   }
+
+   public class When_resolving_the_default_individual_retriever_more_than_once : concern_for_DefaultIndividualRetriever
    {
       //the cache lives on the instance, so two effective registrations would hand out two different default individuals
       [Observation]
       public void should_always_resolve_the_same_instance()
       {
-         ReferenceEquals(IoC.Resolve<IDefaultIndividualRetriever>(), IoC.Resolve<IDefaultIndividualRetriever>()).ShouldBeTrue();
+         ReferenceEquals(sut, IoC.Resolve<IDefaultIndividualRetriever>()).ShouldBeTrue();
       }
    }
-}
 }

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.165" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.165" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -17,8 +17,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.CLI.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.165" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.165" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.164" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.165" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
+++ b/tests/PKSim.UI.Tests/PKSim.UI.Tests.csproj
@@ -22,11 +22,11 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
 		<PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.164" />
 		<PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
-		<PackageReference Include="OSPSuite.UI" Version="13.0.161" />
+		<PackageReference Include="OSPSuite.UI" Version="13.0.164" />
 		<PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />


### PR DESCRIPTION
Fixes #3709

> Requires OSPSuite.Core **13.0.165** (contains Open-Systems-Pharmacology/OSPSuite.Core#2959 — thread-safe `WithIdRepository` — and Open-Systems-Pharmacology/OSPSuite.Core#2965 — volatile `IsLoaded` publication) — already referenced by this branch.

### What changes

- `LazyLoadTask` loads each object under its own gate: a private lock object per loaded instance, held in a `ConditionalWeakTable` so a gate never outlives the object it guards. The already-loaded fast path stays lock-free; the `IsLoaded` check is re-tested inside the gate, so one thread loads the content while others wait — and loads of unrelated objects do not block each other.
- `IsLoaded` is published through a volatile field (`PKSimBuildingBlock`, the comparisons, and Core's `ParameterIdentification`/`SensitivityAnalysis` via Core 13.0.165), so a thread that takes the fast path also sees the writes that loaded the object. `Simulation` and `Population` flag their owned children before the volatile parent write, so a reader that sees the parent loaded also sees its children loaded.
- `LoadResults` takes the same single gate for the load and the results, so the two steps are atomic per simulation.
- `DefaultIndividualRetriever` caches per population through `Lazy<Individual>` in a `ConcurrentDictionary`, creating the default individual once; a creation that throws is evicted so the next call retries instead of rethrowing a cached exception.

### Why

`LoadSimulationFromSnapshotPresenter` already maps snapshot simulations concurrently (`Task.WhenAll`), and that mapping resolves template building blocks through `IExecutionContext.Load` → `LazyLoadTask`. The load is a check-then-act around a database read plus XML deserialization: two threads can both pass the `IsLoaded` check, deserialize into the same shared building block, and bulk-register its object graph into the global `IWithIdRepository` at the same time. That is the most likely mechanism behind #648/#684, which led #690 to serialize the snapshot mapping loop in 2018.

This is also a prerequisite for #3710 (parallel model construction during snapshot load).

### Tests

The concurrency specs are handshake-based (events, no sleeps for correctness) and each guard was verified by mutation — reverting it makes the spec fail:

- loading the same object from two threads blocks the second thread and loads and registers the content exactly once
- loading two unrelated objects does not block across gates
- retrieving the default individual for the same population from two threads creates it once and hands both callers the same instance
- retrieving for a different population is not blocked by a creation in progress
- a failed creation is not cached: the next call retries
- an integration spec pins the retriever to a single container registration, which the per-instance cache relies on

### Follow-ups filed

- #3718 — `DefaultIndividualRetriever` hands out a shared mutable `Individual`; ownership to be decided separately
- #3720 — defer nested lazy loads so a thread holds at most one gate, removing the acyclic-references invariant this PR documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved reliability when creating and retrieving default individuals concurrently.
  - Improved consistency when multiple operations load the same item simultaneously.

- **Maintenance**
  - Updated supporting platform components to version 13.0.164 across the application and test suites.

- **Tests**
  - Added coverage for concurrent default-individual retrieval and simultaneous item loading to help prevent duplicate processing and inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
