### PR TITLE
Fixes #3728 Apply the representation info when creating a module from a snapshot

### DIFF
--- a/src/PKSim.Core/Services/RepresentationInfoUpdater.cs
+++ b/src/PKSim.Core/Services/RepresentationInfoUpdater.cs
@@ -1,0 +1,39 @@
+﻿using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Visitor;
+using PKSim.Core.Repositories;
+
+namespace PKSim.Core.Services
+{
+   public interface IRepresentationInfoUpdater
+   {
+      void UpdateRepresentationInfoIn(IVisitable<IVisitor> visitable);
+   }
+
+   public class RepresentationInfoUpdater : IRepresentationInfoUpdater, IVisitor<IObjectBase>
+   {
+      private readonly IRepresentationInfoRepository _representationInfoRepository;
+
+      public RepresentationInfoUpdater(IRepresentationInfoRepository representationInfoRepository)
+      {
+         _representationInfoRepository = representationInfoRepository;
+      }
+
+      public void UpdateRepresentationInfoIn(IVisitable<IVisitor> visitable)
+      {
+         _representationInfoRepository.Start();
+         visitable.AcceptVisitor(this);
+      }
+
+      public void Visit(IObjectBase objToVisit)
+      {
+         if (!_representationInfoRepository.ContainsInfoFor(objToVisit))
+            return;
+
+         var repInfo = _representationInfoRepository.InfoFor(objToVisit);
+         objToVisit.Icon = repInfo.IconName;
+
+         if (string.IsNullOrEmpty(objToVisit.Description))
+            objToVisit.Description = repInfo.Description;
+      }
+   }
+}

--- a/src/PKSim.Core/Services/RepresentationInfoUpdater.cs
+++ b/src/PKSim.Core/Services/RepresentationInfoUpdater.cs
@@ -18,11 +18,7 @@ namespace PKSim.Core.Services
          _representationInfoRepository = representationInfoRepository;
       }
 
