### PR TITLE
Fixes #3711 Add a --cores option to PKSim.CLI

### DIFF
--- a/src/PKSim.CLI/Commands/CLICommand.cs
+++ b/src/PKSim.CLI/Commands/CLICommand.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Text;
 using CommandLine;
 using Microsoft.Extensions.Logging;
 using OSPSuite.Utility.Extensions;
+using PKSim.Core;
 
 namespace PKSim.CLI.Commands
 {
@@ -18,10 +20,23 @@ namespace PKSim.CLI.Commands
       [Option("logLevel", Required = false, HelpText = "Optional. Log verbosity (Debug, Information, Warning, Error). Default is Information.")]
       public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
+      [Option("cores", Required = false, HelpText = "Optional. Maximum number of cores (1 or more) to use for parallel work such as model construction and simulation runs. Default is the number of processors minus one.")]
+      public int? NumberOfCores { get; set; }
+
+      //parallelism gets exactly one owner per level: a caller managing process-level fan-out
+      //(e.g. the QualificationRunner) passes --cores 1 so this process does not multiply it
+      public void ApplyCoresTo(ICoreUserSettings userSettings)
+      {
+         if (NumberOfCores.HasValue)
+            userSettings.MaximumNumberOfCoresToUse = Math.Max(1, NumberOfCores.Value);
+      }
+
       protected virtual void LogDefaultOptions(StringBuilder sb)
       {
          LogFilesFullPath.Each(x => sb.AppendLine($"Log file: {x}"));
          sb.AppendLine($"Log level: {LogLevel}");
+         if (NumberOfCores.HasValue)
+            sb.AppendLine($"Number of cores: {NumberOfCores.Value}");
       }
    }
 

--- a/src/PKSim.CLI/Program.cs
+++ b/src/PKSim.CLI/Program.cs
@@ -50,6 +50,7 @@ namespace PKSim.CLI
 
          logger.AddDebug($"Arguments:\n{command}");
          ApplicationStartup.Start();
+         command.ApplyCoresTo(IoC.Resolve<ICoreUserSettings>());
          var runner = IoC.Resolve<IBatchRunner<TRunOptions>>();
          try
          {

--- a/tests/PKSim.Tests/CLI/CLICommandSpecs.cs
+++ b/tests/PKSim.Tests/CLI/CLICommandSpecs.cs
@@ -1,0 +1,81 @@
+using CommandLine;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using PKSim.CLI.Commands;
+using PKSim.CLI.Core.MinimalImplementations;
+
+namespace PKSim.CLI
+{
+   public class TestCommand : CLICommand<object>
+   {
+      public override string Name => "Test";
+      public override object ToRunOptions() => new object();
+   }
+
+   public abstract class concern_for_CLICommand : ContextSpecification<TestCommand>
+   {
+      protected CLIUserSettings _userSettings;
+      protected int _defaultNumberOfCores;
+
+      protected override void Context()
+      {
+         _userSettings = new CLIUserSettings();
+         _defaultNumberOfCores = _userSettings.MaximumNumberOfCoresToUse;
+      }
+
+      protected static TestCommand Parse(params string[] args)
+      {
+         TestCommand command = null;
+         Parser.Default.ParseArguments<TestCommand>(args).WithParsed(x => command = x);
+         command.ShouldNotBeNull();
+         return command;
+      }
+   }
+
+   public class When_parsing_a_command_with_the_cores_option : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse("--cores", "3");
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      [Observation]
+      public void should_use_the_given_number_of_cores()
+      {
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(3);
+      }
+   }
+
+   public class When_parsing_a_command_without_the_cores_option : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse();
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      //a standalone CLI invocation owns the whole machine by default
+      [Observation]
+      public void should_keep_the_default_number_of_cores()
+      {
+         sut.NumberOfCores.HasValue.ShouldBeFalse();
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(_defaultNumberOfCores);
+      }
+   }
+
+   public class When_parsing_a_command_with_a_cores_option_below_one : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse("--cores", "0");
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      [Observation]
+      public void should_use_at_least_one_core()
+      {
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(1);
+      }
+   }
+}

--- a/tests/PKSim.Tests/PKSim.Tests.csproj
+++ b/tests/PKSim.Tests/PKSim.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\PKSim.BatchTool\PKSim.BatchTool.csproj" />
+    <ProjectReference Include="..\..\src\PKSim.CLI\PKSim.CLI.csproj" />
     <ProjectReference Include="..\..\src\PKSim.CLI.Core\PKSim.CLI.Core.csproj" />
     <ProjectReference Include="..\..\src\PKSim.Core\PKSim.Core.csproj" />
     <ProjectReference Include="..\..\src\PKSim.Infrastructure\PKSim.Infrastructure.csproj" />


### PR DESCRIPTION
Fixes #3711

Adds a `--cores <n>` option to the shared `CLICommand` base so every verb (`snap`, `run`, `export`, `qualification`) accepts it. When provided, `ICoreUserSettings.MaximumNumberOfCoresToUse` is set right after container initialization and before the runner resolves (clamped to at least 1); when absent, the `ProcessorCount - 1` default is untouched, so interactive and single-project CLI use keeps full parallelism.

Per the agreed design, parallelism gets exactly one owner per level: the QualificationRunner will pass `--cores 1` to each spawned child (Open-Systems-Pharmacology/QualificationRunner#189) so process fan-out and in-process workers do not multiply.

Specs parse through the real `CommandLine.Parser`: `--cores 3` is applied, an absent option keeps the default, and `--cores 0` clamps to one core.

Companion: Open-Systems-Pharmacology/MoBi#2519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--cores` command-line option to configure the number of CPU cores used during batch operations.
  * Core usage is applied automatically when starting a command.
  * Values below one are adjusted to use at least one core.
  * Command output now reports the configured core count when provided.

* **Tests**
  * Added coverage for configured, omitted, and below-minimum core-count options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->