-      public void UpdateRepresentationInfoIn(IVisitable<IVisitor> visitable)
-      {
-         _representationInfoRepository.Start();
-         visitable.AcceptVisitor(this);
-      }
+      public void UpdateRepresentationInfoIn(IVisitable<IVisitor> visitable) => visitable.AcceptVisitor(this);
 
       public void Visit(IObjectBase objToVisit)
       {

--- a/src/PKSim.Infrastructure/ORM/Repositories/RepresentationInfoRepository.cs
+++ b/src/PKSim.Infrastructure/ORM/Repositories/RepresentationInfoRepository.cs
@@ -70,7 +70,11 @@ namespace PKSim.Infrastructure.ORM.Repositories
 
       public string DisplayNameFor(RepresentationObjectType objectType, string objectName) => InfoFor(objectType, objectName).DisplayName;
 
-      public bool ContainsInfoFor(IObjectBase objectBase) => _representationInfosCache.Contains(getKey(objectBase));
+      public bool ContainsInfoFor(IObjectBase objectBase)
+      {
+         Start();
+         return _representationInfosCache.Contains(getKey(objectBase));
+      }
 
       private string getKey(RepresentationObjectType objectType, string objectName) => $"{objectType}{ObjectPath.PATH_DELIMITER}{objectName}";
 

--- a/src/PKSim.Infrastructure/Services/MoBiExportTask.cs
+++ b/src/PKSim.Infrastructure/Services/MoBiExportTask.cs
@@ -9,21 +9,19 @@ using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
-using OSPSuite.Utility.Visitor;
 using PKSim.Assets;
 using PKSim.Core;
 using PKSim.Core.Model;
-using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using ILazyLoadTask = PKSim.Core.Services.ILazyLoadTask;
 
 namespace PKSim.Infrastructure.Services
 {
-   public class MoBiExportTask : IMoBiExportTask, IVisitor<IObjectBase>
+   public class MoBiExportTask : IMoBiExportTask
    {
       private readonly ISimulationConfigurationTask _simulationConfigurationTask;
       private readonly ISimulationToModelCoreSimulationMapper _simulationMapper;
-      private readonly IRepresentationInfoRepository _representationInfoRepository;
+      private readonly IRepresentationInfoUpdater _representationInfoUpdater;
       private readonly IPKSimConfiguration _configuration;
       private readonly ILazyLoadTask _lazyLoadTask;
       private readonly IDialogCreator _dialogCreator;
@@ -39,7 +37,7 @@ namespace PKSim.Infrastructure.Services
       public MoBiExportTask(
          ISimulationConfigurationTask simulationConfigurationTask,
          ISimulationToModelCoreSimulationMapper simulationMapper,
-         IRepresentationInfoRepository representationInfoRepository,
+         IRepresentationInfoUpdater representationInfoUpdater,
          IPKSimConfiguration configuration,
          ILazyLoadTask lazyLoadTask,
          IDialogCreator dialogCreator,
@@ -54,7 +52,7 @@ namespace PKSim.Infrastructure.Services
       {
          _simulationConfigurationTask = simulationConfigurationTask;
          _simulationMapper = simulationMapper;
-         _representationInfoRepository = representationInfoRepository;
+         _representationInfoUpdater = representationInfoUpdater;
          _configuration = configuration;
          _lazyLoadTask = lazyLoadTask;
          _dialogCreator = dialogCreator;
@@ -174,20 +172,8 @@ namespace PKSim.Infrastructure.Services
 
       private void updateRepresentationInfo(IModelCoreSimulation moBiSimulation)
       {
-         moBiSimulation.Configuration.AcceptVisitor(this);
-         moBiSimulation.Model.AcceptVisitor(this);
-      }
-
-      public void Visit(IObjectBase objToVisit)
-      {
-         if (!_representationInfoRepository.ContainsInfoFor(objToVisit))
-            return;
-
-         var repInfo = _representationInfoRepository.InfoFor(objToVisit);
-         objToVisit.Icon = repInfo.IconName;
-
-         if (string.IsNullOrEmpty(objToVisit.Description))
-            objToVisit.Description = repInfo.Description;
+         _representationInfoUpdater.UpdateRepresentationInfoIn(moBiSimulation.Configuration);
+         _representationInfoUpdater.UpdateRepresentationInfoIn(moBiSimulation.Model);
       }
    }
 }

--- a/src/PKSim.R/Exchange/SnapshotExchange.cs
+++ b/src/PKSim.R/Exchange/SnapshotExchange.cs
@@ -15,10 +15,11 @@ public static class SnapshotExchange
    public static string CreateModule(string projectSnapshot)
    {
       Api.InitializeOnce();
-      var (projectSnapshotToModuleMapper, objectIdResetter, serializer) =
-         Api.ResolveTasks<IProjectSnapshotToModuleMapper, IObjectIdResetter, IPKMLPersistor>();
+      var (projectSnapshotToModuleMapper, objectIdResetter, serializer, representationInfoUpdater) =
+         Api.ResolveTasks<IProjectSnapshotToModuleMapper, IObjectIdResetter, IPKMLPersistor, IRepresentationInfoUpdater>();
 
       var module = projectSnapshotToModuleMapper.MapFrom(projectSnapshot).module;
+      representationInfoUpdater.UpdateRepresentationInfoIn(module);
       objectIdResetter.ResetIdFor(module);
 
       return serializer.Serialize(module);

--- a/src/PKSim.Starter/SnapshotExchange.cs
+++ b/src/PKSim.Starter/SnapshotExchange.cs
@@ -34,6 +34,7 @@ public static class SnapshotExchange
       var projectSnapshotToModuleMapper = container.Resolve<IProjectSnapshotToModuleMapper>();
 
       var module = projectSnapshotToModuleMapper.MapFrom(projectSnapshot).module;
+      container.Resolve<IRepresentationInfoUpdater>().UpdateRepresentationInfoIn(module);
       var objectIdResetter = container.Resolve<IObjectIdResetter>();
       objectIdResetter.ResetIdFor(module);
       return serialize(module, container);
@@ -46,6 +47,7 @@ public static class SnapshotExchange
       var qualificationInputTask = container.Resolve<IQualificationInputTask>();
 
       var (module, project) = projectSnapshotToSimulationTransferMapper.MapFrom(projectSnapshot);
+      container.Resolve<IRepresentationInfoUpdater>().UpdateRepresentationInfoIn(module);
       var objectIdResetter = container.Resolve<IObjectIdResetter>();
       objectIdResetter.ResetIdFor(module);
       var inputMappings = qualificationInputTask.ExportInputs(project, qualificationConfiguration);

--- a/tests/PKSim.Tests/Core/RepresentationInfoUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/Core/RepresentationInfoUpdaterSpecs.cs
@@ -37,12 +37,6 @@ namespace PKSim.Core
       }
 
       [Observation]
-      public void should_start_the_representation_info_repository_so_that_the_lookup_cache_is_filled()
-      {
-         A.CallTo(() => _representationInfoRepository.Start()).MustHaveHappened();
-      }
-
-      [Observation]
       public void should_set_the_icon_of_the_visited_container()
       {
          _organism.Icon.ShouldBeEqualTo("Organism");

--- a/tests/PKSim.Tests/Core/RepresentationInfoUpdaterSpecs.cs
+++ b/tests/PKSim.Tests/Core/RepresentationInfoUpdaterSpecs.cs
@@ -1,0 +1,109 @@
+﻿using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using PKSim.Core.Model;
+using PKSim.Core.Repositories;
+using PKSim.Core.Services;
+
+namespace PKSim.Core
+{
+   public abstract class concern_for_RepresentationInfoUpdater : ContextSpecification<IRepresentationInfoUpdater>
+   {
+      protected IRepresentationInfoRepository _representationInfoRepository;
+      protected IContainer _organism;
+      protected IContainer _liver;
+
+      protected override void Context()
+      {
+         _representationInfoRepository = A.Fake<IRepresentationInfoRepository>();
+         sut = new RepresentationInfoUpdater(_representationInfoRepository);
+
+         _organism = new Container().WithName("Organism");
+         _liver = new Container().WithName("Liver");
+         _organism.Add(_liver);
+
+         A.CallTo(() => _representationInfoRepository.ContainsInfoFor(A<IObjectBase>._)).Returns(true);
+         A.CallTo(() => _representationInfoRepository.InfoFor(_organism)).Returns(new RepresentationInfo {IconName = "Organism", Description = "The organism"});
+         A.CallTo(() => _representationInfoRepository.InfoFor(_liver)).Returns(new RepresentationInfo {IconName = "Liver", Description = "The liver"});
+      }
+   }
+
+   public class When_updating_the_representation_info_in_a_container_structure : concern_for_RepresentationInfoUpdater
+   {
+      protected override void Because()
+      {
+         sut.UpdateRepresentationInfoIn(_organism);
+      }
+
+      [Observation]
+      public void should_start_the_representation_info_repository_so_that_the_lookup_cache_is_filled()
+      {
+         A.CallTo(() => _representationInfoRepository.Start()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_set_the_icon_of_the_visited_container()
+      {
+         _organism.Icon.ShouldBeEqualTo("Organism");
+      }
+
+      [Observation]
+      public void should_set_the_icon_of_the_nested_containers()
+      {
+         _liver.Icon.ShouldBeEqualTo("Liver");
+      }
+
+      [Observation]
+      public void should_set_the_description_of_the_visited_containers()
+      {
+         _liver.Description.ShouldBeEqualTo("The liver");
+      }
+   }
+
+   public class When_updating_the_representation_info_of_a_container_that_already_has_a_description : concern_for_RepresentationInfoUpdater
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _liver.Description = "My own description";
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateRepresentationInfoIn(_organism);
+      }
+
+      [Observation]
+      public void should_keep_the_existing_description()
+      {
+         _liver.Description.ShouldBeEqualTo("My own description");
+      }
+
+      [Observation]
+      public void should_still_set_the_icon()
+      {
+         _liver.Icon.ShouldBeEqualTo("Liver");
+      }
+   }
+
+   public class When_updating_the_representation_info_of_an_object_that_is_not_known_by_the_repository : concern_for_RepresentationInfoUpdater
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _representationInfoRepository.ContainsInfoFor(_liver)).Returns(false);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateRepresentationInfoIn(_organism);
+      }
+
+      [Observation]
+      public void should_leave_the_icon_untouched()
+      {
+         _liver.Icon.ShouldBeEmpty();
+      }
+   }
+}

--- a/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
+++ b/tests/PKSim.Tests/Infrastructure/MoBiExportTaskSpecs.cs
@@ -12,7 +12,6 @@ using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Exceptions;
 using PKSim.Core;
-using PKSim.Core.Repositories;
 using PKSim.Core.Services;
 using PKSim.Infrastructure.Services;
 using DataRepository = OSPSuite.Core.Domain.Data.DataRepository;
@@ -25,7 +24,7 @@ namespace PKSim.Infrastructure
    {
       protected ISimulationConfigurationTask _simulationConfigurationTask;
       protected ISimulationToModelCoreSimulationMapper _simulationMapper;
-      protected IRepresentationInfoRepository _representationInfoRepository;
+      protected IRepresentationInfoUpdater _representationInfoUpdater;
       protected IPKSimConfiguration _configuration;
       protected ILazyLoadTask _lazyLoadTask;
       protected IDialogCreator _dialogCreator;
@@ -44,7 +43,7 @@ namespace PKSim.Infrastructure
       {
          _simulationConfigurationTask = A.Fake<ISimulationConfigurationTask>();
          _simulationMapper = A.Fake<ISimulationToModelCoreSimulationMapper>();
-         _representationInfoRepository = A.Fake<IRepresentationInfoRepository>();
+         _representationInfoUpdater = A.Fake<IRepresentationInfoUpdater>();
          _configuration = A.Fake<IPKSimConfiguration>();
          _lazyLoadTask = A.Fake<ILazyLoadTask>();
          _dialogCreator = A.Fake<IDialogCreator>();
@@ -78,7 +77,7 @@ namespace PKSim.Infrastructure
 
          A.CallTo(() => _simulationMapper.MapFrom(_sim, A<SimulationConfiguration>._, true)).Returns(_modelCoreSimulation);
 
-         sut = new MoBiExportTask(_simulationConfigurationTask, _simulationMapper, _representationInfoRepository,
+         sut = new MoBiExportTask(_simulationConfigurationTask, _simulationMapper, _representationInfoUpdater,
             _configuration, _lazyLoadTask, _dialogCreator, _simulationPersistor, _projectRetriever, _objectIdResetter, _journalRetriever, _applicationSettings, _startableProcessFactory, _modelCoreSimulationSnapshotUpdater, _overwriteParameterSetApplicationTask);
       }
    }


### PR DESCRIPTION
Fixes #3728

### Cause

Container icons and descriptions are not intrinsic to a PK-Sim spatial structure — no organ container carries them until they are stamped on. That stamping happens in `MoBiExportTask`, which visits the simulation and copies `IconName` and `Description` from the representation info repository:

```csharp
public void Visit(IObjectBase objToVisit)
{
   var repInfo = _representationInfoRepository.InfoFor(objToVisit);
   objToVisit.Icon = repInfo.IconName;
   ...
}
```

That pass only ever ran on the *Export simulation to MoBi* path. Recreating a module in MoBi from the PK-Sim snapshot embedded in it goes through `SnapshotExchange.CreateModule` → `IProjectSnapshotToModuleMapper` → serialize, which never touches it. So a recreated module came back with no icons and no container descriptions, and MoBi's simulation tree — which renders `container.Icon` with no name-based fallback — showed organs blank.

This is why the same model showed icons before: that module had been produced by a MoBi export rather than recreated from its snapshot.

### Change

- Lift the visitor out of `MoBiExportTask` into a new `RepresentationInfoUpdater` in `PKSim.Core.Services`, so export and snapshot-recreate share one implementation.
- Apply it in `PKSim.Starter.SnapshotExchange.CreateModule` and `CreateModuleAndExportInputs`, so a recreated module matches an exported one.
- Apply it in `PKSim.R.Exchange.SnapshotExchange.CreateModule` as well — the headless counterpart that MoBi.R loads had the identical gap.
- `MoBiExportTask` now consumes `IRepresentationInfoUpdater` instead of `IRepresentationInfoRepository`.

`ContainsInfoFor` was the only accessor on `RepresentationInfoRepository` that did not start it: it reads the lookup cache directly, and that cache is only filled in `PerformPostStartProcessing`. Warm in the PK-Sim UI, empty in the CLI/R container the snapshot exchanges run in, where the guard would return false for every object and skip the whole pass silently. It now starts like every sibling accessor.

### Verification

Round-tripped a module to PK-Sim from MoBi and it came back with organ icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of object icons and descriptions during module creation and export.
  * Representation details are now refreshed before modules are serialized or exported.
  * Existing descriptions are preserved when already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


